### PR TITLE
refactor: send-only sampleable runtime

### DIFF
--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1346,7 +1346,7 @@ impl AudioProcessor {
         } => {
           // State transfer + replace, then reconnect
           if let Some(old_module) = self.patch.sampleables.remove(&module_id) {
-            new_module.transfer_state_from(old_module.as_ref().as_ref());
+            new_module.transfer_state_from(old_module.as_ref());
             self.patch.remove_message_listeners_for_module(&module_id);
             if self
               .garbage_tx
@@ -1354,17 +1354,16 @@ impl AudioProcessor {
               .is_err()
             {}
           }
-          self
-            .patch
-            .sampleables
-            .insert(module_id.clone(), new_module.clone());
+          self.patch.sampleables.insert(module_id.clone(), new_module);
           // Re-register message listeners for the replaced module
-          self
-            .patch
-            .add_message_listeners_for_module(&module_id, &new_module);
+          self.patch.add_message_listeners_for_module(&module_id);
           // Reconnect all modules so the new module picks up its connections
           for module in self.patch.sampleables.values() {
             module.connect(&self.patch);
+          }
+          // Refresh any module-local caches rebuilt from params after reconnect.
+          for module in self.patch.sampleables.values() {
+            module.on_patch_update();
           }
         }
         GraphCommand::DispatchMessage(msg) => {
@@ -1507,7 +1506,7 @@ impl AudioProcessor {
     let mut newly_inserted_ids: Vec<String> = Vec::new();
     for (id, new_module) in inserts {
       if let Some(old_module) = self.patch.sampleables.remove(&id) {
-        new_module.transfer_state_from(old_module.as_ref().as_ref());
+        new_module.transfer_state_from(old_module.as_ref());
         self.patch.remove_message_listeners_for_module(&id);
         if self
           .garbage_tx
@@ -1539,9 +1538,7 @@ impl AudioProcessor {
     // Incrementally update message listeners for changed modules only.
     // Stale entries were already removed above; now add entries for new and remapped modules.
     for id in newly_inserted_ids.iter().chain(remapped_ids.iter()) {
-      if let Some(sampleable) = self.patch.sampleables.get(id).cloned() {
-        self.patch.add_message_listeners_for_module(id, &sampleable);
-      }
+      self.patch.add_message_listeners_for_module(id);
     }
 
     // Swap wav_data into the patch (cheap — just moving Arc clones).
@@ -2388,21 +2385,14 @@ pub struct TransportSnapshot {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use modular_core::Signal;
+  use modular_core::poly::PolyOutput;
   use modular_core::types::ModuleIdRemap;
+  use modular_core::types::{Message, MessageHandler, MessageTag, MidiNoteOn};
+  use std::sync::atomic::AtomicUsize;
 
   // ============================================================================
-  // Legacy tests - commented out after Phase 2 architecture change
-  // ============================================================================
-  // These tests used the old AudioState::new() and direct apply_patch() method
-  // which have been replaced by the command queue architecture.
-  //
-  // TODO: Rewrite tests to use the new architecture:
-  // - Create AudioProcessor directly for unit tests
-  // - Or create integration tests that use the full command queue flow
-  //
-  // The functionality being tested (module ID remaps, stopped state, etc.)
-  // is now handled in AudioProcessor::apply_patch_update() and the command
-  // queue dispatch logic.
+  // AudioProcessor + command queue tests
   // ============================================================================
 
   #[test]
@@ -2466,11 +2456,11 @@ mod tests {
   }
 
   impl MockModule {
-    fn new(label: &str) -> Arc<Box<dyn modular_core::types::Sampleable>> {
-      Arc::new(Box::new(Self {
+    fn new(label: &str) -> Box<dyn modular_core::types::Sampleable> {
+      Box::new(Self {
         label: label.to_string(),
         current_id: label.to_string(),
-      }))
+      })
     }
   }
 
@@ -2494,9 +2484,130 @@ mod tests {
     }
   }
 
-  fn create_test_processor() -> AudioProcessor {
+  struct CountingMessageModule {
+    current_id: String,
+    label: String,
+    hits: Arc<AtomicUsize>,
+  }
+
+  impl CountingMessageModule {
+    fn new(label: &str, hits: Arc<AtomicUsize>) -> Box<dyn modular_core::types::Sampleable> {
+      Box::new(Self {
+        current_id: label.to_string(),
+        label: label.to_string(),
+        hits,
+      })
+    }
+  }
+
+  impl MessageHandler for CountingMessageModule {
+    fn handled_message_tags(&self) -> &'static [MessageTag] {
+      &[MessageTag::MidiNoteOn]
+    }
+
+    fn handle_message(&self, _message: &Message) -> napi::Result<()> {
+      self.hits.fetch_add(1, Ordering::SeqCst);
+      Ok(())
+    }
+  }
+
+  impl modular_core::types::Sampleable for CountingMessageModule {
+    fn get_id(&self) -> &str {
+      &self.current_id
+    }
+    fn tick(&self) {}
+    fn update(&self) {}
+    fn get_poly_sample(&self, _port: &str) -> napi::Result<modular_core::poly::PolyOutput> {
+      Ok(modular_core::poly::PolyOutput::default())
+    }
+    fn get_module_type(&self) -> &str {
+      &self.label
+    }
+    fn connect(&self, _patch: &modular_core::patch::Patch) {}
+    fn as_any(&self) -> &dyn std::any::Any {
+      self
+    }
+  }
+
+  struct ConstantOutputModule {
+    current_id: String,
+    value: f32,
+  }
+
+  impl ConstantOutputModule {
+    fn new(id: &str, value: f32) -> Box<dyn modular_core::types::Sampleable> {
+      Box::new(Self {
+        current_id: id.to_string(),
+        value,
+      })
+    }
+  }
+
+  impl MessageHandler for ConstantOutputModule {}
+
+  impl modular_core::types::Sampleable for ConstantOutputModule {
+    fn get_id(&self) -> &str {
+      &self.current_id
+    }
+    fn tick(&self) {}
+    fn update(&self) {}
+    fn get_poly_sample(&self, _port: &str) -> napi::Result<PolyOutput> {
+      Ok(PolyOutput::mono(self.value))
+    }
+    fn get_module_type(&self) -> &str {
+      "constant-output"
+    }
+    fn connect(&self, _patch: &modular_core::patch::Patch) {}
+    fn as_any(&self) -> &dyn std::any::Any {
+      self
+    }
+  }
+
+  struct PatchUpdateSensitiveModule {
+    current_id: String,
+    params_signal: Mutex<Signal>,
+    cached_signal: Mutex<Signal>,
+  }
+
+  impl PatchUpdateSensitiveModule {
+    fn new(id: &str, signal: Signal) -> Box<dyn modular_core::types::Sampleable> {
+      Box::new(Self {
+        current_id: id.to_string(),
+        params_signal: Mutex::new(signal),
+        cached_signal: Mutex::new(Signal::Volts(0.0)),
+      })
+    }
+  }
+
+  impl MessageHandler for PatchUpdateSensitiveModule {}
+
+  impl modular_core::types::Sampleable for PatchUpdateSensitiveModule {
+    fn get_id(&self) -> &str {
+      &self.current_id
+    }
+    fn tick(&self) {}
+    fn update(&self) {}
+    fn get_poly_sample(&self, _port: &str) -> napi::Result<PolyOutput> {
+      Ok(PolyOutput::mono(self.cached_signal.lock().get_value()))
+    }
+    fn get_module_type(&self) -> &str {
+      "patch-update-sensitive"
+    }
+    fn connect(&self, patch: &modular_core::patch::Patch) {
+      modular_core::types::Connect::connect(&mut *self.params_signal.lock(), patch);
+    }
+    fn on_patch_update(&self) {
+      let signal = self.params_signal.lock().clone();
+      *self.cached_signal.lock() = signal;
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+      self
+    }
+  }
+
+  fn create_test_processor() -> (CommandProducer, AudioProcessor) {
     let (
-      _cmd_producer,
+      cmd_producer,
       cmd_consumer,
       err_producer,
       _err_consumer,
@@ -2514,13 +2625,15 @@ mod tests {
       transport_meter: Arc::new(TransportMeter::default()),
     };
 
-    AudioProcessor::new(
+    let processor = AudioProcessor::new(
       cmd_consumer,
       err_producer,
       garbage_producer,
       shared,
       44100.0,
-    )
+    );
+
+    (cmd_producer, processor)
   }
 
   #[test]
@@ -2528,7 +2641,7 @@ mod tests {
     // Regression test: when remaps form a chain (A→B, B→C), all modules
     // must survive. Before the fix, applying A→B first would overwrite B
     // (destroying it) before B→C could move it to C.
-    let mut processor = create_test_processor();
+    let (_cmd_producer, mut processor) = create_test_processor();
 
     // Set up initial state: cycle-2 (shift), cycle-3 (thirds)
     processor
@@ -2597,7 +2710,7 @@ mod tests {
   #[test]
   fn test_remap_swap_preserves_both_modules() {
     // Test swap: A→B and B→A simultaneously
-    let mut processor = create_test_processor();
+    let (_cmd_producer, mut processor) = create_test_processor();
 
     processor
       .patch
@@ -2649,7 +2762,7 @@ mod tests {
   #[test]
   fn test_remap_simple_rename() {
     // Simple case: single remap, no chain
-    let mut processor = create_test_processor();
+    let (_cmd_producer, mut processor) = create_test_processor();
 
     processor
       .patch
@@ -2679,6 +2792,133 @@ mod tests {
       "my-vca",
       "module should be at new ID"
     );
+  }
+
+  #[test]
+  fn test_single_module_update_re_registers_message_listeners() {
+    let (mut cmd_producer, mut processor) = create_test_processor();
+
+    let old_hits = Arc::new(AtomicUsize::new(0));
+    let new_hits = Arc::new(AtomicUsize::new(0));
+    processor.patch.sampleables.insert(
+      "m1".into(),
+      CountingMessageModule::new("old", Arc::clone(&old_hits)),
+    );
+    processor.patch.rebuild_message_listeners();
+
+    cmd_producer
+      .push(GraphCommand::SingleModuleUpdate {
+        module_id: "m1".into(),
+        module: CountingMessageModule::new("new", Arc::clone(&new_hits)),
+      })
+      .unwrap();
+    cmd_producer
+      .push(GraphCommand::DispatchMessage(Message::MidiNoteOn(
+        MidiNoteOn {
+          device: None,
+          channel: 0,
+          note: 60,
+          velocity: 100,
+        },
+      )))
+      .unwrap();
+
+    processor.process_commands();
+
+    assert_eq!(old_hits.load(Ordering::SeqCst), 0);
+    assert_eq!(new_hits.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn test_single_module_update_refreshes_patch_update_caches() {
+    let (mut cmd_producer, mut processor) = create_test_processor();
+
+    processor
+      .patch
+      .sampleables
+      .insert("src".into(), ConstantOutputModule::new("src", 3.5));
+    processor.patch.sampleables.insert(
+      "dep".into(),
+      PatchUpdateSensitiveModule::new(
+        "dep",
+        Signal::Cable {
+          module: "src".into(),
+          resolved: None,
+          port: "out".into(),
+          channel: 0,
+        },
+      ),
+    );
+
+    for module in processor.patch.sampleables.values() {
+      module.connect(&processor.patch);
+    }
+    for module in processor.patch.sampleables.values() {
+      module.on_patch_update();
+    }
+
+    let initial = processor
+      .patch
+      .sampleables
+      .get("dep")
+      .unwrap()
+      .get_poly_sample("out")
+      .unwrap()
+      .get(0);
+    assert_eq!(initial, 3.5);
+
+    cmd_producer
+      .push(GraphCommand::SingleModuleUpdate {
+        module_id: "src".into(),
+        module: ConstantOutputModule::new("src", 7.25),
+      })
+      .unwrap();
+
+    processor.process_commands();
+
+    let updated = processor
+      .patch
+      .sampleables
+      .get("dep")
+      .unwrap()
+      .get_poly_sample("out")
+      .unwrap()
+      .get(0);
+    assert_eq!(updated, 7.25);
+  }
+
+  #[test]
+  fn test_patch_update_remap_re_registers_message_listeners() {
+    let (_cmd_producer, mut processor) = create_test_processor();
+
+    let hits = Arc::new(AtomicUsize::new(0));
+    processor.patch.sampleables.insert(
+      "old-id".into(),
+      CountingMessageModule::new("old-id", Arc::clone(&hits)),
+    );
+    processor.patch.rebuild_message_listeners();
+
+    let mut update = PatchUpdate::new(48000.0);
+    update.remaps = vec![ModuleIdRemap {
+      from: "old-id".into(),
+      to: "new-id".into(),
+    }];
+    update.desired_ids.insert("new-id".into());
+
+    processor.apply_patch_update(update);
+
+    let message = Message::MidiNoteOn(MidiNoteOn {
+      device: None,
+      channel: 0,
+      note: 60,
+      velocity: 100,
+    });
+
+    processor.patch.dispatch_message(&message).unwrap();
+
+    assert_eq!(hits.load(Ordering::SeqCst), 1);
+    assert!(!processor.patch.sampleables.contains_key("old-id"));
+    assert!(processor.patch.sampleables.contains_key("new-id"));
   }
 
   // ============================================================================

--- a/crates/modular/src/commands.rs
+++ b/crates/modular/src/commands.rs
@@ -3,11 +3,10 @@
 //! This module defines the commands sent from the main thread to the audio thread,
 //! and the errors reported back from the audio thread.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use modular_core::types::{Message, ModuleIdRemap, Sampleable, ScopeBufferKey, WavData};
 use napi_derive::napi;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::audio::ScopeBuffer;
 
@@ -30,8 +29,8 @@ pub struct PatchUpdate {
   /// Unique ID for this update, used to track apply/discard on the audio thread.
   pub update_id: u64,
 
-  /// Modules to insert (pre-constructed and Arc-wrapped on main thread).
-  pub inserts: Vec<(String, Arc<Box<dyn modular_core::types::Sampleable>>)>,
+  /// Modules to insert (pre-constructed on main thread).
+  pub inserts: Vec<(String, Box<dyn modular_core::types::Sampleable>)>,
 
   /// Set of desired module IDs, pre-computed on the main thread.
   /// Any existing module not in this set (and not reserved) is stale.
@@ -98,7 +97,7 @@ pub enum GraphCommand {
   /// does state transfer + replacement, then reconnects.
   SingleModuleUpdate {
     module_id: String,
-    module: Arc<Box<dyn Sampleable>>,
+    module: Box<dyn Sampleable>,
   },
 
   /// MIDI/control messages (can be sent individually)
@@ -166,7 +165,7 @@ pub const ERROR_QUEUE_CAPACITY: usize = 256;
 #[allow(dead_code)]
 pub enum GarbageItem {
   /// A module removed from the patch
-  Module(Arc<Box<dyn Sampleable>>),
+  Module(Box<dyn Sampleable>),
   /// A scope buffer removed from the collection
   Scope(ScopeBuffer),
   /// A queued patch update that was superseded by a newer update before it fired

--- a/crates/modular_core/src/dsp/fx/dattorro.rs
+++ b/crates/modular_core/src/dsp/fx/dattorro.rs
@@ -438,7 +438,7 @@ mod tests {
     const SAMPLE_RATE: f32 = 48000.0;
     const DEFAULT_PORT: &str = "output";
 
-    fn make_dattorro(params: serde_json::Value) -> Arc<Box<dyn Sampleable>> {
+    fn make_dattorro(params: serde_json::Value) -> Box<dyn Sampleable> {
         let constructors = get_constructors();
         let deserializers = get_params_deserializers();
         let deserializer = deserializers.get("$dattorro").unwrap();
@@ -488,7 +488,7 @@ mod tests {
     fn works_with_only_input() {
         // All non-input params should be optional — construct with just input
         let dattorro = make_dattorro(json!({ "input": 1.0 }));
-        let (left, right) = collect_stereo(&**dattorro, 5000);
+        let (left, right) = collect_stereo(dattorro.as_ref(), 5000);
         let left_energy: f32 = left.iter().map(|s| s * s).sum();
         let right_energy: f32 = right.iter().map(|s| s * s).sum();
         assert!(
@@ -504,7 +504,7 @@ mod tests {
     #[test]
     fn silence_in_silence_out() {
         let dattorro = make_dattorro(dattorro_params(json!({})));
-        let (left, right) = collect_stereo(&**dattorro, 1000);
+        let (left, right) = collect_stereo(dattorro.as_ref(), 1000);
         assert!(left.iter().all(|&s| s == 0.0), "left should be silent");
         assert!(right.iter().all(|&s| s == 0.0), "right should be silent");
     }
@@ -513,7 +513,7 @@ mod tests {
     fn impulse_produces_output() {
         let dattorro = make_dattorro(dattorro_params(json!({ "input": 1.0, "decay": 3.0 })));
         // Collect enough samples for the reverb tail to develop
-        let (left, right) = collect_stereo(&**dattorro, 10000);
+        let (left, right) = collect_stereo(dattorro.as_ref(), 10000);
 
         // After the initial transient, there should be non-zero output
         let left_energy: f32 = left.iter().map(|s| s * s).sum();
@@ -534,7 +534,7 @@ mod tests {
         let dattorro = make_dattorro(dattorro_params(
             json!({ "input": 1.0, "decay": 3.0, "size": 2.0 }),
         ));
-        let (left, right) = collect_stereo(&**dattorro, 5000);
+        let (left, right) = collect_stereo(dattorro.as_ref(), 5000);
 
         // L and R should not be identical (stereo decorrelation)
         let identical = left
@@ -548,7 +548,7 @@ mod tests {
     fn no_dc_offset_accumulation() {
         // Feed constant DC and check that output doesn't grow unbounded
         let dattorro = make_dattorro(dattorro_params(json!({ "input": 1.0, "decay": 2.0 })));
-        let (left, right) = collect_stereo(&**dattorro, 48000); // 1 second
+        let (left, right) = collect_stereo(dattorro.as_ref(), 48000); // 1 second
 
         // Check the last 1000 samples for DC offset stability
         let last_left = &left[47000..];
@@ -574,8 +574,8 @@ mod tests {
         let dattorro_high = make_dattorro(dattorro_params(json!({ "input": 1.0, "decay": 3.0 })));
 
         let n = 20000;
-        let (left_low, _) = collect_stereo(&**dattorro_low, n);
-        let (left_high, _) = collect_stereo(&**dattorro_high, n);
+        let (left_low, _) = collect_stereo(dattorro_low.as_ref(), n);
+        let (left_high, _) = collect_stereo(dattorro_high.as_ref(), n);
 
         // Measure energy in the tail (last quarter)
         let tail_start = n * 3 / 4;
@@ -591,7 +591,7 @@ mod tests {
     #[test]
     fn output_is_two_channels() {
         let dattorro = make_dattorro(dattorro_params(json!({})));
-        step(&**dattorro);
+        step(dattorro.as_ref());
         let poly = dattorro.get_poly_sample(DEFAULT_PORT).unwrap();
         assert_eq!(poly.channels(), 2, "output should be stereo (2 channels)");
     }
@@ -603,12 +603,12 @@ mod tests {
         let n = 10000;
 
         let dattorro_no_mod = make_dattorro(dattorro_params(json!({ "input": 1.0, "decay": 3.0 })));
-        let (left_no_mod, _) = collect_stereo(&**dattorro_no_mod, n);
+        let (left_no_mod, _) = collect_stereo(dattorro_no_mod.as_ref(), n);
 
         let dattorro_with_mod = make_dattorro(dattorro_params(
             json!({ "input": 1.0, "decay": 3.0, "modulation": 2.5 }),
         ));
-        let (left_with_mod, _) = collect_stereo(&**dattorro_with_mod, n);
+        let (left_with_mod, _) = collect_stereo(dattorro_with_mod.as_ref(), n);
 
         // Outputs should differ due to modulated delay lengths
         let differs = left_no_mod

--- a/crates/modular_core/src/dsp/fx/plate.rs
+++ b/crates/modular_core/src/dsp/fx/plate.rs
@@ -474,7 +474,7 @@ mod tests {
     const SAMPLE_RATE: f32 = 48000.0;
     const DEFAULT_PORT: &str = "output";
 
-    fn make_plate(params: serde_json::Value) -> Arc<Box<dyn Sampleable>> {
+    fn make_plate(params: serde_json::Value) -> Box<dyn Sampleable> {
         let constructors = get_constructors();
         let deserializers = get_params_deserializers();
         let deserializer = deserializers.get("$plate").unwrap();
@@ -518,7 +518,7 @@ mod tests {
     #[test]
     fn works_with_only_input() {
         let plate = make_plate(json!({ "input": 1.0 }));
-        let (left, right) = collect_stereo(&**plate, 10000);
+        let (left, right) = collect_stereo(plate.as_ref(), 10000);
         let left_energy: f32 = left.iter().map(|s| s * s).sum();
         let right_energy: f32 = right.iter().map(|s| s * s).sum();
         assert!(
@@ -534,7 +534,7 @@ mod tests {
     #[test]
     fn silence_in_silence_out() {
         let plate = make_plate(plate_params(json!({})));
-        let (left, right) = collect_stereo(&**plate, 1000);
+        let (left, right) = collect_stereo(plate.as_ref(), 1000);
         assert!(left.iter().all(|&s| s == 0.0), "left should be silent");
         assert!(right.iter().all(|&s| s == 0.0), "right should be silent");
     }
@@ -542,7 +542,7 @@ mod tests {
     #[test]
     fn impulse_produces_output() {
         let plate = make_plate(plate_params(json!({ "input": 1.0, "decay": 3.0 })));
-        let (left, right) = collect_stereo(&**plate, 20000);
+        let (left, right) = collect_stereo(plate.as_ref(), 20000);
         let left_energy: f32 = left.iter().map(|s| s * s).sum();
         let right_energy: f32 = right.iter().map(|s| s * s).sum();
         assert!(
@@ -558,7 +558,7 @@ mod tests {
     #[test]
     fn stereo_channels_differ() {
         let plate = make_plate(plate_params(json!({ "input": 1.0, "decay": 3.0 })));
-        let (left, right) = collect_stereo(&**plate, 10000);
+        let (left, right) = collect_stereo(plate.as_ref(), 10000);
         let identical = left
             .iter()
             .zip(right.iter())
@@ -569,7 +569,7 @@ mod tests {
     #[test]
     fn no_dc_offset_accumulation() {
         let plate = make_plate(plate_params(json!({ "input": 1.0, "decay": 2.0 })));
-        let (left, right) = collect_stereo(&**plate, 48000);
+        let (left, right) = collect_stereo(plate.as_ref(), 48000);
         let last_left = &left[47000..];
         let last_right = &right[47000..];
         let left_mean: f32 = last_left.iter().sum::<f32>() / last_left.len() as f32;
@@ -589,8 +589,8 @@ mod tests {
         let plate_low = make_plate(plate_params(json!({ "input": 1.0, "decay": -3.0 })));
         let plate_high = make_plate(plate_params(json!({ "input": 1.0, "decay": 3.0 })));
         let n = 20000;
-        let (left_low, _) = collect_stereo(&**plate_low, n);
-        let (left_high, _) = collect_stereo(&**plate_high, n);
+        let (left_low, _) = collect_stereo(plate_low.as_ref(), n);
+        let (left_high, _) = collect_stereo(plate_high.as_ref(), n);
         let tail_start = n * 3 / 4;
         let low_tail_energy: f32 = left_low[tail_start..].iter().map(|s| s * s).sum();
         let high_tail_energy: f32 = left_high[tail_start..].iter().map(|s| s * s).sum();
@@ -603,7 +603,7 @@ mod tests {
     #[test]
     fn output_is_two_channels() {
         let plate = make_plate(plate_params(json!({})));
-        step(&**plate);
+        step(plate.as_ref());
         let poly = plate.get_poly_sample(DEFAULT_PORT).unwrap();
         assert_eq!(poly.channels(), 2, "output should be stereo (2 channels)");
     }
@@ -612,11 +612,11 @@ mod tests {
     fn modulation_changes_output() {
         let n = 20000;
         let plate_no_mod = make_plate(plate_params(json!({ "input": 1.0, "decay": 3.0 })));
-        let (left_no_mod, _) = collect_stereo(&**plate_no_mod, n);
+        let (left_no_mod, _) = collect_stereo(plate_no_mod.as_ref(), n);
         let plate_with_mod = make_plate(plate_params(
             json!({ "input": 1.0, "decay": 3.0, "modulation": 2.5 }),
         ));
-        let (left_with_mod, _) = collect_stereo(&**plate_with_mod, n);
+        let (left_with_mod, _) = collect_stereo(plate_with_mod.as_ref(), n);
         let differs = left_no_mod
             .iter()
             .zip(left_with_mod.iter())
@@ -633,8 +633,8 @@ mod tests {
         let n = 10000;
         let plate_bright = make_plate(plate_params(json!({ "input": 1.0, "bandwidth": 5.0 })));
         let plate_dark = make_plate(plate_params(json!({ "input": 1.0, "bandwidth": -5.0 })));
-        let (left_bright, _) = collect_stereo(&**plate_bright, n);
-        let (left_dark, _) = collect_stereo(&**plate_dark, n);
+        let (left_bright, _) = collect_stereo(plate_bright.as_ref(), n);
+        let (left_dark, _) = collect_stereo(plate_dark.as_ref(), n);
         // Different bandwidth should produce different output
         let differs = left_bright
             .iter()

--- a/crates/modular_core/src/dsp/samplers/sampler.rs
+++ b/crates/modular_core/src/dsp/samplers/sampler.rs
@@ -121,11 +121,7 @@ mod tests {
 
     const SAMPLE_RATE: f32 = 48000.0;
 
-    fn make_module(
-        module_type: &str,
-        id: &str,
-        params: serde_json::Value,
-    ) -> Arc<Box<dyn Sampleable>> {
+    fn make_module(module_type: &str, id: &str, params: serde_json::Value) -> Box<dyn Sampleable> {
         let constructors = get_constructors();
         let deserializers = get_params_deserializers();
         let deserializer = deserializers
@@ -180,7 +176,7 @@ mod tests {
 
         // Run a few samples — no trigger, should output silence
         for _ in 0..4 {
-            step(&**module);
+            step(module.as_ref());
         }
 
         let output = module.get_poly_sample("output").unwrap();
@@ -206,7 +202,7 @@ mod tests {
         module.connect(&patch);
 
         // First tick: gate is high, Schmitt trigger detects rising edge, position resets to 0
-        step(&**module);
+        step(module.as_ref());
         let out = module.get_poly_sample("output").unwrap();
         assert!(
             (out.get(0) - 1.0).abs() < 1e-6,
@@ -233,9 +229,9 @@ mod tests {
         module.connect(&patch);
 
         // Play through the 2-frame sample
-        step(&**module); // frame 0 -> output 1.0
-        step(&**module); // frame 1 -> output 2.0
-        step(&**module); // frame 2 -> past end -> silence
+        step(module.as_ref()); // frame 0 -> output 1.0
+        step(module.as_ref()); // frame 1 -> output 2.0
+        step(module.as_ref()); // frame 2 -> past end -> silence
 
         let out = module.get_poly_sample("output").unwrap();
         assert_eq!(out.get(0), 0.0, "should be silent after sample ends");
@@ -261,7 +257,7 @@ mod tests {
 
         // With negative speed, gate trigger should start from end of sample.
         // Frame 3 = 4.0, frame 2 = 3.0, frame 1 = 2.0, frame 0 = 1.0
-        step(&**module); // trigger + play from end: frame 3
+        step(module.as_ref()); // trigger + play from end: frame 3
         let out = module.get_poly_sample("output").unwrap();
         assert!(
             (out.get(0) - 4.0).abs() < 1e-6,
@@ -269,7 +265,7 @@ mod tests {
             out.get(0)
         );
 
-        step(&**module); // frame 2
+        step(module.as_ref()); // frame 2
         let out = module.get_poly_sample("output").unwrap();
         assert!(
             (out.get(0) - 3.0).abs() < 1e-6,
@@ -277,7 +273,7 @@ mod tests {
             out.get(0)
         );
 
-        step(&**module); // frame 1
+        step(module.as_ref()); // frame 1
         let out = module.get_poly_sample("output").unwrap();
         assert!(
             (out.get(0) - 2.0).abs() < 1e-6,
@@ -285,7 +281,7 @@ mod tests {
             out.get(0)
         );
 
-        step(&**module); // frame 0
+        step(module.as_ref()); // frame 0
         let out = module.get_poly_sample("output").unwrap();
         assert!(
             (out.get(0) - 1.0).abs() < 1e-6,
@@ -294,7 +290,7 @@ mod tests {
         );
 
         // After passing frame 0, should be silent
-        step(&**module);
+        step(module.as_ref());
         let out = module.get_poly_sample("output").unwrap();
         assert_eq!(
             out.get(0),
@@ -322,7 +318,7 @@ mod tests {
         module.connect(&patch);
 
         // First tick: gate rises, plays frame 0
-        step(&**module);
+        step(module.as_ref());
         let out = module.get_poly_sample("output").unwrap();
         assert!(
             (out.get(0) - 1.0).abs() < 1e-6,
@@ -336,7 +332,7 @@ mod tests {
         );
 
         // Second tick: frame 1
-        step(&**module);
+        step(module.as_ref());
         let out = module.get_poly_sample("output").unwrap();
         assert!(
             (out.get(0) - 2.0).abs() < 1e-6,

--- a/crates/modular_core/src/dsp/utilities/buffer.rs
+++ b/crates/modular_core/src/dsp/utilities/buffer.rs
@@ -282,7 +282,7 @@ mod tests {
         };
         patch
             .sampleables
-            .insert(MOCK_BUFFER_MODULE_ID.to_string(), Arc::new(Box::new(owner)));
+            .insert(MOCK_BUFFER_MODULE_ID.to_string(), Box::new(owner));
 
         let mut buffer = Buffer::new(
             MOCK_BUFFER_MODULE_ID.to_string(),
@@ -354,11 +354,7 @@ mod tests {
 
     const SAMPLE_RATE: f32 = 48000.0;
 
-    fn make_module(
-        module_type: &str,
-        id: &str,
-        params: serde_json::Value,
-    ) -> Arc<Box<dyn Sampleable>> {
+    fn make_module(module_type: &str, id: &str, params: serde_json::Value) -> Box<dyn Sampleable> {
         let constructors = get_constructors();
         let deserializers = get_params_deserializers();
         let deserializer = deserializers
@@ -394,7 +390,7 @@ mod tests {
             serde_json::json!({ "input": 3.0, "length": 0.01 }),
         );
 
-        step(&**module);
+        step(module.as_ref());
 
         let output = module
             .get_poly_sample("output")
@@ -416,7 +412,7 @@ mod tests {
 
         let n = 10;
         for _ in 0..n {
-            step(&**module);
+            step(module.as_ref());
         }
 
         let buffer = module
@@ -438,7 +434,7 @@ mod tests {
             serde_json::json!({ "input": input_val, "length": 0.01 }),
         );
 
-        step(&**module);
+        step(module.as_ref());
 
         let buffer = module
             .get_buffer_output("buffer")
@@ -469,7 +465,7 @@ mod tests {
         // Step more than frame_count times to force wrapping
         let total_steps = frame_count + 3;
         for _ in 0..total_steps {
-            step(&**module);
+            step(module.as_ref());
         }
 
         // write_index should keep incrementing past frame_count (no modular reset)

--- a/crates/modular_core/src/dsp/utilities/math.rs
+++ b/crates/modular_core/src/dsp/utilities/math.rs
@@ -1,13 +1,12 @@
 use crate::dsp::utils::{hz_to_voct_f64, voct_to_hz_f64};
 use crate::poly::{MonoSignal, MonoSignalExt};
-use crate::types::{ClockMessages, Connect, Signal};
+use crate::types::{ClockMessages, Connect};
 use deserr::{DeserializeError, Deserr, ErrorKind, IntoValue, ValuePointerRef};
 use fasteval::{Compiler, Evaler, Instruction};
 use napi::Result;
-use regex::Regex;
 use schemars::JsonSchema;
 use std::collections::BTreeMap;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 /// Compiled fasteval expression data. Wrapped in `Arc` so that
 /// `MathExpressionParam` can derive `Clone` cheaply (Arc clone)
@@ -35,36 +34,15 @@ struct MathExpressionParam {
 
     #[serde(skip)]
     #[schemars(skip)]
-    signals: Vec<Signal>,
-
-    #[serde(skip)]
-    #[schemars(skip)]
     compiled: Arc<MathCompiled>,
 }
 
 impl MathExpressionParam {
     /// Parse a math expression string into a MathExpressionParam.
     fn parse(source: String) -> std::result::Result<Self, String> {
-        let re = Regex::new(r"module\(([a-zA-Z0-9\-_$]+):([a-zA-Z0-9\-_$]+):(\d+)\)")
-            .map_err(|e| e.to_string())?;
-        let mut signals = Vec::new();
-
-        let result = re.replace_all(&source, |caps: &regex::Captures| {
-            let module = caps[1].to_string();
-            let port = caps[2].to_string();
-            let channel: usize = caps[3].parse().unwrap_or(0);
-            signals.push(Signal::Cable {
-                module,
-                module_ptr: Weak::default(),
-                port,
-                channel,
-            });
-            format!("module{}", signals.len() - 1)
-        });
-
         let mut slab = fasteval::Slab::new();
         let parser = fasteval::Parser::new();
-        let instruction = match parser.parse(&result, &mut slab.ps) {
+        let instruction = match parser.parse(&source, &mut slab.ps) {
             Err(e) => {
                 return Err(format!("Failed to parse expression: {}", e));
             }
@@ -73,10 +51,13 @@ impl MathExpressionParam {
 
         Ok(MathExpressionParam {
             source,
-            signals,
             compiled: Arc::new(MathCompiled { slab, instruction }),
         })
     }
+}
+
+impl Connect for MathExpressionParam {
+    fn connect(&mut self, _patch: &crate::Patch) {}
 }
 
 // deserr implementation for MathExpressionParam - transparent string wrapper that parses.
@@ -96,15 +77,7 @@ impl<E: DeserializeError> deserr::Deserr<E> for MathExpressionParam {
     }
 }
 
-impl Connect for MathExpressionParam {
-    fn connect(&mut self, patch: &crate::Patch) {
-        for signal in &mut self.signals {
-            signal.connect(patch);
-        }
-    }
-}
-
-#[derive(Clone, Deserr, JsonSchema, ChannelCount, SignalParams)]
+#[derive(Clone, Deserr, JsonSchema, ChannelCount, SignalParams, Connect)]
 #[serde(rename_all = "camelCase")]
 #[deserr(rename_all = camelCase, deny_unknown_fields)]
 struct MathParams {
@@ -119,21 +92,6 @@ struct MathParams {
     /// third input variable, referenced as `z` in the expression
     #[deserr(default)]
     z: Option<MonoSignal>,
-}
-
-impl Connect for MathParams {
-    fn connect(&mut self, patch: &crate::Patch) {
-        Connect::connect(&mut self.expression, patch);
-        if let Some(ref mut x) = self.x {
-            Connect::connect(x, patch);
-        }
-        if let Some(ref mut y) = self.y {
-            Connect::connect(y, patch);
-        }
-        if let Some(ref mut z) = self.z {
-            Connect::connect(z, patch);
-        }
-    }
 }
 
 #[derive(Outputs, JsonSchema)]
@@ -211,22 +169,12 @@ impl Math {
         let y = self.params.y.value_or(0.0) as f64;
         let z = self.params.z.value_or(0.0) as f64;
         let t = self.state.phase as f64 + self.state.loop_index as f64;
-        let signals = self
-            .params
-            .expression
-            .signals
-            .iter()
-            .map(|s| s.get_value() as f64)
-            .collect::<Vec<_>>();
 
         let mut btree = BTreeMap::new();
         btree.insert("x".to_string(), x);
         btree.insert("y".to_string(), y);
         btree.insert("z".to_string(), z);
         btree.insert("t".to_string(), t);
-        for (i, val) in signals.iter().enumerate() {
-            btree.insert(format!("module{}", i).to_string(), *val);
-        }
 
         let mut cb = move |name: &str, args: Vec<f64>| -> Option<f64> {
             if let Some(val) = btree.get(name) {

--- a/crates/modular_core/src/patch.rs
+++ b/crates/modular_core/src/patch.rs
@@ -14,20 +14,14 @@ use crate::types::{
 };
 
 use std::collections::HashMap;
-use std::sync::{Arc, Weak};
-
-#[derive(Clone)]
-struct MessageListenerRef {
-    id: String,
-    weak: Weak<Box<dyn Sampleable>>,
-}
+use std::sync::Arc;
 
 /// The core patch structure containing the DSP graph
 pub struct Patch {
     pub audio_in: Arc<Mutex<PolyOutput>>,
     pub sampleables: SampleableMap,
     pub wav_data: HashMap<String, Arc<WavData>>,
-    message_listeners: HashMap<MessageTag, Vec<MessageListenerRef>>,
+    message_listeners: HashMap<MessageTag, Vec<String>>,
 }
 
 impl Patch {
@@ -39,7 +33,7 @@ impl Patch {
 
         sampleables.insert(
             audio_in_sampleable.get_id().to_string(),
-            Arc::new(Box::new(audio_in_sampleable)),
+            Box::new(audio_in_sampleable),
         );
         println!("sampleables {:?}", sampleables.keys());
         let mut patch = Patch {
@@ -59,78 +53,49 @@ impl Patch {
             input: self.audio_in.clone(),
         };
         let id = WellKnownModule::HiddenAudioIn.id().to_string();
-        self.sampleables
-            .insert(id, Arc::new(Box::new(audio_in_sampleable)));
+        self.sampleables.insert(id, Box::new(audio_in_sampleable));
     }
 
     pub fn rebuild_message_listeners(&mut self) {
         self.message_listeners.clear();
-        for (id, sampleable) in &self.sampleables {
-            for tag in sampleable.handled_message_tags() {
-                self.message_listeners
-                    .entry(*tag)
-                    .or_default()
-                    .push(MessageListenerRef {
-                        id: id.clone(),
-                        weak: Arc::downgrade(sampleable),
-                    });
-            }
+        let ids: Vec<String> = self.sampleables.keys().cloned().collect();
+        for id in ids {
+            self.add_message_listeners_for_module(&id);
         }
     }
 
     /// Add message listener entries for a single module (incremental update).
-    pub fn add_message_listeners_for_module(
-        &mut self,
-        id: &str,
-        sampleable: &Arc<Box<dyn Sampleable>>,
-    ) {
+    pub fn add_message_listeners_for_module(&mut self, id: &str) {
+        let Some(sampleable) = self.sampleables.get(id) else {
+            return;
+        };
+
         for tag in sampleable.handled_message_tags() {
             self.message_listeners
                 .entry(*tag)
                 .or_default()
-                .push(MessageListenerRef {
-                    id: id.to_string(),
-                    weak: Arc::downgrade(sampleable),
-                });
+                .push(id.to_string());
         }
     }
 
     /// Remove all message listener entries for a given module id.
     pub fn remove_message_listeners_for_module(&mut self, module_id: &str) {
         for listeners in self.message_listeners.values_mut() {
-            listeners.retain(|r| r.id != module_id);
+            listeners.retain(|id| id != module_id);
         }
-    }
-
-    /// Collect strong references to all modules currently in this patch that
-    /// have registered to handle the given message tag.
-    ///
-    /// This method prunes stale entries. In particular, it will never return a
-    /// module that is no longer present in `self.sampleables`, even if some
-    /// other subsystem still holds a strong `Arc` to that module.
-    pub fn message_listeners_for(&mut self, tag: MessageTag) -> Vec<Arc<Box<dyn Sampleable>>> {
-        let Some(list) = self.message_listeners.get_mut(&tag) else {
-            return Vec::new();
-        };
-
-        list.retain(|r| {
-            if !self.sampleables.contains_key(&r.id) {
-                return false;
-            }
-            r.weak.upgrade().is_some()
-        });
-
-        list.iter()
-            .filter(|r| self.sampleables.contains_key(&r.id))
-            .filter_map(|r| r.weak.upgrade())
-            .collect()
     }
 
     pub fn dispatch_message(&mut self, message: &Message) -> napi::Result<()> {
-        let listeners = self.message_listeners_for(message.tag());
-        for s in listeners {
-            s.handle_message(message)?;
+        let Some(listener_ids) = self.message_listeners.get(&message.tag()) else {
+            return Ok(());
+        };
+
+        for id in listener_ids {
+            if let Some(sampleable) = self.sampleables.get(id) {
+                sampleable.handle_message(message)?;
+            }
         }
+
         Ok(())
     }
 
@@ -209,6 +174,64 @@ mod tests {
 
     use crate::types::MessageHandler;
     use napi::Result;
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Mutex as StdMutex, OnceLock};
+
+    struct CountingAllocator;
+
+    static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+    static TRACKING_ENABLED: AtomicUsize = AtomicUsize::new(0);
+    static TRACKING_LOCK: OnceLock<StdMutex<()>> = OnceLock::new();
+
+    #[global_allocator]
+    static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
+
+    unsafe impl GlobalAlloc for CountingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            if TRACKING_ENABLED.load(Ordering::Relaxed) != 0 {
+                ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            }
+            unsafe { System.alloc(layout) }
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) }
+        }
+    }
+
+    fn allocation_tracking_lock() -> &'static StdMutex<()> {
+        TRACKING_LOCK.get_or_init(|| StdMutex::new(()))
+    }
+
+    fn assert_message_listener_dispatch_does_not_allocate() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let s: Box<dyn Sampleable> = Box::new(CountingMessageSampleable {
+            id: "m1".to_string(),
+            hits: Arc::clone(&hits),
+        });
+
+        let mut patch = Patch::new();
+        patch.sampleables.insert("m1".to_string(), s);
+        patch.rebuild_message_listeners();
+
+        let message = Message::MidiNoteOn(crate::types::MidiNoteOn {
+            device: None,
+            note: 60,
+            velocity: 100,
+            channel: 0,
+        });
+
+        let _guard = allocation_tracking_lock().lock().unwrap();
+        ALLOCATIONS.store(0, Ordering::SeqCst);
+        TRACKING_ENABLED.store(1, Ordering::SeqCst);
+        patch.dispatch_message(&message).unwrap();
+        TRACKING_ENABLED.store(0, Ordering::SeqCst);
+
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        assert_eq!(ALLOCATIONS.load(Ordering::SeqCst), 0);
+    }
 
     #[test]
     fn test_patch_new_has_hidden_audio_in() {
@@ -271,22 +294,126 @@ mod tests {
     }
 
     #[test]
-    fn message_listeners_never_return_removed_modules() {
-        let s: Arc<Box<dyn Sampleable>> = Arc::new(Box::new(DummyMessageSampleable {
+    fn message_listener_index_stores_ids_only() {
+        let s: Box<dyn Sampleable> = Box::new(DummyMessageSampleable {
             id: "m1".to_string(),
-        }));
+        });
 
         let mut patch = Patch::new();
-        patch.sampleables.insert("m1".to_string(), Arc::clone(&s));
+        patch.sampleables.insert("m1".to_string(), s);
         patch.rebuild_message_listeners();
 
-        // Index should include it.
-        assert_eq!(patch.message_listeners_for(MessageTag::MidiNoteOn).len(), 1);
+        assert_eq!(
+            patch
+                .message_listeners
+                .get(&MessageTag::MidiNoteOn)
+                .cloned(),
+            Some(vec!["m1".to_string()])
+        );
+    }
 
-        // Remove from patch but keep an external strong ref (`s`).
+    struct CountingMessageSampleable {
+        id: String,
+        hits: Arc<AtomicUsize>,
+    }
+
+    impl Sampleable for CountingMessageSampleable {
+        fn get_id(&self) -> &str {
+            &self.id
+        }
+
+        fn tick(&self) {}
+
+        fn update(&self) {}
+
+        fn get_poly_sample(&self, _port: &str) -> Result<crate::poly::PolyOutput> {
+            Ok(crate::poly::PolyOutput::default())
+        }
+
+        fn get_module_type(&self) -> &str {
+            "counting"
+        }
+
+        fn connect(&self, _patch: &Patch) {}
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl MessageHandler for CountingMessageSampleable {
+        fn handled_message_tags(&self) -> &'static [MessageTag] {
+            &[MessageTag::MidiNoteOn]
+        }
+
+        fn handle_message(&self, _message: &Message) -> Result<()> {
+            self.hits.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn message_listener_removed_module_is_not_dispatched() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let s: Box<dyn Sampleable> = Box::new(CountingMessageSampleable {
+            id: "m1".to_string(),
+            hits: Arc::clone(&hits),
+        });
+
+        let mut patch = Patch::new();
+        patch.sampleables.insert("m1".to_string(), s);
+        patch.rebuild_message_listeners();
+
+        let message = Message::MidiNoteOn(crate::types::MidiNoteOn {
+            device: None,
+            note: 60,
+            velocity: 100,
+            channel: 0,
+        });
+
+        patch.dispatch_message(&message).unwrap();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
         patch.sampleables.remove("m1");
+        patch.remove_message_listeners_for_module("m1");
 
-        // Rebuild/prune and ensure it is not returned.
-        assert_eq!(patch.message_listeners_for(MessageTag::MidiNoteOn).len(), 0);
+        patch.dispatch_message(&message).unwrap();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            patch
+                .message_listeners
+                .get(&MessageTag::MidiNoteOn)
+                .map(Vec::len),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn message_listener_dispatch_does_not_allocate() {
+        const ISOLATED_ALLOC_TEST_ENV: &str = "MODULAR_CORE_ISOLATED_ALLOC_TEST";
+
+        if std::env::var_os(ISOLATED_ALLOC_TEST_ENV).is_some() {
+            assert_message_listener_dispatch_does_not_allocate();
+            return;
+        }
+
+        // The allocator counter is process-global, so run the actual assertion in
+        // a child test process to avoid unrelated allocations from concurrently
+        // executing tests in the parent harness.
+        let output = Command::new(std::env::current_exe().unwrap())
+            .env(ISOLATED_ALLOC_TEST_ENV, "1")
+            .arg("--exact")
+            .arg("patch::tests::message_listener_dispatch_does_not_allocate")
+            .arg("--nocapture")
+            .arg("--test-threads=1")
+            .output()
+            .expect("failed to spawn isolated allocation test");
+
+        assert!(
+            output.status.success(),
+            "isolated allocation test failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }

--- a/crates/modular_core/src/pattern_system/combinators.rs
+++ b/crates/modular_core/src/pattern_system/combinators.rs
@@ -403,10 +403,8 @@ fn gcd(a: &Fraction, b: &Fraction) -> Fraction {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Weak;
-
     use super::*;
-    use crate::{pattern_system::constructors::pure, types::Signal};
+    use crate::pattern_system::constructors::pure;
 
     #[test]
     fn test_stack() {
@@ -491,35 +489,19 @@ mod tests {
     }
 
     #[test]
-    fn foo() {
-        let sig1 = Signal::Cable {
-            module: "sine".into(),
-            module_ptr: Weak::new(),
-            port: "output".into(),
-            channel: 0,
-        };
+    fn slowcat_alternates_non_numeric_values() {
+        let first = "sig1".to_string();
+        let second = "sig2".to_string();
 
-        let sig2 = Signal::Cable {
-            module: "sine".into(),
-            module_ptr: Weak::new(),
-            port: "output".into(),
-            channel: 0,
-        };
-
-        let pat = slowcat(
-            vec![sig1.clone(), sig2.clone()]
-                .into_iter()
-                .map(|sig| pure(sig))
-                .collect(),
-        );
+        let pat = slowcat(vec![pure(first.clone()), pure(second.clone())]);
         // Each cycle should have only one value
         for i in 0..6 {
             let haps = pat.query_arc(Fraction::from_integer(i), Fraction::from_integer(i + 1));
             assert_eq!(haps.len(), 1);
             if i % 2 == 0 {
-                assert_eq!(haps[0].value, sig1);
+                assert_eq!(haps[0].value, first);
             } else {
-                assert_eq!(haps[0].value, sig2);
+                assert_eq!(haps[0].value, second);
             }
         }
     }

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -7,20 +7,21 @@
 //!
 //! ## Why This Is Safe
 //!
-//! 1. **Exclusive Audio Thread Ownership**: After construction, all modules live in
-//!    `AudioProcessor::patch` which is owned exclusively by the audio thread closure.
-//!    See `crates/modular/src/audio.rs` `make_stream()`.
+//! 1. **Single-owner handoff**: Modules are constructed on the main thread, prepared,
+//!    then moved into the runtime as owned `Box<dyn Sampleable + Send>` values. After
+//!    that transfer, they are owned exclusively by the audio thread runtime.
 //!
 //! 2. **Command Queue Isolation**: The main thread communicates via `PatchUpdate`
 //!    commands through an `rtrb` SPSC queue. It never directly accesses module state.
 //!
-//! 3. **No Escaping References**: Module `Arc`s are stored in `Patch::sampleables` and
-//!    are never cloned or sent to other threads after being added to the patch.
+//! 3. **No shared module access**: Runtime module state is not shared across threads.
+//!    `Sampleable` is send-only; once transferred, module trait methods are called only
+//!    by the audio thread owner.
 //!
 //! ## Invariants (DO NOT VIOLATE - will cause undefined behavior)
 //!
 //! - **NEVER** call `Sampleable` trait methods from the main thread
-//! - **NEVER** clone module `Arc`s and send them across threads
+//! - **NEVER** share a module instance across threads after handoff
 //! - **NEVER** access `Patch::sampleables` from outside `AudioProcessor`
 //! - **ALWAYS** use the command queue for main→audio communication
 //!
@@ -45,11 +46,9 @@ use std::borrow::Cow;
 use std::cell::UnsafeCell;
 use std::fmt::Debug;
 use std::ops::{Add, Deref, Div, Mul, Sub};
+use std::ptr::NonNull;
 use std::result::Result as StdResult;
-use std::{
-    collections::HashMap,
-    sync::{self, Arc},
-};
+use std::{collections::HashMap, sync::Arc};
 
 use crate::dsp::tables::warp;
 use crate::dsp::utils::{hz_to_voct, midi_to_voct};
@@ -99,7 +98,7 @@ impl WellKnownModule {
     pub fn to_cable(&self, channel: usize, port: &str) -> Signal {
         Signal::Cable {
             module: self.id().into(),
-            module_ptr: std::sync::Weak::new(),
+            resolved: None,
             port: port.into(),
             channel,
         }
@@ -227,7 +226,10 @@ pub struct Config {
     pub params: Value,
 }
 
-pub type SampleableMap = HashMap<String, Arc<Box<dyn Sampleable>>>;
+pub type SampleableMap = HashMap<String, Box<dyn Sampleable>>;
+/// Cached during the patch `connect()` phase and only dereferenced later during
+/// audio-thread reads; callers must not hold or use it across another reconnect.
+pub type SampleablePtr = NonNull<dyn Sampleable>;
 
 /// One-pole lowpass filter for parameter smoothing to prevent clicking
 /// Coefficient of 0.99 gives roughly 5ms smoothing time at 48kHz
@@ -1017,15 +1019,15 @@ impl JsonSchema for Wav {
 /// 2. The owning module's `update()` writes; readers on the same thread read.
 ///    Demand-driven ordering (`ensure_source_updated`) guarantees the writer
 ///    finishes before any reader accesses the data within the same tick.
-/// 3. `Send + Sync` is implemented manually — cross-thread transfer happens only
-///    via the command queue (construction → audio thread), never concurrent access.
+/// 3. Only `Sync` is implemented manually. `BufferData` is naturally `Send`, and the
+///    shared `Arc<BufferData>` handle may be observed from multiple owners while actual
+///    mutation still follows the runtime's phase-separated audio-thread contract.
 #[derive(Debug)]
 pub struct BufferData {
     inner: UnsafeCell<SampleBuffer>,
     write_index: UnsafeCell<usize>,
 }
 
-unsafe impl Send for BufferData {}
 unsafe impl Sync for BufferData {}
 
 impl BufferData {
@@ -1206,18 +1208,35 @@ struct BufferSerde {
     channels: usize,
 }
 
-#[derive(Clone)]
 pub struct Buffer {
     /// Source module ID
     source_module: String,
     /// Source port name
     source_port: String,
-    /// Cached strong reference to the source module, populated during `connect()`.
-    cached_source_module: Option<Arc<Box<dyn Sampleable>>>,
+    /// Cached raw pointer to the source module, populated during `connect()`.
+    cached_source_ptr: Option<SampleablePtr>,
     /// Cached strong reference to the buffer data, populated during `connect()`.
     cached_buffer: Option<Arc<BufferData>>,
     /// Channel count (used for channel derivation at deserialization time)
     channels: usize,
+}
+
+// SAFETY: `cached_source_ptr` is populated during `connect()` and later dereferenced only from
+// the audio thread after connection has finished. `Buffer` values may move to that thread as
+// params, but they must not be shared concurrently because the cached pointer is thread-affine.
+unsafe impl Send for Buffer {}
+
+impl Clone for Buffer {
+    fn clone(&self) -> Self {
+        Self {
+            source_module: self.source_module.clone(),
+            source_port: self.source_port.clone(),
+            // Runtime caches are patch-lifetime-specific and must be reconnected.
+            cached_source_ptr: None,
+            cached_buffer: None,
+            channels: self.channels,
+        }
+    }
 }
 
 impl Buffer {
@@ -1226,7 +1245,7 @@ impl Buffer {
         Self {
             source_module,
             source_port,
-            cached_source_module: None,
+            cached_source_ptr: None,
             cached_buffer: None,
             channels,
         }
@@ -1259,8 +1278,8 @@ impl Buffer {
     /// This triggers the $buffer module's `update()` which writes the current sample
     /// and increments write_index. Must be called before reading the buffer.
     pub fn ensure_source_updated(&self) {
-        if let Some(module) = &self.cached_source_module {
-            module.update();
+        if let Some(module_ptr) = self.cached_source_ptr {
+            unsafe { module_ptr.as_ref().update() };
         }
     }
 
@@ -1428,7 +1447,7 @@ impl Connect for Buffer {
     fn connect(&mut self, patch: &Patch) {
         // Resolve source module and get its buffer output
         if let Some(module) = patch.sampleables.get(&self.source_module) {
-            self.cached_source_module = Some(Arc::clone(module));
+            self.cached_source_ptr = Some(NonNull::from(module.as_ref()));
             if let Some(buffer_data) = module.get_buffer_output(&self.source_port) {
                 self.cached_buffer = Some(Arc::clone(buffer_data));
             } else {
@@ -1436,6 +1455,7 @@ impl Connect for Buffer {
                     "[Buffer] module '{}' has no buffer output on port '{}'",
                     self.source_module, self.source_port
                 );
+                self.cached_source_ptr = None;
                 self.cached_buffer = None;
             }
         } else {
@@ -1443,7 +1463,7 @@ impl Connect for Buffer {
                 "[Buffer] source module '{}' not found in patch",
                 self.source_module
             );
-            self.cached_source_module = None;
+            self.cached_source_ptr = None;
             self.cached_buffer = None;
         }
     }
@@ -1819,12 +1839,17 @@ pub enum Signal {
     /// Cable connection to another module's output at a specific channel
     Cable {
         module: String,
-        module_ptr: std::sync::Weak<Box<dyn Sampleable>>,
+        resolved: Option<SampleablePtr>,
         port: String,
         /// Which channel of the output to read (0-indexed)
         channel: usize,
     },
 }
+
+// SAFETY: cable variants cache a `NonNull<dyn Sampleable>` during `connect()`. That cached pointer
+// is only dereferenced from the audio thread after connection finishes, but `Signal` values still
+// need to cross from main-thread deserialization into audio-thread-owned params.
+unsafe impl Send for Signal {}
 
 // Custom serde deserialization to allow a bare number as shorthand for volts.
 //
@@ -1874,7 +1899,7 @@ impl<'de> Deserialize<'de> for Signal {
                     channel,
                 } => Signal::Cable {
                     module,
-                    module_ptr: sync::Weak::new(),
+                    resolved: None,
                     port,
                     channel,
                 },
@@ -1972,7 +1997,7 @@ impl<E: DeserializeError> deserr::Deserr<E> for Signal {
                         })?;
                         Ok(Signal::Cable {
                             module,
-                            module_ptr: sync::Weak::new(),
+                            resolved: None,
                             port,
                             channel,
                         })
@@ -2045,12 +2070,12 @@ impl Signal {
         match self {
             Signal::Volts(v) => *v,
             Signal::Cable {
-                module_ptr,
+                resolved,
                 port,
                 channel,
                 ..
-            } => match module_ptr.upgrade() {
-                Some(module_ptr) => module_ptr
+            } => match resolved {
+                Some(ptr) => unsafe { ptr.as_ref() }
                     .get_poly_sample(port)
                     .map(|p| p.get_cycling(*channel))
                     .unwrap_or(0.0),
@@ -2098,11 +2123,13 @@ impl SignalExt for Option<Signal> {
 impl Connect for Signal {
     fn connect(&mut self, patch: &Patch) {
         if let Signal::Cable {
-            module, module_ptr, ..
+            module, resolved, ..
         } = self
-            && let Some(sampleable) = patch.sampleables.get(module)
         {
-            *module_ptr = Arc::downgrade(sampleable);
+            *resolved = patch
+                .sampleables
+                .get(module)
+                .map(|sampleable| NonNull::from(sampleable.as_ref()));
         }
     }
 }
@@ -2120,22 +2147,17 @@ impl PartialEq for Signal {
             (
                 Signal::Cable {
                     module: module_1,
-                    module_ptr: module_ptr_1,
                     port: port_1,
                     channel: channel_1,
+                    ..
                 },
                 Signal::Cable {
                     module: module_2,
-                    module_ptr: module_ptr_2,
                     port: port_2,
                     channel: channel_2,
+                    ..
                 },
-            ) => {
-                module_ptr_1.upgrade() == module_ptr_2.upgrade()
-                    && port_1 == port_2
-                    && module_1 == module_2
-                    && channel_1 == channel_2
-            }
+            ) => port_1 == port_2 && module_1 == module_2 && channel_1 == channel_2,
             _ => false,
         }
     }
@@ -2397,9 +2419,8 @@ pub struct ModuleIdRemap {
     pub to: String,
 }
 
-pub type SampleableConstructor = Box<
-    dyn Fn(&String, f32, crate::params::DeserializedParams) -> Result<Arc<Box<dyn Sampleable>>>,
->;
+pub type SampleableConstructor =
+    Box<dyn Fn(&String, f32, crate::params::DeserializedParams) -> Result<Box<dyn Sampleable>>>;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -2511,6 +2532,63 @@ pub enum Message {
 mod tests {
     use super::*;
     use serde_json::from_str;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct BufferSourceTestSampleable {
+        id: String,
+        update_count: Arc<AtomicUsize>,
+        buffer: Arc<BufferData>,
+    }
+
+    impl Sampleable for BufferSourceTestSampleable {
+        fn get_id(&self) -> &str {
+            &self.id
+        }
+
+        fn tick(&self) {}
+
+        fn update(&self) {
+            self.update_count.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn get_poly_sample(&self, _port: &str) -> Result<PolyOutput> {
+            Ok(PolyOutput::mono(0.0))
+        }
+
+        fn get_module_type(&self) -> &str {
+            "buffer_source_test"
+        }
+
+        fn connect(&self, _patch: &Patch) {}
+
+        fn get_buffer_output(&self, port: &str) -> Option<&Arc<BufferData>> {
+            (port == "buffer").then_some(&self.buffer)
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl MessageHandler for BufferSourceTestSampleable {}
+
+    fn patch_with_buffer_source(
+        id: &str,
+        samples: Vec<Vec<f32>>,
+    ) -> (Patch, Arc<AtomicUsize>, SampleablePtr, Arc<BufferData>) {
+        let update_count = Arc::new(AtomicUsize::new(0));
+        let buffer = Arc::new(BufferData::from_samples(samples));
+        let module: Box<dyn Sampleable> = Box::new(BufferSourceTestSampleable {
+            id: id.to_string(),
+            update_count: Arc::clone(&update_count),
+            buffer: Arc::clone(&buffer),
+        });
+        let source_ptr = NonNull::from(module.as_ref());
+        let mut patch = Patch::new();
+        patch.sampleables.insert(id.to_string(), module);
+        (patch, update_count, source_ptr, buffer)
+    }
 
     #[test]
     fn test_signal_deserialization_volts() {
@@ -2931,6 +3009,85 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn raw_pointer_buffer_connect_populates_cached_source_ptr_and_buffer() {
+        let (patch, update_count, source_ptr, source_buffer) =
+            patch_with_buffer_source("buf", vec![vec![1.0, 2.0, 3.0]]);
+        let mut buffer = Buffer::new("buf".to_string(), "buffer".to_string(), 1);
+
+        assert!(buffer.cached_source_ptr.is_none());
+        assert!(buffer.cached_buffer.is_none());
+
+        buffer.connect(&patch);
+
+        assert_eq!(buffer.cached_source_ptr, Some(source_ptr));
+        assert!(
+            buffer
+                .cached_buffer
+                .as_ref()
+                .is_some_and(|cached| Arc::ptr_eq(cached, &source_buffer))
+        );
+        assert_eq!(update_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn raw_pointer_buffer_ensure_source_updated_calls_update_through_cached_pointer() {
+        let (patch, update_count, _, _) = patch_with_buffer_source("buf", vec![vec![0.5]]);
+        let mut buffer = Buffer::new("buf".to_string(), "buffer".to_string(), 1);
+
+        buffer.connect(&patch);
+        buffer.ensure_source_updated();
+
+        assert_eq!(update_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn raw_pointer_buffer_clone_clears_runtime_caches() {
+        let (patch, _, _, _) = patch_with_buffer_source("buf", vec![vec![0.5]]);
+        let mut buffer = Buffer::new("buf".to_string(), "buffer".to_string(), 1);
+
+        buffer.connect(&patch);
+        let cloned = buffer.clone();
+
+        assert!(cloned.cached_source_ptr.is_none());
+        assert!(cloned.cached_buffer.is_none());
+        assert_eq!(cloned.frame_count(), 0);
+        assert_eq!(cloned.read(0, 0), 0.0);
+    }
+
+    #[test]
+    fn raw_pointer_buffer_connect_missing_source_clears_pointer_and_buffer() {
+        let (patch, update_count, _, _) = patch_with_buffer_source("buf", vec![vec![4.0, 5.0]]);
+        let empty_patch = Patch::new();
+        let mut buffer = Buffer::new("buf".to_string(), "buffer".to_string(), 1);
+
+        buffer.connect(&patch);
+        buffer.ensure_source_updated();
+        assert_eq!(update_count.load(Ordering::SeqCst), 1);
+
+        buffer.connect(&empty_patch);
+        buffer.ensure_source_updated();
+
+        assert!(buffer.cached_source_ptr.is_none());
+        assert!(buffer.cached_buffer.is_none());
+        assert_eq!(update_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn raw_pointer_buffer_connect_missing_port_clears_pointer_and_buffer() {
+        let (patch, update_count, _, _) = patch_with_buffer_source("buf", vec![vec![6.0, 7.0]]);
+        let mut buffer = Buffer::new("buf".to_string(), "missing".to_string(), 1);
+
+        buffer.connect(&patch);
+        buffer.ensure_source_updated();
+
+        assert!(buffer.cached_source_ptr.is_none());
+        assert!(buffer.cached_buffer.is_none());
+        assert_eq!(buffer.frame_count(), 0);
+        assert_eq!(buffer.read(0, 0), 0.0);
+        assert_eq!(update_count.load(Ordering::SeqCst), 0);
     }
 }
 

--- a/crates/modular_core/tests/dsp_fresh_tests.rs
+++ b/crates/modular_core/tests/dsp_fresh_tests.rs
@@ -9,7 +9,6 @@ use modular_core::params::DeserializedParams;
 use modular_core::patch::Patch;
 use modular_core::types::{ModuleState, PatchGraph, Sampleable};
 use serde_json::json;
-use std::sync::Arc;
 
 const SAMPLE_RATE: f32 = 48000.0;
 const DEFAULT_PORT: &str = "output";
@@ -17,7 +16,7 @@ const DEFAULT_PORT: &str = "output";
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /// Create a named module from the constructor registry with given params.
-fn make_module(module_type: &str, id: &str, params: serde_json::Value) -> Arc<Box<dyn Sampleable>> {
+fn make_module(module_type: &str, id: &str, params: serde_json::Value) -> Box<dyn Sampleable> {
     let constructors = get_constructors();
     let deserializers = get_params_deserializers();
     let deserializer = deserializers
@@ -92,7 +91,7 @@ fn sine_produces_bipolar_output() {
     let osc = make_module("$sine", "sine-1", json!({ "freq": 0.0 }));
     // 0 V/oct ≈ C4 (261.63 Hz)
 
-    let samples = collect_samples(&**osc, 1000);
+    let samples = collect_samples(osc.as_ref(), 1000);
     let (mn, mx) = min_max(&samples);
 
     // Sine output should swing ±5 V
@@ -105,7 +104,7 @@ fn sine_zero_frequency_is_dc() {
     let osc = make_module("$sine", "sine-1", json!({ "freq": -10.0 }));
     // Very low frequency → nearly DC over 100 samples
 
-    let samples = collect_samples(&**osc, 100);
+    let samples = collect_samples(osc.as_ref(), 100);
     let (mn, mx) = min_max(&samples);
 
     // At such a low frequency the output barely moves
@@ -120,7 +119,7 @@ fn sine_zero_frequency_is_dc() {
 fn sine_polyphonic() {
     let osc = make_module("$sine", "sine-1", json!({ "freq": [0.0, 1.0] }));
 
-    let _ch0 = collect_channel(&**osc, 0, 500);
+    let _ch0 = collect_channel(osc.as_ref(), 0, 500);
     // Reset for channel 1 read — we already stepped, so just read accumulated data
     // Actually the module already computed both channels per tick.
     // We need to re-check: collect_channel steps the module, so ch1 will be
@@ -132,7 +131,7 @@ fn sine_polyphonic() {
     let mut ch0_samples = Vec::new();
     let mut ch1_samples = Vec::new();
     for _ in 0..500 {
-        step(&**osc2);
+        step(osc2.as_ref());
         let poly = osc2.get_poly_sample(DEFAULT_PORT).unwrap();
         ch0_samples.push(poly.get(0));
         ch1_samples.push(poly.get(1));
@@ -163,7 +162,7 @@ fn sine_polyphonic() {
 fn saw_produces_bipolar_output() {
     let osc = make_module("$saw", "saw-1", json!({ "freq": 0.0 }));
 
-    let samples = collect_samples(&**osc, 1000);
+    let samples = collect_samples(osc.as_ref(), 1000);
     let (mn, mx) = min_max(&samples);
 
     assert!(mx > 4.0, "saw peak should be near +5V, got {mx}");
@@ -176,7 +175,7 @@ fn saw_produces_bipolar_output() {
 fn pulse_produces_bipolar_output() {
     let osc = make_module("$pulse", "pulse-1", json!({ "freq": 0.0 }));
 
-    let samples = collect_samples(&**osc, 1000);
+    let samples = collect_samples(osc.as_ref(), 1000);
     let (mn, mx) = min_max(&samples);
 
     assert!(mx > 4.0, "pulse peak should be near +5V, got {mx}");
@@ -191,10 +190,10 @@ fn pulse_width_affects_duty_cycle() {
         "pulse-narrow",
         json!({ "freq": 0.0, "width": 4.0 }),
     );
-    let samples_narrow = collect_samples(&**osc_narrow, 1000);
+    let samples_narrow = collect_samples(osc_narrow.as_ref(), 1000);
 
     let osc_wide = make_module("$pulse", "pulse-wide", json!({ "freq": 0.0, "width": 0.0 }));
-    let samples_wide = collect_samples(&**osc_wide, 1000);
+    let samples_wide = collect_samples(osc_wide.as_ref(), 1000);
 
     // Count positive samples
     let pos_narrow = samples_narrow.iter().filter(|&&s| s > 0.0).count();
@@ -213,7 +212,7 @@ fn pulse_width_affects_duty_cycle() {
 fn noise_produces_output() {
     let n = make_module("$noise", "noise-1", json!({ "color": "white" }));
 
-    let samples = collect_samples(&**n, 1000);
+    let samples = collect_samples(n.as_ref(), 1000);
     let (mn, mx) = min_max(&samples);
 
     assert!(mx > 0.5, "noise should have some positive values");
@@ -243,7 +242,7 @@ fn scale_and_shift_applies() {
 
     // Step enough times for param smoothing to converge
     for _ in 0..500 {
-        step(&**sas);
+        step(sas.as_ref());
     }
     let sample = sas.get_poly_sample(DEFAULT_PORT).unwrap().get(0);
 
@@ -654,6 +653,7 @@ fn step_rejects_empty_steps() {
     }
 }
 
+
 // ─── Curve ───────────────────────────────────────────────────────────────────
 
 #[test]
@@ -661,7 +661,7 @@ fn curve_linear_passthrough() {
     // exp=1 should be linear: output ≈ input
     let m = make_module("$curve", "curve-1", json!({ "input": 3.0, "exp": 1.0 }));
     for _ in 0..500 {
-        step(&**m);
+        step(m.as_ref());
     }
     let sample = m.get_poly_sample(DEFAULT_PORT).unwrap().get(0);
     assert!(
@@ -675,7 +675,7 @@ fn curve_unity_at_5v() {
     // At 5V input, output should be 5V regardless of exponent
     let m = make_module("$curve", "curve-2", json!({ "input": 5.0, "exp": 3.0 }));
     for _ in 0..500 {
-        step(&**m);
+        step(m.as_ref());
     }
     let sample = m.get_poly_sample(DEFAULT_PORT).unwrap().get(0);
     assert!(
@@ -689,7 +689,7 @@ fn curve_cubic_midpoint() {
     // exp=3, input=2.5: output = 5 * (2.5/5)^3 = 5 * 0.125 = 0.625
     let m = make_module("$curve", "curve-3", json!({ "input": 2.5, "exp": 3.0 }));
     for _ in 0..500 {
-        step(&**m);
+        step(m.as_ref());
     }
     let sample = m.get_poly_sample(DEFAULT_PORT).unwrap().get(0);
     assert!(
@@ -703,7 +703,7 @@ fn curve_preserves_sign() {
     // Negative input should produce negative output
     let m = make_module("$curve", "curve-4", json!({ "input": -2.5, "exp": 2.0 }));
     for _ in 0..500 {
-        step(&**m);
+        step(m.as_ref());
     }
     let sample = m.get_poly_sample(DEFAULT_PORT).unwrap().get(0);
     // sign(-2.5) * 5 * (2.5/5)^2 = -1 * 5 * 0.25 = -1.25
@@ -718,7 +718,7 @@ fn curve_zero_input() {
     // Zero input should produce zero output
     let m = make_module("$curve", "curve-5", json!({ "input": 0.0, "exp": 3.0 }));
     for _ in 0..500 {
-        step(&**m);
+        step(m.as_ref());
     }
     let sample = m.get_poly_sample(DEFAULT_PORT).unwrap().get(0);
     assert!(
@@ -732,7 +732,7 @@ fn curve_exp_zero_step_function() {
     // exp=0: any nonzero input → ±5V
     let m = make_module("$curve", "curve-6", json!({ "input": 1.0, "exp": 0.0 }));
     for _ in 0..500 {
-        step(&**m);
+        step(m.as_ref());
     }
     let sample = m.get_poly_sample(DEFAULT_PORT).unwrap().get(0);
     assert!(
@@ -945,7 +945,7 @@ fn transfer_state_from_preserves_wrapper_outputs_for_feedback_cycles() {
     // Transfer state from old modules to new modules
     for (id, new_module) in &new_patch.sampleables {
         if let Some(old_module) = old_patch.sampleables.get(id) {
-            new_module.transfer_state_from(old_module.as_ref().as_ref());
+            new_module.transfer_state_from(old_module.as_ref());
         }
     }
 
@@ -1061,7 +1061,7 @@ fn interval_seq_cv_holds_during_rest_after_state_transfer() {
 
     for (id, new_module) in &new_patch.sampleables {
         if let Some(old_module) = old_patch.sampleables.get(id) {
-            new_module.transfer_state_from(old_module.as_ref().as_ref());
+            new_module.transfer_state_from(old_module.as_ref());
         }
     }
 

--- a/crates/modular_core/tests/types_tests.rs
+++ b/crates/modular_core/tests/types_tests.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use napi::Result;
 use serde_json::json;
 
 use modular_core::patch::Patch;
 use modular_core::types::{
-    ClockMessages, Connect, Message, MessageHandler, MessageTag, MidiControlChange, MidiNoteOn,
-    Sampleable, Signal, SignalExt,
+    Buffer, BufferData, ClockMessages, Connect, Message, MessageHandler, MessageTag,
+    MidiControlChange, MidiNoteOn, Sampleable, Signal, SignalExt,
 };
 
 // The proc-macro expands to `crate::types::...`; provide that module in this integration test crate.
@@ -66,11 +67,12 @@ impl Sampleable for DummySampleable {
 
 impl MessageHandler for DummySampleable {}
 
+
 fn make_empty_patch() -> Patch {
     Patch::new()
 }
 
-fn make_patch_with_sampleable(sampleable: Arc<Box<dyn Sampleable>>) -> Patch {
+fn make_patch_with_sampleable(sampleable: Box<dyn Sampleable>) -> Patch {
     let mut patch = Patch::new();
     patch
         .sampleables
@@ -129,13 +131,13 @@ fn signal_deserialize_tagged_variants_still_work() {
         Signal::Cable {
             module,
             port,
-            module_ptr,
+            resolved,
             channel,
         } => {
             assert_eq!(module, "m1");
             assert_eq!(port, "out");
             assert_eq!(channel, 0);
-            assert!(module_ptr.upgrade().is_none());
+            assert!(resolved.is_none());
         }
         other => panic!("expected Signal::Cable, got {other:?}"),
     }
@@ -143,25 +145,92 @@ fn signal_deserialize_tagged_variants_still_work() {
 
 #[test]
 fn signal_cable_connect_and_read() {
-    let sampleable: Arc<Box<dyn Sampleable>> = Arc::new(Box::new(DummySampleable::new(
-        "m1",
-        "dummy",
-        [("out", 3.5)],
-    )));
-    let patch = make_patch_with_sampleable(Arc::clone(&sampleable));
+    let sampleable: Box<dyn Sampleable> =
+        Box::new(DummySampleable::new("m1", "dummy", [("out", 3.5)]));
+    let patch = make_patch_with_sampleable(sampleable);
 
     let mut s = Signal::Cable {
         module: "m1".to_string(),
-        module_ptr: Weak::new(),
+        resolved: None,
         port: "out".to_string(),
         channel: 0,
     };
 
-    // Before connect, cable reads 0.0 (module_ptr doesn't resolve).
+    // Before connect, cable reads 0.0 because the cache is unresolved.
     approx_eq(s.get_value(), 0.0, 1e-6);
 
     s.connect(&patch);
+
+    match &s {
+        Signal::Cable { resolved, .. } => assert!(resolved.is_some()),
+        other => panic!("expected Signal::Cable, got {other:?}"),
+    }
+
     approx_eq(s.get_value(), 3.5, 1e-6);
+}
+
+#[test]
+fn signal_cable_reconnect_to_missing_source_clears_resolved_and_reads_zero() {
+    let sampleable: Box<dyn Sampleable> =
+        Box::new(DummySampleable::new("m1", "dummy", [("out", 3.5)]));
+    let patch = make_patch_with_sampleable(sampleable);
+    let empty_patch = make_empty_patch();
+
+    let mut s = Signal::Cable {
+        module: "m1".to_string(),
+        resolved: None,
+        port: "out".to_string(),
+        channel: 0,
+    };
+
+    s.connect(&patch);
+    approx_eq(s.get_value(), 3.5, 1e-6);
+
+    s.connect(&empty_patch);
+
+    match &s {
+        Signal::Cable { resolved, .. } => assert!(resolved.is_none()),
+        other => panic!("expected Signal::Cable, got {other:?}"),
+    }
+
+    approx_eq(s.get_value(), 0.0, 1e-6);
+}
+
+#[test]
+fn signal_cable_reconnect_to_replacement_source_rebinds_resolved_and_reads_new_value() {
+    let first: Box<dyn Sampleable> = Box::new(DummySampleable::new("m1", "dummy", [("out", 3.5)]));
+    let second: Box<dyn Sampleable> =
+        Box::new(DummySampleable::new("m1", "dummy", [("out", 7.25)]));
+    let first_patch = make_patch_with_sampleable(first);
+    let second_patch = make_patch_with_sampleable(second);
+
+    let mut s = Signal::Cable {
+        module: "m1".to_string(),
+        resolved: None,
+        port: "out".to_string(),
+        channel: 0,
+    };
+
+    s.connect(&first_patch);
+    let first_resolved = match &s {
+        Signal::Cable { resolved, .. } => {
+            approx_eq(s.get_value(), 3.5, 1e-6);
+            *resolved
+        }
+        other => panic!("expected Signal::Cable, got {other:?}"),
+    };
+
+    s.connect(&second_patch);
+
+    match &s {
+        Signal::Cable { resolved, .. } => {
+            assert!(resolved.is_some());
+            assert_ne!(*resolved, first_resolved);
+        }
+        other => panic!("expected Signal::Cable, got {other:?}"),
+    }
+
+    approx_eq(s.get_value(), 7.25, 1e-6);
 }
 
 #[test]

--- a/crates/modular_derive/src/module_attr.rs
+++ b/crates/modular_derive/src/module_attr.rs
@@ -650,13 +650,13 @@ fn impl_module_macro_attr(
         /// 2. **Command Queue Isolation**: The main thread communicates via `PatchUpdate`
         ///    commands through an `rtrb` SPSC queue. It never directly accesses module state.
         ///
-        /// 3. **No Escaping References**: Module `Arc`s are stored in `Patch::sampleables` and
-        ///    are never cloned or sent to other threads after being added to the patch.
+        /// 3. **No Escaping References**: Owned modules are stored in `Patch::sampleables` and
+        ///    are never aliased across threads after being added to the patch.
         ///
         /// ## Invariants (DO NOT VIOLATE)
         ///
         /// - **NEVER** call Sampleable trait methods from the main thread
-        /// - **NEVER** clone module Arcs and send them across threads
+        /// - **NEVER** share module ownership across threads
         /// - **NEVER** access Patch::sampleables from outside AudioProcessor
         /// - **ALWAYS** use the command queue for main→audio communication
         ///
@@ -744,7 +744,7 @@ fn impl_module_macro_attr(
 
             fn transfer_state_from(&self, old: &dyn crate::types::Sampleable) {
                 if let Some(old_typed) = old.as_any().downcast_ref::<Self>() {
-                    // Guard against self-aliasing: if old and new are the same Arc,
+                    // Guard against self-aliasing: if old and new are the same box,
                     // creating two &mut refs to the same UnsafeCell contents is UB.
                     if std::ptr::eq(self as *const Self, old_typed as *const Self) {
                         return;
@@ -771,7 +771,7 @@ fn impl_module_macro_attr(
             }
         }
 
-        fn #constructor_name(id: &String, sample_rate: f32, deserialized: crate::params::DeserializedParams) -> napi::Result<std::sync::Arc<Box<dyn crate::types::Sampleable>>> {
+        fn #constructor_name(id: &String, sample_rate: f32, deserialized: crate::params::DeserializedParams) -> napi::Result<Box<dyn crate::types::Sampleable>> {
             let concrete_params = deserialized.params.into_any()
                 .downcast::<#params_struct_name>()
                 .map_err(|_| napi::Error::from_reason(
@@ -796,7 +796,7 @@ fn impl_module_macro_attr(
             };
 
             #has_init_call
-            Ok(std::sync::Arc::new(Box::new(sampleable)))
+            Ok(Box::new(sampleable))
         }
 
         impl #impl_generics crate::types::Module for #name #ty_generics #where_clause {

--- a/docs/superpowers/plans/2026-04-23-send-only-sampleable-runtime.md
+++ b/docs/superpowers/plans/2026-04-23-send-only-sampleable-runtime.md
@@ -1,0 +1,1442 @@
+# Send-Only Sampleable Runtime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace fake shared module ownership with a send-only runtime model that keeps true shared assets on `Arc`, moves module-graph connection caches to raw pointers, and precomputes more runtime metadata before audio-thread apply.
+
+**Architecture:** Land this in small, verifiable slices. First replace weak-ref connection caches (`Signal`, `Buffer`, seq caches) and listener weak refs with raw pointers or ids while the graph still uses `Arc`. Then convert the owned module graph, command payloads, and proc-macro constructors from `Arc<Box<dyn Sampleable>>` to `Box<dyn Sampleable>`, drop `Sync` from `Sampleable`, and finish by precomputing more runtime metadata so audio-thread apply stops rebuilding ownership-derived state.
+
+**Tech Stack:** Rust 2024, `napi`, existing proc-macro code in `modular_derive`, `parking_lot`, `rtrb`, existing Rust unit tests in `modular_core` and `modular`.
+
+---
+
+## File Map
+
+- `crates/modular_core/src/types.rs`
+  - Owns `Sampleable` trait, `SampleableMap`, `SampleableConstructor`, `Signal`, `Buffer`, and core trait tests.
+- `crates/modular_core/src/patch.rs`
+  - Owns patch-level module storage and message listener index.
+- `crates/modular_core/src/dsp/seq/seq_value.rs`
+  - Owns `SeqSourceConnections` and cached source resolution for pattern values.
+- `crates/modular_core/src/dsp/seq/seq.rs`
+  - Uses `SeqSourceConnections` during playback.
+- `crates/modular_core/src/dsp/utilities/math.rs`
+  - Constructs `Signal::Cable` values while parsing math expressions.
+- `crates/modular_core/src/pattern_system/combinators.rs`
+  - Test-only `Signal::Cable` constructors that must follow new field shape.
+- `crates/modular_core/src/dsp/utilities/buffer.rs`
+  - Integration tests around `Buffer` and `$buffer` ownership behavior.
+- `crates/modular_core/src/dsp/samplers/sampler.rs`
+  - Test helper returns constructor output type.
+- `crates/modular_core/src/dsp/fx/plate.rs`
+  - Test helper returns constructor output type.
+- `crates/modular_core/src/dsp/fx/dattorro.rs`
+  - Test helper returns constructor output type.
+- `crates/modular_derive/src/module_attr.rs`
+  - Generated wrapper `Send`/`Sync` contract and constructor return type.
+- `crates/modular/src/commands.rs`
+  - Command queue payload types and garbage queue ownership.
+- `crates/modular/src/audio.rs`
+  - Audio-thread apply path, runtime metadata prep, and Rust tests.
+- `crates/modular/src/lib.rs`
+  - Main-thread single-module update path.
+- `crates/modular_core/Cargo.toml`
+  - Add `static_assertions` dev-dependency for compile-time send/not-sync assertions.
+
+---
+
+### Task 1: Replace `Signal` weak refs with raw-pointer caches
+
+**Files:**
+- Modify: `crates/modular_core/src/types.rs`
+- Modify: `crates/modular_core/src/dsp/utilities/math.rs`
+- Modify: `crates/modular_core/src/pattern_system/combinators.rs`
+- Test: `cargo test -p modular_core raw_pointer_signal_ -- --nocapture`
+
+- [ ] **Step 1: Write the failing `Signal` raw-pointer tests**
+
+In `crates/modular_core/src/types.rs`, inside the existing test module near the other `connect()` tests, add this helper and these tests exactly:
+
+```rust
+    use std::sync::Arc;
+
+    #[derive(Default)]
+    struct SignalProbeSampleable {
+        id: String,
+        output: f32,
+    }
+
+    impl Sampleable for SignalProbeSampleable {
+        fn get_id(&self) -> &str {
+            &self.id
+        }
+
+        fn tick(&self) {}
+
+        fn update(&self) {}
+
+        fn get_poly_sample(&self, _port: &str) -> napi::Result<crate::poly::PolyOutput> {
+            Ok(crate::poly::PolyOutput::mono(self.output))
+        }
+
+        fn get_module_type(&self) -> &str {
+            "$probe"
+        }
+
+        fn connect(&self, _patch: &Patch) {}
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl MessageHandler for SignalProbeSampleable {}
+
+    fn signal_probe_patch(output: f32) -> Patch {
+        let mut patch = Patch::new();
+        patch.sampleables.insert(
+            "osc".to_string(),
+            Arc::new(Box::new(SignalProbeSampleable {
+                id: "osc".to_string(),
+                output,
+            })),
+        );
+        patch
+    }
+
+    #[test]
+    fn raw_pointer_signal_connect_resolves_nonnull_source() {
+        let patch = signal_probe_patch(3.25);
+        let mut signal = Signal::Cable {
+            module: "osc".to_string(),
+            resolved: None,
+            port: "output".to_string(),
+            channel: 0,
+        };
+
+        signal.connect(&patch);
+
+        let Signal::Cable { resolved, .. } = &signal else {
+            panic!("expected cable signal");
+        };
+        assert!(resolved.is_some(), "connect() should cache a raw source pointer");
+        assert!((signal.get_value() - 3.25).abs() < 1e-6);
+    }
+
+    #[test]
+    fn raw_pointer_signal_connect_clears_missing_source() {
+        let patch = Patch::new();
+        let mut signal = Signal::Cable {
+            module: "missing".to_string(),
+            resolved: None,
+            port: "output".to_string(),
+            channel: 0,
+        };
+
+        signal.connect(&patch);
+
+        let Signal::Cable { resolved, .. } = &signal else {
+            panic!("expected cable signal");
+        };
+        assert!(resolved.is_none(), "missing source should clear cached pointer");
+        assert_eq!(signal.get_value(), 0.0);
+    }
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p modular_core raw_pointer_signal_ -- --nocapture
+```
+
+Expected: FAIL to compile with errors like `variant 'Signal::Cable' has no field named 'resolved'`.
+
+- [ ] **Step 3: Implement the raw-pointer `Signal` cache**
+
+In `crates/modular_core/src/types.rs`, make these exact local replacements:
+
+1. Add `NonNull` to the top-level imports near the other `std` imports:
+
+```rust
+use std::ptr::NonNull;
+```
+
+2. Add shared pointer alias next to the `SampleableMap` alias block:
+
+```rust
+pub type SampleablePtr = NonNull<dyn Sampleable>;
+```
+
+3. Replace the `Signal::Cable` field definition with:
+
+```rust
+    Cable {
+        module: String,
+        resolved: Option<SampleablePtr>,
+        port: String,
+        channel: usize,
+    },
+```
+
+4. In both serde construction sites, replace `module_ptr: sync::Weak::new()` with:
+
+```rust
+resolved: None,
+```
+
+5. Replace `Signal::get_value()` with this version:
+
+```rust
+    pub fn get_value(&self) -> f32 {
+        match self {
+            Signal::Volts(v) => *v,
+            Signal::Cable {
+                module,
+                resolved,
+                port,
+                channel,
+                ..
+            } => {
+                if let Some(sample) = get_materialized_block_sample(module, port, *channel) {
+                    return sample;
+                }
+
+                match resolved {
+                    Some(ptr) => unsafe {
+                        ptr.as_ref()
+                            .get_poly_sample(port)
+                            .map(|p| p.get_cycling(*channel))
+                            .unwrap_or(0.0)
+                    },
+                    None => 0.0,
+                }
+            }
+        }
+    }
+```
+
+6. Replace `impl Connect for Signal` with:
+
+```rust
+impl Connect for Signal {
+    fn connect(&mut self, patch: &Patch) {
+        if let Signal::Cable {
+            module, resolved, ..
+        } = self
+        {
+            *resolved = patch
+                .sampleables
+                .get(module)
+                .map(|sampleable| NonNull::from(sampleable.as_ref()));
+        }
+    }
+}
+```
+
+7. Replace `Signal` equality on the cached field with this match arm body:
+
+```rust
+                resolved_1 == resolved_2
+                    && port_1 == port_2
+                    && module_1 == module_2
+                    && channel_1 == channel_2
+```
+
+and rename the matched fields from `module_ptr_*` to `resolved_*` in the pattern.
+
+8. In `crates/modular_core/src/dsp/utilities/math.rs`, replace the `Signal::Cable` construction with:
+
+```rust
+            signals.push(Signal::Cable {
+                module,
+                resolved: None,
+                port,
+                channel,
+            });
+```
+
+9. In `crates/modular_core/src/pattern_system/combinators.rs`, replace both test constructors with:
+
+```rust
+        let sig1 = Signal::Cable {
+            module: "sine".into(),
+            resolved: None,
+            port: "output".into(),
+            channel: 0,
+        };
+
+        let sig2 = Signal::Cable {
+            module: "sine".into(),
+            resolved: None,
+            port: "output".into(),
+            channel: 0,
+        };
+```
+
+- [ ] **Step 4: Run the `Signal` tests again**
+
+Run:
+
+```bash
+cargo test -p modular_core raw_pointer_signal_ -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/modular_core/src/types.rs crates/modular_core/src/dsp/utilities/math.rs crates/modular_core/src/pattern_system/combinators.rs
+git commit -m "refactor(core): cache signal sources as raw ptrs"
+```
+
+---
+
+### Task 2: Convert `Buffer` and seq caches from shared refs to raw pointers
+
+**Files:**
+- Modify: `crates/modular_core/src/types.rs`
+- Modify: `crates/modular_core/src/dsp/seq/seq_value.rs`
+- Modify: `crates/modular_core/src/dsp/seq/seq.rs`
+- Test: `cargo test -p modular_core raw_pointer_ -- --nocapture`
+
+- [ ] **Step 1: Write the failing `Buffer` and seq tests**
+
+In `crates/modular_core/src/types.rs`, add these tests inside the existing test module after the `Signal` raw-pointer tests:
+
+```rust
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct BufferProbeSampleable {
+        id: String,
+        output: Arc<BufferData>,
+        updates: Arc<AtomicUsize>,
+    }
+
+    impl Sampleable for BufferProbeSampleable {
+        fn get_id(&self) -> &str {
+            &self.id
+        }
+
+        fn tick(&self) {}
+
+        fn update(&self) {
+            self.updates.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn get_poly_sample(&self, _port: &str) -> napi::Result<crate::poly::PolyOutput> {
+            Ok(crate::poly::PolyOutput::default())
+        }
+
+        fn get_module_type(&self) -> &str {
+            "$buffer"
+        }
+
+        fn connect(&self, _patch: &Patch) {}
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn get_buffer_output(&self, port: &str) -> Option<&Arc<BufferData>> {
+            match port {
+                "buffer" => Some(&self.output),
+                _ => None,
+            }
+        }
+    }
+
+    impl MessageHandler for BufferProbeSampleable {}
+
+    fn buffer_probe_patch(updates: Arc<AtomicUsize>) -> Patch {
+        let mut patch = Patch::new();
+        patch.sampleables.insert(
+            "buffer-src".to_string(),
+            Arc::new(Box::new(BufferProbeSampleable {
+                id: "buffer-src".to_string(),
+                output: Arc::new(BufferData::from_samples(vec![vec![1.0, 2.0, 3.0]])),
+                updates,
+            })),
+        );
+        patch
+    }
+
+    #[test]
+    fn raw_pointer_buffer_connect_populates_source_ptr_and_buffer_arc() {
+        let updates = Arc::new(AtomicUsize::new(0));
+        let patch = buffer_probe_patch(Arc::clone(&updates));
+        let mut buffer = Buffer::new("buffer-src".to_string(), "buffer".to_string(), 1);
+
+        buffer.connect(&patch);
+
+        assert!(buffer.cached_source_ptr.is_some());
+        assert!(buffer.cached_buffer.is_some());
+        buffer.ensure_source_updated();
+        assert_eq!(updates.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn raw_pointer_buffer_connect_clears_missing_source_ptr() {
+        let patch = Patch::new();
+        let mut buffer = Buffer::new("missing".to_string(), "buffer".to_string(), 1);
+
+        buffer.connect(&patch);
+
+        assert!(buffer.cached_source_ptr.is_none());
+        assert!(buffer.cached_buffer.is_none());
+        assert_eq!(buffer.read(0, 0), 0.0);
+    }
+```
+
+In `crates/modular_core/src/dsp/seq/seq_value.rs`, add this test in the existing test module:
+
+```rust
+    #[test]
+    fn raw_pointer_seq_pattern_connects_nonnull_source_ptrs() {
+        let sampleable: Arc<Box<dyn Sampleable>> = Arc::new(Box::new(DummySampleable::new(
+            "lfo",
+            [("output", 2.5)],
+        )));
+        let patch = make_patch_with_sampleable(sampleable);
+        let mut pattern = SeqPatternParam::parse("module(lfo:output:0)").unwrap();
+
+        pattern.connect(&patch);
+
+        let connected: std::ptr::NonNull<dyn Sampleable> = pattern
+            .connected_sampleable("lfo")
+            .expect("expected connected sampleable pointer");
+        unsafe {
+            assert_eq!(connected.as_ref().get_id(), "lfo");
+        }
+
+        let signal = match &pattern.cached_haps()[0][0].value {
+            SeqValue::Signal { signal, .. } => signal,
+            _ => panic!("expected cached signal value"),
+        };
+        assert!((pattern.resolve_signal_value(signal) - 2.5).abs() < 1e-6);
+    }
+```
+
+- [ ] **Step 2: Run the new raw-pointer tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p modular_core raw_pointer_ -- --nocapture
+```
+
+Expected: FAIL to compile with errors like `no field 'cached_source_ptr' on type 'Buffer'` and `mismatched types: expected NonNull<dyn Sampleable>`.
+
+- [ ] **Step 3: Implement raw-pointer `Buffer` and seq caches**
+
+In `crates/modular_core/src/types.rs`, make these exact local replacements:
+
+1. Replace the `Buffer` field block with:
+
+```rust
+pub struct Buffer {
+    source_module: String,
+    source_port: String,
+    cached_source_ptr: Option<SampleablePtr>,
+    cached_buffer: Option<Arc<BufferData>>,
+    channels: usize,
+}
+```
+
+2. Update `Buffer::new()` to initialize `cached_source_ptr: None`.
+
+3. Replace `ensure_source_updated()` with:
+
+```rust
+    pub fn ensure_source_updated(&self) {
+        if let Some(ptr) = self.cached_source_ptr {
+            unsafe {
+                ptr.as_ref().update();
+            }
+        }
+    }
+```
+
+4. Replace `impl Connect for Buffer` with:
+
+```rust
+impl Connect for Buffer {
+    fn connect(&mut self, patch: &Patch) {
+        if let Some(module) = patch.sampleables.get(&self.source_module) {
+            self.cached_source_ptr = Some(NonNull::from(module.as_ref()));
+            if let Some(buffer_data) = module.get_buffer_output(&self.source_port) {
+                self.cached_buffer = Some(Arc::clone(buffer_data));
+            } else {
+                eprintln!(
+                    "[Buffer] module '{}' has no buffer output on port '{}'",
+                    self.source_module, self.source_port
+                );
+                self.cached_buffer = None;
+            }
+        } else {
+            eprintln!(
+                "[Buffer] source module '{}' not found in patch",
+                self.source_module
+            );
+            self.cached_source_ptr = None;
+            self.cached_buffer = None;
+        }
+    }
+}
+```
+
+In `crates/modular_core/src/dsp/seq/seq_value.rs`, make these exact replacements:
+
+1. Change imports at the top to:
+
+```rust
+use std::{
+    cell::UnsafeCell,
+    ptr::NonNull,
+    sync::Arc,
+};
+```
+
+2. Replace `SeqValue::connect_sampleable_map()` with:
+
+```rust
+    fn connect_sampleable_map(&mut self, sampleables: &SampleableMap) {
+        if let SeqValue::Signal { signal, .. } = self {
+            if let Signal::Cable {
+                module, resolved, ..
+            } = signal
+            {
+                *resolved = sampleables
+                    .get(module)
+                    .map(|sampleable| NonNull::from(sampleable.as_ref()));
+            }
+        }
+    }
+```
+
+3. Replace `SeqSourceConnections` with:
+
+```rust
+#[derive(Debug, Default)]
+pub(crate) struct SeqSourceConnections {
+    connections: UnsafeCell<Vec<Option<crate::types::SampleablePtr>>>,
+}
+
+impl SeqSourceConnections {
+    fn new(size: usize) -> Self {
+        Self {
+            connections: UnsafeCell::new(vec![None; size]),
+        }
+    }
+
+    fn update(&self, source_module_ids: &[String], patch: &Patch) {
+        let connections = unsafe { &mut *self.connections.get() };
+
+        debug_assert_eq!(connections.len(), source_module_ids.len());
+
+        for (module_id, connection) in source_module_ids.iter().zip(connections.iter_mut()) {
+            *connection = patch
+                .sampleables
+                .get(module_id)
+                .map(|sampleable| NonNull::from(sampleable.as_ref()));
+        }
+    }
+
+    pub(crate) fn connected_sampleable(
+        &self,
+        source_module_ids: &[String],
+        module_id: &str,
+    ) -> Option<crate::types::SampleablePtr> {
+        let index = source_module_ids
+            .binary_search_by(|candidate| candidate.as_str().cmp(module_id))
+            .ok()?;
+
+        let connections = unsafe { &*self.connections.get() };
+        connections.get(index).copied().flatten()
+    }
+}
+```
+
+4. Replace the `#[cfg(test)] fn connected_sampleable` helper with:
+
+```rust
+    #[cfg(test)]
+    fn connected_sampleable(&self, module_id: &str) -> Option<crate::types::SampleablePtr> {
+        self.source_connections
+            .connected_sampleable(self.source_module_ids.as_ref(), module_id)
+    }
+```
+
+5. In `resolve_signal_value()`, replace the cable branch body with:
+
+```rust
+            Signal::Cable { module, port, channel, .. } => self
+                .connected_sampleable(module)
+                .map(|sampleable| unsafe {
+                    sampleable
+                        .as_ref()
+                        .get_poly_sample(port)
+                        .map(|output| output.get_cycling(*channel))
+                        .unwrap_or(0.0)
+                })
+                .unwrap_or(0.0),
+```
+
+In `crates/modular_core/src/dsp/seq/seq.rs`, replace the cable-resolution branch with:
+
+```rust
+            } => connection_state
+                .connected_sampleable(source_module_ids, module)
+                .map(|sampleable| unsafe {
+                    sampleable
+                        .as_ref()
+                        .get_poly_sample(port)
+                        .map(|output| output.get_cycling(*channel))
+                        .unwrap_or(0.0)
+                })
+                .unwrap_or(0.0),
+```
+
+- [ ] **Step 4: Run the raw-pointer regression tests again**
+
+Run:
+
+```bash
+cargo test -p modular_core raw_pointer_ -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/modular_core/src/types.rs crates/modular_core/src/dsp/seq/seq_value.rs crates/modular_core/src/dsp/seq/seq.rs
+git commit -m "refactor(core): use raw ptr caches for buffer and seq"
+```
+
+---
+
+### Task 3: Replace patch listener weak refs with listener ids
+
+**Files:**
+- Modify: `crates/modular_core/src/patch.rs`
+- Test: `cargo test -p modular_core message_listener_ -- --nocapture`
+
+- [ ] **Step 1: Write the failing listener-index tests**
+
+In `crates/modular_core/src/patch.rs`, update the test module with this new helper and these tests:
+
+```rust
+    use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+
+    struct CountingMessageSampleable {
+        id: String,
+        hits: Arc<AtomicUsize>,
+    }
+
+    impl Sampleable for CountingMessageSampleable {
+        fn get_id(&self) -> &str {
+            &self.id
+        }
+
+        fn tick(&self) {}
+
+        fn update(&self) {}
+
+        fn get_poly_sample(&self, _port: &str) -> Result<crate::poly::PolyOutput> {
+            Ok(crate::poly::PolyOutput::default())
+        }
+
+        fn get_module_type(&self) -> &str {
+            "dummy"
+        }
+
+        fn connect(&self, _patch: &Patch) {}
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    impl MessageHandler for CountingMessageSampleable {
+        fn handled_message_tags(&self) -> &'static [MessageTag] {
+            &[MessageTag::MidiNoteOn]
+        }
+
+        fn handle_message(&self, _message: &Message) -> Result<()> {
+            self.hits.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn message_listener_index_stores_ids_only() {
+        let mut patch = Patch::new();
+        patch.sampleables.insert(
+            "m1".to_string(),
+            Arc::new(Box::new(DummyMessageSampleable {
+                id: "m1".to_string(),
+            })),
+        );
+
+        patch.rebuild_message_listeners();
+
+        assert_eq!(
+            patch.message_listeners.get(&MessageTag::MidiNoteOn).cloned(),
+            Some(vec!["m1".to_string()]),
+        );
+    }
+
+    #[test]
+    fn message_listener_removed_module_is_not_dispatched() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let mut patch = Patch::new();
+        patch.sampleables.insert(
+            "m1".to_string(),
+            Arc::new(Box::new(CountingMessageSampleable {
+                id: "m1".to_string(),
+                hits: Arc::clone(&hits),
+            })),
+        );
+        patch.rebuild_message_listeners();
+
+        patch
+            .dispatch_message(&Message::MidiNoteOn(crate::types::MidiNoteOn {
+                device: None,
+                channel: 0,
+                note: 60,
+                velocity: 100,
+            }))
+            .unwrap();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        patch.sampleables.remove("m1");
+
+        patch
+            .dispatch_message(&Message::MidiNoteOn(crate::types::MidiNoteOn {
+                device: None,
+                channel: 0,
+                note: 61,
+                velocity: 100,
+            }))
+            .unwrap();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+```
+
+- [ ] **Step 2: Run the listener tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p modular_core message_listener_ -- --nocapture
+```
+
+Expected: FAIL to compile with a type mismatch because `message_listeners` still stores `MessageListenerRef` values instead of `Vec<String>`.
+
+- [ ] **Step 3: Implement the id-only listener index**
+
+In `crates/modular_core/src/patch.rs`, make these exact replacements:
+
+1. Remove `Weak` from the imports and replace the listener field with:
+
+```rust
+    message_listeners: HashMap<MessageTag, Vec<String>>,
+```
+
+2. Delete the `MessageListenerRef` struct entirely.
+
+3. Replace `rebuild_message_listeners()` with:
+
+```rust
+    pub fn rebuild_message_listeners(&mut self) {
+        self.message_listeners.clear();
+        for (id, sampleable) in &self.sampleables {
+            for tag in sampleable.handled_message_tags() {
+                self.message_listeners
+                    .entry(*tag)
+                    .or_default()
+                    .push(id.clone());
+            }
+        }
+    }
+```
+
+4. Replace `add_message_listeners_for_module()` with:
+
+```rust
+    pub fn add_message_listeners_for_module(&mut self, id: &str) {
+        let Some(sampleable) = self.sampleables.get(id) else {
+            return;
+        };
+
+        for tag in sampleable.handled_message_tags() {
+            self.message_listeners
+                .entry(*tag)
+                .or_default()
+                .push(id.to_string());
+        }
+    }
+```
+
+5. Keep `remove_message_listeners_for_module()` but change the retain closure to:
+
+```rust
+            listeners.retain(|id| id != module_id);
+```
+
+6. Delete `message_listeners_for()` entirely and replace `dispatch_message()` with:
+
+```rust
+    pub fn dispatch_message(&mut self, message: &Message) -> napi::Result<()> {
+        let listener_ids = self
+            .message_listeners
+            .get(&message.tag())
+            .cloned()
+            .unwrap_or_default();
+
+        for id in listener_ids {
+            if let Some(sampleable) = self.sampleables.get(&id) {
+                sampleable.handle_message(message)?;
+            }
+        }
+
+        Ok(())
+    }
+```
+
+7. Replace the old `message_listeners_never_return_removed_modules()` test with the two new tests above.
+
+- [ ] **Step 4: Run the listener tests again**
+
+Run:
+
+```bash
+cargo test -p modular_core message_listener_ -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/modular_core/src/patch.rs
+git commit -m "refactor(core): store message listener ids"
+```
+
+---
+
+### Task 4: Convert module ownership from `Arc<Box<dyn Sampleable>>` to `Box<dyn Sampleable>`
+
+**Files:**
+- Modify: `crates/modular_core/src/types.rs`
+- Modify: `crates/modular_core/src/patch.rs`
+- Modify: `crates/modular_derive/src/module_attr.rs`
+- Modify: `crates/modular/src/commands.rs`
+- Modify: `crates/modular/src/audio.rs`
+- Modify: `crates/modular/src/lib.rs`
+- Modify: `crates/modular_core/src/dsp/seq/seq_value.rs`
+- Modify: `crates/modular_core/src/dsp/utilities/buffer.rs`
+- Modify: `crates/modular_core/src/dsp/samplers/sampler.rs`
+- Modify: `crates/modular_core/src/dsp/fx/plate.rs`
+- Modify: `crates/modular_core/src/dsp/fx/dattorro.rs`
+- Test: `cargo test -p modular_core`
+- Test: `cargo test -p modular`
+
+- [ ] **Step 1: Write the failing owned-box test coverage**
+
+In `crates/modular/src/audio.rs`, update the existing test helpers and add this test:
+
+```rust
+  impl MockModule {
+    fn new(label: &str) -> Box<dyn modular_core::types::Sampleable> {
+      Box::new(Self {
+        label: label.to_string(),
+        current_id: label.to_string(),
+      })
+    }
+  }
+
+  impl RecordingModule {
+    fn new(id: &str, state: Arc<RecordingModuleState>) -> Box<dyn modular_core::types::Sampleable> {
+      Box::new(Self {
+        id: id.to_string(),
+        state,
+      })
+    }
+  }
+
+  #[test]
+  fn owned_box_patch_update_replaces_module_without_clone() {
+    let mut processor = create_test_processor();
+    let first_state = Arc::new(RecordingModuleState::default());
+    let second_state = Arc::new(RecordingModuleState::default());
+
+    processor
+      .runtime
+      .patch
+      .sampleables
+      .insert("probe".to_string(), RecordingModule::new("probe", Arc::clone(&first_state)));
+
+    let mut update = PatchUpdate::new(TEST_SAMPLE_RATE);
+    update.update_id = 400;
+    update.desired_ids.insert("probe".to_string());
+    update
+      .inserts
+      .push(("probe".to_string(), RecordingModule::new("probe", Arc::clone(&second_state))));
+
+    processor.apply_patch_update(update);
+
+    assert!(processor.runtime.patch.sampleables.contains_key("probe"));
+  }
+```
+
+Also update these helper signatures so they intentionally stop compiling until ownership changes land:
+
+In `crates/modular_core/src/dsp/utilities/buffer.rs`:
+
+```rust
+    fn make_module(
+        module_type: &str,
+        id: &str,
+        params: serde_json::Value,
+    ) -> Box<dyn Sampleable> {
+```
+
+In `crates/modular_core/src/dsp/samplers/sampler.rs`:
+
+```rust
+    fn make_module(
+        module_type: &str,
+        id: &str,
+        params: serde_json::Value,
+    ) -> Box<dyn Sampleable> {
+```
+
+In `crates/modular_core/src/dsp/fx/plate.rs`:
+
+```rust
+    fn make_plate(params: serde_json::Value) -> Box<dyn Sampleable> {
+```
+
+In `crates/modular_core/src/dsp/fx/dattorro.rs`:
+
+```rust
+    fn make_dattorro(params: serde_json::Value) -> Box<dyn Sampleable> {
+```
+
+- [ ] **Step 2: Run the Rust tests to verify ownership still fails to compile**
+
+Run:
+
+```bash
+cargo test -p modular_core
+```
+
+Expected: FAIL to compile with mismatches between `Arc<Box<dyn Sampleable>>` and `Box<dyn Sampleable>`.
+
+- [ ] **Step 3: Convert core ownership aliases and proc-macro constructors**
+
+Make these exact replacements:
+
+In `crates/modular_core/src/types.rs`:
+
+```rust
+pub type SampleableMap = HashMap<String, Box<dyn Sampleable>>;
+
+pub type SampleableConstructor =
+    Box<dyn Fn(&String, f32, crate::params::DeserializedParams) -> Result<Box<dyn Sampleable>>>;
+```
+
+In `crates/modular_core/src/patch.rs`, replace the hidden audio input inserts with:
+
+```rust
+        sampleables.insert(
+            audio_in_sampleable.get_id().to_string(),
+            Box::new(audio_in_sampleable),
+        );
+```
+
+and:
+
+```rust
+        self.sampleables
+            .insert(id, Box::new(audio_in_sampleable));
+```
+
+In `Patch::from_graph()`, keep the same logic but the constructor return type now drops directly into the map without `Arc` wrapping.
+
+In `crates/modular_derive/src/module_attr.rs`, make these exact replacements:
+
+1. Update wrapper safety docs to replace `Arc`s with owned boxes:
+
+```rust
+        /// 3. **No Escaping References**: Module boxes are stored in `Patch::sampleables`
+        ///    and are never shared back to the main thread after being added to the patch.
+```
+
+2. Replace the invariants block lines:
+
+```rust
+        /// - **NEVER** move live module boxes back to the main thread after publication
+```
+
+3. Change the constructor signature to:
+
+```rust
+        fn #constructor_name(id: &String, sample_rate: f32, deserialized: crate::params::DeserializedParams) -> napi::Result<Box<dyn crate::types::Sampleable>> {
+```
+
+4. Replace the constructor return statement with:
+
+```rust
+            Ok(Box::new(sampleable))
+```
+
+- [ ] **Step 4: Convert command queue payloads and audio-thread apply to owned boxes**
+
+In `crates/modular/src/commands.rs`, replace the module ownership types with:
+
+```rust
+  pub inserts: Vec<(String, Box<dyn modular_core::types::Sampleable>)>,
+```
+
+```rust
+  SingleModuleUpdate {
+    module_id: String,
+    module: Box<dyn Sampleable>,
+  },
+```
+
+```rust
+  Module(Box<dyn Sampleable>),
+```
+
+In `crates/modular/src/audio.rs`, make these exact local replacements:
+
+1. In `GraphCommand::SingleModuleUpdate`, replace the insert/listener block with:
+
+```rust
+          self
+            .runtime
+            .patch
+            .sampleables
+            .insert(module_id.clone(), new_module);
+          self.runtime.patch.add_message_listeners_for_module(&module_id);
+```
+
+2. In `apply_patch_update()`, replace old-state transfer lines with:
+
+```rust
+      if let Some(old_module) = self.runtime.patch.sampleables.remove(&id) {
+        new_module.transfer_state_from(old_module.as_ref());
+        self.runtime.patch.remove_message_listeners_for_module(&id);
+        if self.garbage_tx.push(GarbageItem::Module(old_module)).is_err() {
+        }
+      }
+```
+
+3. Replace incremental listener re-registration with:
+
+```rust
+    for id in newly_inserted_ids.iter().chain(remapped_ids.iter()) {
+      self.runtime.patch.add_message_listeners_for_module(id);
+    }
+```
+
+4. Update `MockModule::new()` and `RecordingModule::new()` to the owned-box versions from Step 1.
+
+In `crates/modular/src/lib.rs`, keep the same `set_module_param()` flow, but `constructor(...)` now returns `Box<dyn Sampleable>` and `GraphCommand::SingleModuleUpdate` takes that box by value.
+
+- [ ] **Step 5: Update helper functions and tests to the new ownership type**
+
+Apply these exact helper replacements:
+
+In `crates/modular_core/src/dsp/utilities/buffer.rs`, replace the owner insert and helper return type with:
+
+```rust
+        patch
+            .sampleables
+            .insert(MOCK_BUFFER_MODULE_ID.to_string(), Box::new(owner));
+```
+
+and keep all `step(&*module);` calls on boxed sampleables.
+
+In `crates/modular_core/src/dsp/seq/seq_value.rs`, replace helper/test ownership with:
+
+```rust
+    fn make_patch_with_sampleable(sampleable: Box<dyn Sampleable>) -> Patch {
+        let mut patch = Patch::new();
+        patch
+            .sampleables
+            .insert(sampleable.get_id().to_owned(), sampleable);
+        patch
+    }
+```
+
+and replace test sampleable creation with:
+
+```rust
+        let sampleable: Box<dyn Sampleable> = Box::new(DummySampleable::new(
+            "lfo",
+            [("output", 2.5)],
+        ));
+```
+
+In `crates/modular_core/src/dsp/samplers/sampler.rs`, `crates/modular_core/src/dsp/fx/plate.rs`, and `crates/modular_core/src/dsp/fx/dattorro.rs`, keep the constructor body unchanged except the return type is now `Box<dyn Sampleable>`.
+
+In `crates/modular_core/src/patch.rs`, replace the test insert with:
+
+```rust
+        patch.sampleables.insert(
+            "m1".to_string(),
+            Box::new(DummyMessageSampleable {
+                id: "m1".to_string(),
+            }),
+        );
+```
+
+- [ ] **Step 6: Run `modular_core` tests**
+
+Run:
+
+```bash
+cargo test -p modular_core
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run `modular` tests**
+
+Run:
+
+```bash
+cargo test -p modular
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/modular_core/src/types.rs crates/modular_core/src/patch.rs crates/modular_derive/src/module_attr.rs crates/modular/src/commands.rs crates/modular/src/audio.rs crates/modular/src/lib.rs crates/modular_core/src/dsp/seq/seq_value.rs crates/modular_core/src/dsp/utilities/buffer.rs crates/modular_core/src/dsp/samplers/sampler.rs crates/modular_core/src/dsp/fx/plate.rs crates/modular_core/src/dsp/fx/dattorro.rs
+git commit -m "refactor(runtime): own sampleables with boxes"
+```
+
+---
+
+### Task 5: Drop `Sync` from `Sampleable` and assert send-only trait objects
+
+**Files:**
+- Modify: `crates/modular_core/Cargo.toml`
+- Modify: `crates/modular_core/src/types.rs`
+- Modify: `crates/modular_derive/src/module_attr.rs`
+- Test: `cargo test -p modular_core sampleable_trait_objects_are_send_but_not_sync -- --exact`
+
+- [ ] **Step 1: Write the failing send-only assertion test**
+
+In `crates/modular_core/Cargo.toml`, add this dev-dependency block at the end of the file:
+
+```toml
+[dev-dependencies]
+static_assertions = "1.1"
+```
+
+In `crates/modular_core/src/types.rs`, add this test inside the existing test module:
+
+```rust
+    #[test]
+    fn sampleable_trait_objects_are_send_but_not_sync() {
+        use static_assertions::{assert_impl_all, assert_not_impl_any};
+
+        assert_impl_all!(Box<dyn Sampleable>: Send);
+        assert_not_impl_any!(Box<dyn Sampleable>: Sync);
+    }
+```
+
+- [ ] **Step 2: Run the assertion test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p modular_core sampleable_trait_objects_are_send_but_not_sync -- --exact
+```
+
+Expected: FAIL because `Sampleable` still inherits `Sync`.
+
+- [ ] **Step 3: Remove `Sync` from the trait and generated wrapper**
+
+In `crates/modular_core/src/types.rs`, replace the trait line with:
+
+```rust
+pub trait Sampleable: MessageHandler + Send {
+```
+
+In `crates/modular_derive/src/module_attr.rs`, delete this line entirely:
+
+```rust
+        unsafe impl Sync for #struct_name {}
+```
+
+Also update the wrapper safety comment block so it no longer claims shared `Sync` access is part of the design. Replace the opening safety paragraph with:
+
+```rust
+        /// This struct uses `UnsafeCell` instead of `Mutex`/`RwLock` for interior mutability.
+        /// This is safe because module wrappers are transferred across threads but executed
+        /// from one runtime owner at a time.
+```
+
+- [ ] **Step 4: Run the assertion test again**
+
+Run:
+
+```bash
+cargo test -p modular_core sampleable_trait_objects_are_send_but_not_sync -- --exact
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/modular_core/Cargo.toml crates/modular_core/src/types.rs crates/modular_derive/src/module_attr.rs
+git commit -m "refactor(core): make sampleables send-only"
+```
+
+---
+
+### Task 6: Precompute runtime metadata before audio-thread apply
+
+**Files:**
+- Modify: `crates/modular/src/audio.rs`
+- Test: `cargo test -p modular pending_runtime_metadata_ -- --nocapture`
+- Test: `cargo test -p modular apply_patch_update_ -- --nocapture`
+- Test: `cargo test -p modular`
+
+- [ ] **Step 1: Write the failing pending-metadata test**
+
+In `crates/modular/src/audio.rs`, add this test near the other pending metadata tests:
+
+```rust
+  #[test]
+  fn pending_runtime_metadata_precomputes_runtime_fields() {
+    let (state, _cmd_consumer, _err_producer, _garbage_producer) = create_test_state(TEST_BLOCK_SIZE);
+    let patch = feed_forward_allowlist_patch();
+
+    state
+      .apply_patch(
+        patch,
+        TEST_SAMPLE_RATE,
+        QueuedTrigger::Immediate,
+        91,
+        HashMap::new(),
+        None,
+      )
+      .expect("apply_patch should succeed");
+
+    let metadata = state.pending_region_orders.lock();
+    let entry = metadata.get(&91).expect("missing pending runtime metadata");
+
+    assert_eq!(
+      entry.module_order,
+      vec![
+        "clamp".to_string(),
+        "curve".to_string(),
+        "scale".to_string(),
+        "wrap".to_string(),
+      ]
+    );
+    assert!(entry.block_region_module_ids.contains("scale"));
+    assert_eq!(
+      entry
+        .region_output_buffers
+        .outputs
+        .get("scale")
+        .expect("missing scale output buffers")[0]
+        .len(),
+      TEST_BLOCK_SIZE
+    );
+  }
+```
+
+- [ ] **Step 2: Run the metadata test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p modular pending_runtime_metadata_ -- --nocapture
+```
+
+Expected: FAIL to compile because `PendingSchedulerRuntimeMetadata` does not yet have `module_order`, `block_region_module_ids`, or `region_output_buffers`.
+
+- [ ] **Step 3: Add precomputed runtime fields and helper allocation function**
+
+In `crates/modular/src/audio.rs`, replace `PendingSchedulerRuntimeMetadata` with:
+
+```rust
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PendingSchedulerRuntimeMetadata {
+  scheduler_debug_snapshot: SchedulerDebugSnapshot,
+  scheduler_analysis: Option<SchedulerAnalysis>,
+  region_order: Vec<Vec<String>>,
+  region_execution_plan: Vec<SchedulerRegionExecutionPlan>,
+  callback_block_size: usize,
+  block_module_specs: HashMap<String, BlockModuleSpec>,
+  block_region_module_ids: HashSet<String>,
+  module_order: Vec<String>,
+  region_output_buffers: RegionOutputBuffer,
+}
+```
+
+Add this new helper right above `allocate_region_output_buffers()`:
+
+```rust
+fn allocate_region_output_buffers_from_channels(
+  output_channels: &HashMap<String, usize>,
+  frames: usize,
+) -> RegionOutputBuffer {
+  let mut outputs = HashMap::new();
+
+  for (module_id, channels) in output_channels {
+    if is_reserved_module_id(module_id) {
+      continue;
+    }
+
+    outputs.insert(module_id.clone(), vec![vec![0.0; frames]; (*channels).max(1)]);
+  }
+
+  RegionOutputBuffer { outputs }
+}
+```
+
+- [ ] **Step 4: Populate metadata on main thread and consume it on audio thread**
+
+In `AudioState::apply_patch()` inside `crates/modular/src/audio.rs`, make these exact additions:
+
+1. Right before the module-construction loop, add:
+
+```rust
+    let mut output_channels: HashMap<String, usize> = HashMap::new();
+```
+
+2. Inside the module-construction loop, right after `let deserialized = ...?;`, add:
+
+```rust
+      output_channels.insert(id.clone(), deserialized.channel_count.max(1));
+```
+
+3. Right after `let block_module_specs = compile_block_module_specs(&desired_modules);`, add:
+
+```rust
+    let mut module_order: Vec<String> = desired_modules.keys().cloned().collect();
+    module_order.sort();
+    let block_region_module_ids: HashSet<String> = scheduler_analysis
+      .regions
+      .iter()
+      .filter(|region| region.mode == SchedulerRegionMode::Block)
+      .flat_map(|region| region.module_ids.iter().cloned())
+      .collect();
+    let region_output_buffers =
+      allocate_region_output_buffers_from_channels(&output_channels, callback_block_size.max(1));
+```
+
+4. When building `PendingSchedulerRuntimeMetadata`, add these fields:
+
+```rust
+        block_region_module_ids,
+        module_order,
+        region_output_buffers,
+```
+
+In `apply_patch_update()`, replace the runtime rebuild assignments with:
+
+```rust
+    self.runtime.block_region_module_ids = pending_runtime_metadata.block_region_module_ids;
+    self.runtime.host_block_size = pending_runtime_metadata.callback_block_size.max(1);
+    self.runtime.block_module_specs = pending_runtime_metadata.block_module_specs;
+    self.runtime.module_order = pending_runtime_metadata.module_order;
+    self.runtime.region_output_buffers = pending_runtime_metadata.region_output_buffers;
+```
+
+Delete the old recompute blocks that rebuild `block_region_module_ids`, `module_order`, and `region_output_buffers` from live patch state during apply. Leave audio-thread `connect()` in place after state transfer.
+
+Update the local test helpers `pending_scheduler_metadata(...)` and `pending_scheduler_metadata_for_patch(...)` near the bottom of `audio.rs` so they initialize the new fields with deterministic values.
+
+- [ ] **Step 5: Run targeted metadata/apply tests**
+
+Run:
+
+```bash
+cargo test -p modular pending_runtime_metadata_ -- --nocapture
+cargo test -p modular apply_patch_update_ -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full `modular` test suite**
+
+Run:
+
+```bash
+cargo test -p modular
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/modular/src/audio.rs
+git commit -m "refactor(audio): precompute runtime metadata"
+```
+
+---
+
+### Task 7: Final verification
+
+**Files:**
+- Modify: none
+- Test: `cargo test -p modular_core`
+- Test: `cargo test -p modular`
+- Test: `yarn typecheck`
+
+- [ ] **Step 1: Run full core verification**
+
+Run:
+
+```bash
+cargo test -p modular_core
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full audio/runtime verification**
+
+Run:
+
+```bash
+cargo test -p modular
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repo typecheck**
+
+Run:
+
+```bash
+yarn typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit verification-only follow-ups if needed**
+
+If verification changed code, commit it with the narrowest matching message. If verification is already clean, skip this step.
+
+```bash
+git add <files-fixed-during-verification>
+git commit -m "fix: address send-only runtime regressions"
+```

--- a/docs/superpowers/specs/2026-04-23-send-only-sampleable-runtime-design.md
+++ b/docs/superpowers/specs/2026-04-23-send-only-sampleable-runtime-design.md
@@ -1,0 +1,295 @@
+# Send-Only Sampleable Runtime Design
+
+## Overview
+
+Replace fake shared ownership in module graph with single-owner runtime model. `Sampleable` becomes `Send` but not `Sync`, patch/runtime own modules directly as `Box<dyn Sampleable>`, and hot connection paths cache non-owning raw pointers resolved during `connect()`. True cross-thread shared data such as `Arc<WavData>` remain shared. This aligns type model with actual runtime behavior, removes unnecessary `Arc` and `Weak` traffic from audio graph, and clears path for moving more runtime compilation work off audio thread.
+
+## Goals
+
+- Make `Sampleable` ownership model honest: transferable across threads, not concurrently shared
+- Remove `Sync` requirement from `Sampleable` trait and generated wrappers
+- Replace module-graph `Arc` and `Weak` usage that exists only to satisfy fake shared ownership
+- Preserve current patch update semantics, including `transfer_state_from()` continuity
+- Keep hot signal and buffer reads cheap after migration
+- Support further removal of audio-thread allocations by compiling more runtime state on main thread
+
+## Non-Goals
+
+- Full arena / slot-based runtime rewrite in this pass
+- Removing `Arc` from truly shared assets or UI-facing shared state
+- Reworking every scheduler structure at once
+- Replacing all string module ids with numeric handles everywhere
+- Changing DSP semantics or connection behavior visible to patch authors
+
+## Background
+
+Today module graph uses shared-ownership types even though module execution follows a single-owner phase model.
+
+- `Sampleable` currently requires `Send + Sync` in `crates/modular_core/src/types.rs`
+- `Patch.sampleables` stores `Arc<Box<dyn Sampleable>>` in `crates/modular_core/src/patch.rs`
+- `Signal::Cable` stores `Weak<Box<dyn Sampleable>>` in `crates/modular_core/src/types.rs`
+- `Buffer` caches a strong module `Arc` only to call `update()` on demand in `crates/modular_core/src/types.rs`
+- `SeqSourceConnections` stores `Weak<Box<dyn Sampleable>>` in `crates/modular_core/src/dsp/seq/seq_value.rs`
+- message listeners also use weak module references in `crates/modular_core/src/patch.rs`
+
+This model implies concurrent shared access that engine does not actually support. Real rule is stronger and simpler:
+
+- main thread may create unpublished modules and runtimes
+- ownership may transfer to audio thread
+- once published to audio thread, main thread must not touch that runtime or its modules
+- module graph mutation and audio processing happen in disjoint phases
+
+Type model should express that rule directly.
+
+## Approach
+
+Adopt hybrid ownership model:
+
+- use owned `Box<dyn Sampleable>` for module graph and queued module transfers
+- use raw non-owning cached pointers for hot intra-runtime module connections
+- keep `Arc` only for data that is truly shared across threads or subsystems
+
+This keeps hot path close to current API shape while removing fake shared ownership from module graph.
+
+## Why This Approach
+
+- Smallest honest change from current architecture
+- Avoids per-sample hash lookup for `Signal` and `Buffer`
+- Avoids much larger arena-handle refactor right now
+- Preserves current `connect()` model, where connection caches are rebuilt after graph changes
+- Supports later main-thread compilation of runtime metadata without requiring full graph rewrite first
+
+## Architecture
+
+### Trait and Wrapper Semantics
+
+`Sampleable` changes from:
+
+```rust
+pub trait Sampleable: MessageHandler + Send + Sync
+```
+
+to:
+
+```rust
+pub trait Sampleable: MessageHandler + Send
+```
+
+Generated wrappers in `crates/modular_derive/src/module_attr.rs` must stop claiming `Sync`. Any remaining `unsafe impl Send` blocks must be reviewed and kept only where required by interior mutability patterns that still satisfy single-thread execution contract.
+
+### Runtime Ownership
+
+Patch and runtime own modules directly.
+
+Conceptually:
+
+```rust
+type SampleableMap = HashMap<String, Box<dyn Sampleable>>;
+
+struct Patch {
+    sampleables: SampleableMap,
+    wav_data: HashMap<String, Arc<WavData>>,
+    message_listeners: HashMap<MessageTag, Vec<String>>,
+}
+```
+
+Queued updates and garbage handoff also move owned boxes rather than shared `Arc`s.
+
+Conceptually:
+
+```rust
+pub struct PatchUpdate {
+    pub inserts: Vec<(String, Box<dyn Sampleable>)>,
+    // ...
+}
+
+pub enum GraphCommand {
+    SingleModuleUpdate { module_id: String, module: Box<dyn Sampleable> },
+    // ...
+}
+
+pub enum GarbageItem {
+    Module(Box<dyn Sampleable>),
+    // ...
+}
+```
+
+### Cached Connection Model
+
+#### Signal
+
+`Signal::Cable` keeps module id for identity / serialization and caches raw pointer for hot reads.
+
+Conceptually:
+
+```rust
+pub enum Signal {
+    Volts(f32),
+    Cable {
+        module: String,
+        resolved: Option<NonNull<dyn Sampleable>>,
+        port: String,
+        channel: usize,
+    },
+}
+```
+
+`connect()` resolves `module` through `patch.sampleables` and stores `NonNull::from(module.as_ref())`. `get_value()` dereferences cached pointer only on audio thread during processing phase.
+
+#### Buffer
+
+`Buffer` no longer keeps strong module ownership. It caches:
+
+- source module id and port name for reconnect
+- raw pointer to source module for `ensure_source_updated()`
+- shared `Arc<BufferData>` only for actual buffer payload
+
+This keeps demand-driven buffer refresh cheap without forcing shared module ownership.
+
+#### Seq Source Connections
+
+`SeqSourceConnections` replaces `Vec<Weak<Box<dyn Sampleable>>>` with `Vec<Option<NonNull<dyn Sampleable>>>`. `connect()` refreshes cached pointers in parallel with sorted source module ids. Query path reads cached pointers directly.
+
+### Message Listeners
+
+Message listeners no longer need weak refs. Store module ids only.
+
+Conceptually:
+
+```rust
+struct MessageListenerRef {
+    id: String,
+}
+```
+
+Dispatch path looks up listener id in `patch.sampleables` at message-send time. This removes another fake shared-ownership seam and naturally prunes removed modules.
+
+### True Shared Data
+
+Keep `Arc` where ownership is genuinely shared across threads or long-lived subsystems.
+
+Examples:
+
+- `Arc<WavData>` shared between main-thread cache and audio runtime
+- UI meters / shared state guarded by atomics or mutexes
+- scope collection / recording handles / transport meter
+- any immutable asset cache intentionally retained by multiple owners
+
+Rule: keep `Arc` only when two live owners may legitimately coexist. Do not use it as connection glue inside audio module graph.
+
+## Raw Pointer Safety Contract
+
+Raw pointer caching is allowed only under existing phase-separation rule.
+
+Required invariants:
+
+1. Production runtime dereferences cached module pointers only on audio thread. Test-only single-thread runtimes such as `Patch::from_graph(...)` may also dereference them under the same non-overlap phase rule.
+2. Graph mutation and `connect()` happen in command-processing phase, never during `process()` / `update()` traversal.
+3. Any module insert, replace, remap, or removal is followed by reconnect before next processing pass uses cached pointers.
+4. Cached pointers are cleared or overwritten during reconnect if source module no longer exists.
+5. Main thread never dereferences cached runtime pointers after ownership transfer.
+
+This contract must be documented adjacent to each raw-pointer cache site.
+
+## Patch Update Flow
+
+Patch updates keep current two-part semantic model:
+
+- main thread constructs fresh modules with fresh params
+- audio thread transfers runtime state from old module to new module
+
+After migration, audio-thread apply still performs state transfer, but no longer manages shared module ownership.
+
+Conceptually:
+
+1. take owned `Box<dyn Sampleable>` inserts from queued update
+2. remove old owned module if present
+3. call `transfer_state_from(old.as_ref())`
+4. queue old owned module for main-thread drop
+5. insert new owned module into patch
+6. rebuild listeners and reconnect all modules
+
+This preserves existing state continuity semantics while matching real ownership.
+
+For current `Signal`, `Buffer`, and seq source caches, precomputed bindings against unpublished new runtime would be sound across `transfer_state_from()` because state transfer mutates new modules in place rather than replacing them with different module objects. Even so, published-runtime `connect()` should remain on audio thread for now. This keeps one canonical binding point after state transfer and runtime install, and preserves room for future optimizations or cache types that may depend on final live-runtime state rather than only new-runtime object identity.
+
+## Runtime Compilation Boundary
+
+This ownership cleanup should also tighten boundary between main-thread preparation and audio-thread apply.
+
+Main thread should increasingly prepare:
+
+- scheduler analysis
+- debug snapshot inputs
+- region execution plan
+- module order
+- block module specs
+- preallocated region output buffers sized for host callback
+
+Audio thread should increasingly limit itself to:
+
+- state transfer
+- owned runtime swap / field replacement
+- reconnect
+- pointer cache refresh
+- old runtime garbage handoff
+
+This change is not required to land as one patch, but design should move in this direction because it removes more audio-thread allocation and rebuild work.
+
+## Error Handling
+
+- Missing source module during `connect()` clears cached pointer and behaves like disconnected input
+- `Signal::get_value()` on unresolved cable returns `0.0`, matching current fallback
+- `Buffer` unresolved source becomes disconnected buffer state
+- message dispatch skips listener ids no longer present in patch
+- patch apply continues to queue removed modules for main-thread destruction
+
+No new user-facing error surface is required for this migration.
+
+## Testing Strategy
+
+Add or update tests for:
+
+- `Sampleable` requires `Send` but not `Sync`
+- generated wrappers no longer require or claim `Sync`
+- `Signal` reconnect refreshes cached pointer after module replacement and remap
+- `Signal` missing source clears pointer and returns `0.0`
+- `Buffer.ensure_source_updated()` still triggers source update after reconnect
+- seq source cache refresh works after patch updates
+- message listener dispatch still reaches active modules and ignores removed ones
+- `SingleModuleUpdate` preserves state continuity with owned modules
+- patch update / clear path hands old modules to garbage queue without audio-thread drop
+
+If runtime compilation work moves off audio thread in same effort, add tests that verify new runtime metadata is precomputed before enqueue.
+
+## Migration Plan
+
+Implement in small steps to keep system working:
+
+1. Replace message listener weak refs with id-based lookup.
+2. Convert `Signal` cable cache from `Weak` to raw pointer.
+3. Convert `Buffer` cached source module from strong `Arc` to raw pointer.
+4. Convert seq source caches from `Weak` to raw pointer.
+5. Change module ownership types from `Arc<Box<dyn Sampleable>>` to `Box<dyn Sampleable>` across `Patch`, commands, and garbage queue.
+6. Drop `Sync` from `Sampleable` and wrapper impls.
+7. Expand main-thread runtime preparation to remove more audio-thread rebuild and allocation work.
+
+Each step should land with focused tests because connection bugs here will be subtle and timing-sensitive.
+
+## Alternatives Considered
+
+### Keep `Arc` and only remove `Sync`
+
+Rejected.
+
+This would reduce some trait dishonesty but leave fake shared ownership embedded in patch graph, commands, listeners, and caches. It would also preserve too much architectural pressure toward concurrent access patterns the engine does not support.
+
+### Full Arena / Slot Runtime Rewrite
+
+Rejected for now.
+
+Stable slot handles with generations would be clean long-term, but would require much larger API churn because hot call sites such as `Signal::get_value()` would need runtime context or equivalent handle lookup machinery. Current migration should stay smaller and preserve hot-path API shape.
+
+## Open Questions
+
+None for this design phase. Raw-pointer hybrid model is selected for current migration.


### PR DESCRIPTION
Implements docs/superpowers/plans/2026-04-23-send-only-sampleable-runtime.md.

Replaces fake-shared module ownership with single-owner runtime model. `Patch::sampleables` now stores `Box<dyn Sampleable>` (was `Arc<Box<...>>`), and hot connection paths cache non-owning `SampleablePtr` (NonNull-backed) instead of `Weak<Box<dyn Sampleable>>`. `Buffer` and `Signal::Cable` migrate their cached source references to raw pointers resolved during `connect()`. Module constructors return `Box<dyn Sampleable>`; the proc-macro's wrapper contract is updated accordingly.

The `Sampleable` trait still requires `Send + Sync` in this commit — the final `Sync` drop is the next slice (sampleable-sync-removal plan).