### PR TITLE
fix(link): keep AblLink alive across spurious toggles and off the audio thread

### DIFF
--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1208,27 +1208,10 @@ fn chrono_simple_timestamp() -> String {
 // ============================================================================
 // AudioProcessor - Audio thread side
 // ============================================================================
-
-/// Live Ableton Link resources. Constructed and dropped on the main thread
-/// (per official Link guidance: `enable()`, construction, and destruction are
-/// not realtime-safe). The audio thread only reads/writes via the RT-safe
-/// capture/commit/clock_micros API. Resources are handed in via `SetLink`
-/// and handed back via the garbage queue for main-thread drop.
-pub struct LinkResources {
-  pub link: rusty_link::AblLink,
-  pub host_time_filter: rusty_link::HostTimeFilter,
-  pub session_state: rusty_link::SessionState,
-}
-
-/// Per-buffer Link session state capture.
-/// Captured once per audio callback to avoid repeated FFI calls per frame.
-struct LinkBufferState {
-  host_time_micros: i64,
-  quantum: f64,
-  tempo: f64,
-  playing: bool,
-  micros_per_sample: f64,
-}
+//
+// Ableton Link integration lives in `crate::link`. The audio thread holds a
+// `LinkState` that owns the live `rusty_link` resources and exposes only
+// realtime-safe operations.
 
 /// Audio processor that runs on the audio thread.
 /// Owns the Patch directly and processes commands from the main thread.
@@ -1255,20 +1238,9 @@ struct AudioProcessor {
   transport_meter: Arc<TransportMeter>,
   /// Sample rate of the audio stream
   sample_rate: f32,
-  /// Ableton Link instance (None when not enabled)
-  link: Option<rusty_link::AblLink>,
-  /// Host time filter for accurate timestamps with cpal
-  host_time_filter: Option<rusty_link::HostTimeFilter>,
-  /// Pre-allocated SessionState for RT-safe capture (allocated when Link is enabled)
-  link_session_state: Option<rusty_link::SessionState>,
-  /// Running sample count for HostTimeFilter
-  link_sample_count: u64,
-  /// Per-buffer Link state capture
-  current_link_state: Option<LinkBufferState>,
-  /// Frame index within current buffer (for per-frame host time calculation)
-  frame_in_buffer: usize,
-  /// Pending quantized start — waiting for bar boundary before actually starting
-  link_pending_start: bool,
+  /// Ableton Link integration (audio-thread side). Owns the live
+  /// `rusty_link` resources when active and exposes only RT-safe operations.
+  link: crate::link::LinkState,
 }
 
 impl AudioProcessor {
@@ -1291,13 +1263,7 @@ impl AudioProcessor {
       queued_update: None,
       transport_meter: shared.transport_meter,
       sample_rate,
-      link: None,
-      host_time_filter: None,
-      link_session_state: None,
-      link_sample_count: 0,
-      current_link_state: None,
-      frame_in_buffer: 0,
-      link_pending_start: false,
+      link: crate::link::LinkState::new(),
     }
   }
 
@@ -1318,18 +1284,11 @@ impl AudioProcessor {
     while let Ok(cmd) = self.command_rx.pop() {
       match cmd {
         GraphCommand::QueuedPatchUpdate { update, trigger } => {
-          // Push tempo to Link if explicitly set via $setTempo. Capture +
-          // commit on the audio thread is the realtime-safe way to mutate
-          // session state per Ableton's docs.
+          // Push tempo to Link if explicitly set via $setTempo. The
+          // capture/commit call inside `set_tempo_now` is the realtime-safe
+          // way to mutate session state per Ableton's docs.
           if let Some(tempo) = update.tempo_override {
-            if let Some(ref link) = self.link {
-              if let Some(ref mut ss) = self.link_session_state {
-                link.capture_audio_session_state(ss);
-                let time = link.clock_micros();
-                ss.set_tempo(tempo, time);
-                link.commit_audio_session_state(ss);
-              }
-            }
+            self.link.set_tempo_now(tempo);
           }
 
           // If there's already a queued update, discard it and apply the new one
@@ -1384,20 +1343,14 @@ impl AudioProcessor {
           }
         }
         GraphCommand::Start => {
-          if let Some(ref link) = self.link {
+          if self.link.is_active() {
             // With Link: keep `stopped=true` and arm a pending start.
             // The buffer-level phase check releases `stopped` when the
             // shared Link timeline reaches a bar boundary.
-            if let Some(ref mut ss) = self.link_session_state {
-              link.capture_audio_session_state(ss);
-              let time = link.clock_micros();
-              self
-                .stopped
-                .store(true, std::sync::atomic::Ordering::SeqCst);
-              ss.set_is_playing_and_request_beat_at_time(true, time, 0.0, 4.0);
-              link.commit_audio_session_state(ss);
-              self.link_pending_start = true;
-            }
+            self
+              .stopped
+              .store(true, std::sync::atomic::Ordering::SeqCst);
+            self.link.request_quantized_start();
           } else {
             // Free-run: flip immediately and reset the clock.
             self
@@ -1411,17 +1364,9 @@ impl AudioProcessor {
         GraphCommand::Stop => {
           // Stop is handled via the stopped flag.
           // Also clear any pending start so a later peer-start does not
-          // resurrect a cancelled patch.
-          self.link_pending_start = false;
-          // Propagate stop to Link session
-          if let Some(ref link) = self.link {
-            if let Some(ref mut ss) = self.link_session_state {
-              link.capture_audio_session_state(ss);
-              let time = link.clock_micros();
-              ss.set_is_playing(false, time);
-              link.commit_audio_session_state(ss);
-            }
-          }
+          // resurrect a cancelled patch, and propagate stop to peers.
+          self.link.clear_pending_start();
+          self.link.signal_stop();
         }
         GraphCommand::ClearPatch => {
           // Discard any pending queued update
@@ -1449,48 +1394,21 @@ impl AudioProcessor {
           // main thread; the audio thread only swaps the prepared resources
           // in/out and ships any old set off to the garbage queue for
           // main-thread drop.
-          let had_link = self.link.is_some();
+          let was_active = self.link.is_active();
+          if let Some(old) = self.link.install(new_resources) {
+            // If the queue is full, the Box drops here on the audio thread
+            // as a fallback — not ideal RT-wise but bounded and strictly
+            // better than leaking the live networking resources.
+            let _ = self.garbage_tx.push(GarbageItem::Link(old));
+          }
 
-          // Take the current resources, if any, so they can be dropped on
-          // the main thread.
-          if had_link {
-            if let (Some(link), Some(htf), Some(ss)) = (
-              self.link.take(),
-              self.host_time_filter.take(),
-              self.link_session_state.take(),
-            ) {
-              let old = Box::new(LinkResources {
-                link,
-                host_time_filter: htf,
-                session_state: ss,
-              });
-              if self.garbage_tx.push(GarbageItem::Link(old)).is_err() {
-                // Garbage queue full — fall through and let the Box drop
-                // here. Not ideal RT-wise but bounded by queue size and
-                // strictly better than leaking the resources.
-              }
-            }
-            // Always clear ROOT_CLOCK external sync when releasing/replacing
-            // the Link instance.
+          // When the live instance changes, clear any external clock sync
+          // on ROOT_CLOCK so the patch's own clock takes over.
+          if was_active {
             use modular_core::types::ROOT_CLOCK_ID;
             if let Some(root_clock) = self.patch.sampleables.get(&*ROOT_CLOCK_ID) {
               root_clock.clear_external_sync();
             }
-            self.current_link_state = None;
-            self.link_pending_start = false;
-          }
-
-          // Install incoming resources, if any.
-          if let Some(res) = new_resources {
-            let LinkResources {
-              link,
-              host_time_filter,
-              session_state,
-            } = *res;
-            self.link = Some(link);
-            self.host_time_filter = Some(host_time_filter);
-            self.link_session_state = Some(session_state);
-            self.link_sample_count = 0;
           }
         }
       }
@@ -1616,30 +1534,6 @@ impl AudioProcessor {
     }
   }
 
-  /// Capture Link session state once per audio buffer.
-  /// Returns None if Link is not active.
-  fn capture_link_state(&mut self) -> Option<LinkBufferState> {
-    let link = self.link.as_ref()?;
-    let htf = self.host_time_filter.as_mut()?;
-    let ss = self.link_session_state.as_mut()?;
-
-    let clock_micros = link.clock_micros();
-    let host_time_micros = htf.sample_time_to_host_time(clock_micros, self.link_sample_count);
-    link.capture_audio_session_state(ss);
-    let quantum = 4.0;
-    let tempo = ss.tempo();
-    let playing = ss.is_playing();
-    let micros_per_sample = 1_000_000.0 / self.sample_rate as f64;
-
-    Some(LinkBufferState {
-      host_time_micros,
-      quantum,
-      tempo,
-      playing,
-      micros_per_sample,
-    })
-  }
-
   /// Process a single frame, returning multi-channel output
   fn process_frame(&mut self, num_channels: usize) -> [f32; PORT_MAX_CHANNELS] {
     use modular_core::types::{ROOT_CLOCK_ID, ROOT_ID};
@@ -1652,21 +1546,12 @@ impl AudioProcessor {
     }
 
     // 1. Sync Link state to ROOT_CLOCK, then update ROOT_CLOCK
-    if let Some(ref link_state) = self.current_link_state {
-      if let Some(ref ss) = self.link_session_state {
-        if let Some(root_clock) = self.patch.sampleables.get(&*ROOT_CLOCK_ID) {
-          // Compute per-frame host time by offsetting from buffer start
-          let frame_offset_micros =
-            (self.frame_in_buffer as f64 * link_state.micros_per_sample) as i64;
-          let frame_host_time = link_state.host_time_micros + frame_offset_micros;
-          let phase = ss.phase_at_time(frame_host_time, link_state.quantum);
-          // Convert phase to bar_phase (0..1) by dividing by quantum
-          let bar_phase = phase / link_state.quantum;
-          root_clock.sync_external_clock(bar_phase, link_state.tempo);
-        }
+    let root_clock = self.patch.sampleables.get(&*ROOT_CLOCK_ID).cloned();
+    self.link.sync_frame(|bar_phase, tempo| {
+      if let Some(ref clock) = root_clock {
+        clock.sync_external_clock(bar_phase, tempo);
       }
-      self.frame_in_buffer += 1;
-    }
+    });
 
     // 2. Update ROOT_CLOCK so its trigger outputs are available this frame
     if let Some(root_clock) = self.patch.sampleables.get(&*ROOT_CLOCK_ID) {
@@ -1867,56 +1752,27 @@ where
           audio_processor.process_commands();
         }
 
-        // Capture Link session state once per buffer (before frame loop)
-        audio_processor.current_link_state = audio_processor.capture_link_state();
-        audio_processor.frame_in_buffer = 0;
+        // Capture Link session state once per buffer (before frame loop).
+        audio_processor
+          .link
+          .capture_buffer_state(audio_processor.sample_rate);
 
         // Operator transport is decoupled from Link peer transport:
         // peers never start or stop Operator. The only Link-driven transport
         // action is releasing a locally-initiated quantized start when the
         // shared timeline reaches a bar boundary.
-        if let Some(ref link_state) = audio_processor.current_link_state {
-          if audio_processor.link_pending_start {
-            if let Some(ref ss) = audio_processor.link_session_state {
-              let time = link_state.host_time_micros;
-              let phase = ss.phase_at_time(time, link_state.quantum);
-              if phase < 0.5 {
-                audio_processor.link_pending_start = false;
-                audio_processor
-                  .stopped
-                  .store(false, std::sync::atomic::Ordering::SeqCst);
-                let msg = modular_core::types::Message::Clock(ClockMessages::Start);
-                let _ = audio_processor.patch.dispatch_message(&msg);
-              }
-            }
-          }
+        if audio_processor.link.check_pending_start_release() {
+          audio_processor
+            .stopped
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+          let msg = modular_core::types::Message::Clock(ClockMessages::Start);
+          let _ = audio_processor.patch.dispatch_message(&msg);
         }
 
-        // Write Link state to transport meter for UI visibility.
-        // Write phase BEFORE the is_stopped() guard so the UI always shows
-        // the free-running Link phase, even when Operator is stopped.
-        if let Some(ref link) = audio_processor.link {
-          audio_processor
-            .transport_meter
-            .write_link_state(true, link.num_peers() as u32);
-          if let Some(ref link_state) = audio_processor.current_link_state {
-            // Update BPM from Link so the UI reflects external tempo changes
-            audio_processor.transport_meter.write_bpm(link_state.tempo);
-            // Write the free-running Link bar phase for the phase indicator
-            if let Some(ref ss) = audio_processor.link_session_state {
-              let phase = ss.phase_at_time(link_state.host_time_micros, link_state.quantum);
-              let bar_phase = phase / link_state.quantum;
-              audio_processor.transport_meter.write_link_phase(bar_phase);
-            }
-          }
-          audio_processor
-            .transport_meter
-            .write_link_pending_start(audio_processor.link_pending_start);
-        } else {
-          audio_processor
-            .transport_meter
-            .write_link_pending_start(false);
-        }
+        // Write Link state to transport meter for UI visibility. Done
+        // BEFORE the is_stopped() guard so the UI always shows the
+        // free-running Link phase, even when Operator is stopped.
+        audio_processor.link.write_meter(&audio_processor.transport_meter);
 
         let num_frames = output.len() / num_channels;
 
@@ -1959,7 +1815,7 @@ where
         }
 
         // Increment Link sample count for HostTimeFilter
-        audio_processor.link_sample_count += num_frames as u64;
+        audio_processor.link.add_samples(num_frames as u64);
 
         // Collect module states for UI (e.g., seq step highlighting)
         // Done once per buffer, not per frame, to minimize overhead

--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1209,6 +1209,17 @@ fn chrono_simple_timestamp() -> String {
 // AudioProcessor - Audio thread side
 // ============================================================================
 
+/// Live Ableton Link resources. Constructed and dropped on the main thread
+/// (per official Link guidance: `enable()`, construction, and destruction are
+/// not realtime-safe). The audio thread only reads/writes via the RT-safe
+/// capture/commit/clock_micros API. Resources are handed in via `SetLink`
+/// and handed back via the garbage queue for main-thread drop.
+pub struct LinkResources {
+  pub link: rusty_link::AblLink,
+  pub host_time_filter: rusty_link::HostTimeFilter,
+  pub session_state: rusty_link::SessionState,
+}
+
 /// Per-buffer Link session state capture.
 /// Captured once per audio callback to avoid repeated FFI calls per frame.
 struct LinkBufferState {
@@ -1252,8 +1263,6 @@ struct AudioProcessor {
   link_session_state: Option<rusty_link::SessionState>,
   /// Running sample count for HostTimeFilter
   link_sample_count: u64,
-  /// Last known tempo for Link (for detecting local tempo changes)
-  last_link_tempo: f64,
   /// Per-buffer Link state capture
   current_link_state: Option<LinkBufferState>,
   /// Frame index within current buffer (for per-frame host time calculation)
@@ -1286,7 +1295,6 @@ impl AudioProcessor {
       host_time_filter: None,
       link_session_state: None,
       link_sample_count: 0,
-      last_link_tempo: 120.0,
       current_link_state: None,
       frame_in_buffer: 0,
       link_pending_start: false,
@@ -1310,7 +1318,9 @@ impl AudioProcessor {
     while let Ok(cmd) = self.command_rx.pop() {
       match cmd {
         GraphCommand::QueuedPatchUpdate { update, trigger } => {
-          // Push tempo to Link if explicitly set via $setTempo
+          // Push tempo to Link if explicitly set via $setTempo. Capture +
+          // commit on the audio thread is the realtime-safe way to mutate
+          // session state per Ableton's docs.
           if let Some(tempo) = update.tempo_override {
             if let Some(ref link) = self.link {
               if let Some(ref mut ss) = self.link_session_state {
@@ -1318,7 +1328,6 @@ impl AudioProcessor {
                 let time = link.clock_micros();
                 ss.set_tempo(tempo, time);
                 link.commit_audio_session_state(ss);
-                self.last_link_tempo = tempo;
               }
             }
           }
@@ -1434,27 +1443,54 @@ impl AudioProcessor {
           self.patch.insert_audio_in();
           self.patch.rebuild_message_listeners();
         }
-        GraphCommand::EnableLink(enabled) => {
-          if enabled {
-            let bpm = self.last_link_tempo;
-            let link = rusty_link::AblLink::new(bpm);
-            link.enable(true);
-            link.enable_start_stop_sync(true);
-            self.host_time_filter = Some(rusty_link::HostTimeFilter::new());
-            self.link_session_state = Some(rusty_link::SessionState::new());
-            self.link_sample_count = 0;
-            self.link = Some(link);
-          } else {
-            // Clear external sync on ROOT_CLOCK before dropping Link
+        GraphCommand::SetLink(new_resources) => {
+          // Construction/destruction of `AblLink` (and `enable()`) are
+          // realtime-unsafe per Ableton's documentation. They run on the
+          // main thread; the audio thread only swaps the prepared resources
+          // in/out and ships any old set off to the garbage queue for
+          // main-thread drop.
+          let had_link = self.link.is_some();
+
+          // Take the current resources, if any, so they can be dropped on
+          // the main thread.
+          if had_link {
+            if let (Some(link), Some(htf), Some(ss)) = (
+              self.link.take(),
+              self.host_time_filter.take(),
+              self.link_session_state.take(),
+            ) {
+              let old = Box::new(LinkResources {
+                link,
+                host_time_filter: htf,
+                session_state: ss,
+              });
+              if self.garbage_tx.push(GarbageItem::Link(old)).is_err() {
+                // Garbage queue full — fall through and let the Box drop
+                // here. Not ideal RT-wise but bounded by queue size and
+                // strictly better than leaking the resources.
+              }
+            }
+            // Always clear ROOT_CLOCK external sync when releasing/replacing
+            // the Link instance.
             use modular_core::types::ROOT_CLOCK_ID;
             if let Some(root_clock) = self.patch.sampleables.get(&*ROOT_CLOCK_ID) {
               root_clock.clear_external_sync();
             }
-            self.link = None;
-            self.host_time_filter = None;
-            self.link_session_state = None;
             self.current_link_state = None;
             self.link_pending_start = false;
+          }
+
+          // Install incoming resources, if any.
+          if let Some(res) = new_resources {
+            let LinkResources {
+              link,
+              host_time_filter,
+              session_state,
+            } = *res;
+            self.link = Some(link);
+            self.host_time_filter = Some(host_time_filter);
+            self.link_session_state = Some(session_state);
+            self.link_sample_count = 0;
           }
         }
       }
@@ -2330,6 +2366,21 @@ impl TransportMeter {
   #[inline]
   pub fn write_link_pending_start(&self, armed: bool) {
     self.link_pending_start.store(armed, Ordering::Relaxed);
+  }
+
+  /// Read the current Link enabled flag (used by the main thread for
+  /// idempotency checks before constructing/destroying Link resources).
+  #[inline]
+  pub fn read_link_enabled(&self) -> bool {
+    self.link_enabled.load(Ordering::Relaxed)
+  }
+
+  /// Read the current BPM (used by the main thread when constructing a new
+  /// `AblLink` so we initialise the session at the user's last known tempo
+  /// rather than always 120).
+  #[inline]
+  pub fn read_bpm(&self) -> f64 {
+    f64::from_bits(self.bpm_bits.load(Ordering::Relaxed))
   }
 
   /// Read transport snapshot from the main thread.

--- a/crates/modular/src/commands.rs
+++ b/crates/modular/src/commands.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use modular_core::types::{Message, ModuleIdRemap, Sampleable, ScopeBufferKey, WavData};
 use napi_derive::napi;
 
-use crate::audio::ScopeBuffer;
+use crate::audio::{LinkResources, ScopeBuffer};
 
 /// When a queued patch update should be applied.
 #[napi(string_enum)]
@@ -113,8 +113,18 @@ pub enum GraphCommand {
   /// Clear the entire patch (used when stopped to reset state)
   ClearPatch,
 
-  /// Enable or disable Ableton Link synchronization
-  EnableLink(bool),
+  /// Install or remove the live Ableton Link session.
+  ///
+  /// `Some(resources)` hands a fully constructed and enabled `AblLink`
+  /// (alongside its `HostTimeFilter` and `SessionState`) to the audio thread.
+  /// `None` tells the audio thread to relinquish its current resources.
+  ///
+  /// Construction, `enable()`, and drop of `AblLink` are documented as
+  /// realtime-unsafe by Ableton and must run on the main thread. The audio
+  /// thread only ever uses the RT-safe capture/commit/clock_micros API on
+  /// the resources it holds. Old resources removed by this command are
+  /// pushed to the garbage queue so the main thread can drop them safely.
+  SetLink(Option<Box<LinkResources>>),
 }
 
 /// Error types that can be reported from the audio thread back to the main thread.
@@ -171,6 +181,9 @@ pub enum GarbageItem {
   Scope(ScopeBuffer),
   /// A queued patch update that was superseded by a newer update before it fired
   PatchUpdate(PatchUpdate),
+  /// Live Link resources removed from the audio thread. Drop tears down
+  /// internal networking threads and sockets — must happen on the main thread.
+  Link(Box<LinkResources>),
 }
 
 /// Capacity for the garbage queue (audio → main).

--- a/crates/modular/src/commands.rs
+++ b/crates/modular/src/commands.rs
@@ -9,7 +9,8 @@ use std::sync::Arc;
 use modular_core::types::{Message, ModuleIdRemap, Sampleable, ScopeBufferKey, WavData};
 use napi_derive::napi;
 
-use crate::audio::{LinkResources, ScopeBuffer};
+use crate::audio::ScopeBuffer;
+use crate::link::LinkResources;
 
 /// When a queued patch update should be applied.
 #[napi(string_enum)]

--- a/crates/modular/src/lib.rs
+++ b/crates/modular/src/lib.rs
@@ -1193,7 +1193,40 @@ impl Synthesizer {
 
   #[napi]
   pub fn enable_link(&self, enabled: bool) -> Result<()> {
-    self.state.send_command(GraphCommand::EnableLink(enabled))?;
+    // Idempotency: if Link is already in the requested state, do nothing.
+    // This both avoids constructing a redundant `AblLink` (heap allocation,
+    // socket open, networking thread spawn — all expensive) and prevents
+    // tearing down an existing live session whose peers would then have to
+    // re-discover us.
+    if self.state.transport_meter.read_link_enabled() == enabled {
+      return Ok(());
+    }
+
+    let resources = if enabled {
+      // Construct + enable on the main thread. Per Ableton's documentation
+      // (`Link.hpp`: "Realtime-safe: no" on `enable()`), construction and
+      // enable cannot run on the audio thread without risking glitches.
+      // Initialise at the user's last known tempo so toggling Link doesn't
+      // reset the session BPM.
+      let bpm = self.state.transport_meter.read_bpm();
+      let link = rusty_link::AblLink::new(bpm);
+      link.enable(true);
+      link.enable_start_stop_sync(true);
+      Some(Box::new(crate::audio::LinkResources {
+        link,
+        host_time_filter: rusty_link::HostTimeFilter::new(),
+        session_state: rusty_link::SessionState::new(),
+      }))
+    } else {
+      None
+    };
+
+    self.state.send_command(GraphCommand::SetLink(resources))?;
+
+    // Update the meter immediately so the UI flips state without waiting
+    // for the next audio callback. Peer count starts at 0 in both cases:
+    // on disable there are no peers; on a fresh enable the live peer count
+    // is 0 until the audio thread overwrites it from `link.num_peers()`.
     self.state.transport_meter.write_link_state(enabled, 0);
     Ok(())
   }

--- a/crates/modular/src/lib.rs
+++ b/crates/modular/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod audio;
 mod commands;
+mod link;
 mod midi;
 mod params_cache;
 mod validation;
@@ -1212,7 +1213,7 @@ impl Synthesizer {
       let link = rusty_link::AblLink::new(bpm);
       link.enable(true);
       link.enable_start_stop_sync(true);
-      Some(Box::new(crate::audio::LinkResources {
+      Some(Box::new(crate::link::LinkResources {
         link,
         host_time_filter: rusty_link::HostTimeFilter::new(),
         session_state: rusty_link::SessionState::new(),

--- a/crates/modular/src/link.rs
+++ b/crates/modular/src/link.rs
@@ -1,0 +1,265 @@
+//! Ableton Link integration.
+//!
+//! Threading model (per official Link documentation in `Link.hpp`):
+//!
+//! * Construction, `enable()`, `enable_start_stop_sync()`, and drop of
+//!   `AblLink` are documented "Realtime-safe: no" — they must run on the
+//!   main thread. We package an enabled `AblLink` together with its
+//!   `HostTimeFilter` and `SessionState` into [`LinkResources`] on the main
+//!   thread and hand them to the audio thread via the command queue.
+//!   Resources are returned via the existing garbage queue for main-thread
+//!   drop.
+//!
+//! * Per-buffer and per-frame access on the audio thread uses only the
+//!   realtime-safe API (`capture_audio_session_state`,
+//!   `commit_audio_session_state`, `clock_micros`, `phase_at_time`).
+//!
+//! [`LinkState`] owns the audio-thread-side runtime state. The audio thread
+//! never constructs or destroys an `AblLink` itself — it only swaps live
+//! resources in and out via [`LinkState::install`].
+
+use rusty_link::{AblLink, HostTimeFilter, SessionState};
+
+use crate::audio::TransportMeter;
+
+/// A bundle of Ableton Link runtime objects, constructed and torn down on
+/// the main thread.
+pub struct LinkResources {
+  pub link: AblLink,
+  pub host_time_filter: HostTimeFilter,
+  pub session_state: SessionState,
+}
+
+/// Per-buffer Link session-state snapshot. Captured once per audio callback
+/// to avoid repeated FFI calls per frame.
+pub struct LinkBufferState {
+  pub host_time_micros: i64,
+  pub quantum: f64,
+  pub tempo: f64,
+  pub micros_per_sample: f64,
+}
+
+/// The bar-phase quantum used throughout the integration (4 beats = 1 bar).
+const QUANTUM: f64 = 4.0;
+
+/// Audio-thread-side Link state. Holds the live resources (when active),
+/// the per-buffer snapshot, the running sample counter for the host-time
+/// filter, an in-frame index, and the pending quantized-start flag.
+pub struct LinkState {
+  link: Option<AblLink>,
+  host_time_filter: Option<HostTimeFilter>,
+  session_state: Option<SessionState>,
+  /// Running sample count for HostTimeFilter.
+  sample_count: u64,
+  /// Per-buffer Link snapshot, refreshed at the start of every audio
+  /// callback by [`LinkState::capture_buffer_state`].
+  buffer: Option<LinkBufferState>,
+  /// Frame index within the current buffer (used to compute per-frame host
+  /// times when syncing ROOT_CLOCK).
+  frame_in_buffer: usize,
+  /// Pending quantized start — a Start was requested but transport is
+  /// waiting for the next Link bar boundary before actually playing.
+  pending_start: bool,
+}
+
+impl LinkState {
+  pub fn new() -> Self {
+    Self {
+      link: None,
+      host_time_filter: None,
+      session_state: None,
+      sample_count: 0,
+      buffer: None,
+      frame_in_buffer: 0,
+      pending_start: false,
+    }
+  }
+
+  /// Whether Link is currently active (resources installed).
+  #[inline]
+  pub fn is_active(&self) -> bool {
+    self.link.is_some()
+  }
+
+  /// Install or remove Link resources. Returns the previously-held resources
+  /// (if any) so the caller can ship them to the garbage queue for
+  /// main-thread drop. Also clears any pending start and the per-buffer
+  /// snapshot whenever the live instance changes.
+  pub fn install(&mut self, new: Option<Box<LinkResources>>) -> Option<Box<LinkResources>> {
+    let old = self.take();
+
+    if let Some(res) = new {
+      let LinkResources {
+        link,
+        host_time_filter,
+        session_state,
+      } = *res;
+      self.link = Some(link);
+      self.host_time_filter = Some(host_time_filter);
+      self.session_state = Some(session_state);
+      self.sample_count = 0;
+    }
+
+    old
+  }
+
+  /// Take the current resources (if any), leaving Link inactive. Used both
+  /// for swap (via `install`) and explicit teardown.
+  fn take(&mut self) -> Option<Box<LinkResources>> {
+    self.buffer = None;
+    self.pending_start = false;
+
+    match (
+      self.link.take(),
+      self.host_time_filter.take(),
+      self.session_state.take(),
+    ) {
+      (Some(link), Some(host_time_filter), Some(session_state)) => Some(Box::new(LinkResources {
+        link,
+        host_time_filter,
+        session_state,
+      })),
+      _ => None,
+    }
+  }
+
+  /// Force-clear the pending-start flag. Called on explicit Stop so a later
+  /// peer-start cannot resurrect a cancelled patch.
+  #[inline]
+  pub fn clear_pending_start(&mut self) {
+    self.pending_start = false;
+  }
+
+  /// Audio-callback prologue: capture the session state once per buffer and
+  /// reset the in-buffer frame index. No-op when Link is inactive.
+  pub fn capture_buffer_state(&mut self, sample_rate: f32) {
+    self.frame_in_buffer = 0;
+    self.buffer = self.capture(sample_rate);
+  }
+
+  fn capture(&mut self, sample_rate: f32) -> Option<LinkBufferState> {
+    let link = self.link.as_ref()?;
+    let htf = self.host_time_filter.as_mut()?;
+    let ss = self.session_state.as_mut()?;
+
+    let clock_micros = link.clock_micros();
+    let host_time_micros = htf.sample_time_to_host_time(clock_micros, self.sample_count);
+    link.capture_audio_session_state(ss);
+    let tempo = ss.tempo();
+    let micros_per_sample = 1_000_000.0 / sample_rate as f64;
+
+    Some(LinkBufferState {
+      host_time_micros,
+      quantum: QUANTUM,
+      tempo,
+      micros_per_sample,
+    })
+  }
+
+  /// Check whether a pending quantized start should be released this buffer.
+  /// Returns `true` exactly once — when the Link bar phase has rolled past
+  /// the boundary — and clears the flag. The caller is responsible for
+  /// flipping the stopped atomic and dispatching `Clock::Start`.
+  pub fn check_pending_start_release(&mut self) -> bool {
+    if !self.pending_start {
+      return false;
+    }
+    let buffer = match &self.buffer {
+      Some(b) => b,
+      None => return false,
+    };
+    let ss = match &self.session_state {
+      Some(s) => s,
+      None => return false,
+    };
+    let phase = ss.phase_at_time(buffer.host_time_micros, buffer.quantum);
+    if phase < 0.5 {
+      self.pending_start = false;
+      true
+    } else {
+      false
+    }
+  }
+
+  /// Compute the current frame's bar-phase and tempo and pass them to
+  /// `sync` so the caller can drive ROOT_CLOCK. Always advances the
+  /// in-buffer frame index when Link is active. No-op when inactive.
+  pub fn sync_frame<F: FnOnce(f64, f64)>(&mut self, sync: F) {
+    let buffer = match &self.buffer {
+      Some(b) => b,
+      None => return,
+    };
+    if let Some(ref ss) = self.session_state {
+      let frame_offset_micros =
+        (self.frame_in_buffer as f64 * buffer.micros_per_sample) as i64;
+      let frame_host_time = buffer.host_time_micros + frame_offset_micros;
+      let phase = ss.phase_at_time(frame_host_time, buffer.quantum);
+      let bar_phase = phase / buffer.quantum;
+      sync(bar_phase, buffer.tempo);
+    }
+    self.frame_in_buffer += 1;
+  }
+
+  /// Push an explicit tempo override to the Link session via the RT-safe
+  /// capture/commit pair.
+  pub fn set_tempo_now(&mut self, tempo: f64) {
+    if let (Some(link), Some(ss)) = (&self.link, &mut self.session_state) {
+      link.capture_audio_session_state(ss);
+      let time = link.clock_micros();
+      ss.set_tempo(tempo, time);
+      link.commit_audio_session_state(ss);
+    }
+  }
+
+  /// Arm a quantized start — request `is_playing=true` + beat=0 at the next
+  /// bar boundary. Sets the pending_start flag so the audio loop can
+  /// release the local stopped atomic when the boundary arrives.
+  pub fn request_quantized_start(&mut self) {
+    if let (Some(link), Some(ss)) = (&self.link, &mut self.session_state) {
+      link.capture_audio_session_state(ss);
+      let time = link.clock_micros();
+      ss.set_is_playing_and_request_beat_at_time(true, time, 0.0, QUANTUM);
+      link.commit_audio_session_state(ss);
+      self.pending_start = true;
+    }
+  }
+
+  /// Propagate a stop to the Link session.
+  pub fn signal_stop(&mut self) {
+    if let (Some(link), Some(ss)) = (&self.link, &mut self.session_state) {
+      link.capture_audio_session_state(ss);
+      let time = link.clock_micros();
+      ss.set_is_playing(false, time);
+      link.commit_audio_session_state(ss);
+    }
+  }
+
+  /// Advance the host-time filter sample counter by the number of frames
+  /// processed in this buffer.
+  #[inline]
+  pub fn add_samples(&mut self, n: u64) {
+    self.sample_count = self.sample_count.saturating_add(n);
+  }
+
+  /// Per-buffer transport-meter writes for UI display: enabled flag,
+  /// peer count, current Link tempo, free-running bar phase, and the
+  /// pending-start flag. When Link is inactive only `link_pending_start`
+  /// is reset (the enabled/peers state is already maintained by the
+  /// main thread on disable).
+  pub fn write_meter(&self, meter: &TransportMeter) {
+    if let Some(ref link) = self.link {
+      meter.write_link_state(true, link.num_peers() as u32);
+      if let Some(ref buffer) = self.buffer {
+        meter.write_bpm(buffer.tempo);
+        if let Some(ref ss) = self.session_state {
+          let phase = ss.phase_at_time(buffer.host_time_micros, buffer.quantum);
+          let bar_phase = phase / buffer.quantum;
+          meter.write_link_phase(bar_phase);
+        }
+      }
+      meter.write_link_pending_start(self.pending_start);
+    } else {
+      meter.write_link_pending_start(false);
+    }
+  }
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -883,6 +883,28 @@ function App() {
         createUntitledFile,
     ]);
 
+    // Ctrl+Enter (and Ctrl+Shift+Enter) are reserved for patch updates.
+    // Browsers activate a focused <button> on Enter regardless of modifier
+    // state, which would spuriously toggle e.g. the Link button after it had
+    // been clicked. Suppress the default activation when a button is focused.
+    useEffect(() => {
+        const onKeyDownCapture = (e: KeyboardEvent) => {
+            if (
+                e.ctrlKey &&
+                e.key === 'Enter' &&
+                e.target instanceof HTMLButtonElement
+            ) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+        };
+        window.addEventListener('keydown', onKeyDownCapture, { capture: true });
+        return () =>
+            window.removeEventListener('keydown', onKeyDownCapture, {
+                capture: true,
+            });
+    }, []);
+
     return (
         <div className="app">
             <header className="app-header">


### PR DESCRIPTION
## Summary

Two bugs caused Ableton Link peers to drop or the Link toggle to flip itself.

### Ctrl+Enter spuriously toggles the Link button

Browsers activate a focused `<button>` on Enter regardless of modifier state. After the user clicked the Link button it kept DOM focus, so the next Ctrl+Enter (Update Patch) both fired the menu accelerator AND synthesized a click on the focused Link button — toggling Link off, then on again on the next Ctrl+Enter, etc. With audio already running, this looked like Link \"disabling itself\" or peers dropping.

Fix: window-level capture-phase keydown handler in [App.tsx](src/renderer/App.tsx) that suppresses default activation when Ctrl+Enter targets a `HTMLButtonElement`. Ctrl+Enter is now reserved for the Update Patch hotkey on every focused element.

### `enable_link()` ran on the audio thread

`GraphCommand::EnableLink(true)` constructed a fresh `rusty_link::AblLink` on every call, **on the audio thread**. Per Ableton's documentation ([Link.hpp](https://github.com/Ableton/link/blob/master/include/ableton/Link.hpp)) `enable()` is documented \"Realtime-safe: no\", and the same is true of construction (heap allocation, socket open, networking thread spawn) and destruction (thread join, socket close). The reference [`linkaudio`](https://github.com/Ableton/link/blob/master/examples/linkaudio/AudioEngine.ipp) and [`linkhut`](https://github.com/Ableton/link/blob/master/examples/linkhut/main.cpp) examples build the `Link` instance once on the app thread and only ever touch it from the audio thread via the realtime-safe capture/commit/clock_micros API.

Fix:

- Move construction, `enable()`, and `enable_start_stop_sync()` to the main thread inside `Synthesizer::enable_link`.
- Replace `EnableLink(bool)` with `SetLink(Option<Box<LinkResources>>)`, handing a fully-prepared `AblLink` + `HostTimeFilter` + `SessionState` bundle to the audio thread.
- The audio thread only swaps the bundle in/out and ships any old set to the existing garbage queue (new `GarbageItem::Link` variant) so the drop runs on the main thread.
- Make `enable_link` idempotent against the meter's `link_enabled` flag, so a redundant request never tears down a live peer session.
- Initialise new sessions at the meter's current BPM rather than always 120, so toggling Link doesn't lose the user's tempo.

### Refactor: pull Link integration into its own module

`audio.rs` carried ~200 lines of Link logic across seven `AudioProcessor` fields. Extracted into a new [`crates/modular/src/link.rs`](crates/modular/src/link.rs) behind a `LinkState` type. `AudioProcessor` now holds a single `link: LinkState` and calls into a small RT-safe API (`capture_buffer_state`, `check_pending_start_release`, `sync_frame`, `set_tempo_now`, `request_quantized_start`, `signal_stop`, `add_samples`, `write_meter`, `install`, `is_active`, `clear_pending_start`).

## Test plan

- [x] `cargo test -p modular --lib` (43 passed)
- [x] `yarn typecheck` clean
- [x] `yarn build-native` clean
- [ ] Manual: click Link button, then mash Ctrl+Enter — Link button must stay enabled and peers must stay connected.
- [ ] Manual on LAN with a second Operator / Live / linkhut peer: toggle Link off → on rapidly, peers reconnect within a beat or two; long jam holds peers without spurious drops.
- [ ] Manual: \$setTempo while Link is enabled propagates to peers; toggling Link off then on preserves the user-set BPM rather than reverting to 120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)