### PR TITLE
chore(dsl): scaffold @modular/dsl package

### DIFF
--- a/crates/modular/dsl/package.json
+++ b/crates/modular/dsl/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "@modular/dsl",
+    "version": "0.0.1-0",
+    "description": "Operator DSL runtime + generated factories",
+    "license": "AGPL",
+    "private": true,
+    "main": "src/index.ts",
+    "types": "src/index.ts",
+    "scripts": {
+        "typecheck": "tsc -b"
+    },
+    "dependencies": {
+        "@modular/core": "workspace:*"
+    }
+}

--- a/crates/modular/dsl/src/index.ts
+++ b/crates/modular/dsl/src/index.ts
@@ -1,0 +1,3 @@
+// @modular/dsl — Operator DSL runtime + generated factories.
+// Public surface is added incrementally as runtime is relocated and generated artifacts land.
+export {};

--- a/crates/modular/dsl/tsconfig.json
+++ b/crates/modular/dsl/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "rootDir": "src",
+        "outDir": "dist",
+        "declaration": true,
+        "noEmit": true
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
         "zod": "^4.3.5"
     },
     "workspaces": [
-        "crates/*"
+        "crates/*",
+        "crates/modular/dsl"
     ],
     "lint-staged": {
         "*.{ts,tsx,js,jsx,mjs,json,css,md}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1934,7 +1934,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@modular/core@workspace:crates/modular":
+"@modular/core@workspace:*, @modular/core@workspace:crates/modular":
   version: 0.0.0-use.local
   resolution: "@modular/core@workspace:crates/modular"
   dependencies:
@@ -1951,6 +1951,14 @@ __metadata:
     oxlint: "npm:^1.14.0"
     tinybench: "npm:^6.0.0"
     typescript: "npm:^5.9.2"
+  languageName: unknown
+  linkType: soft
+
+"@modular/dsl@workspace:crates/modular/dsl":
+  version: 0.0.0-use.local
+  resolution: "@modular/dsl@workspace:crates/modular/dsl"
+  dependencies:
+    "@modular/core": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
Empty TypeScript workspace package that will host the relocated DSL runtime (PR 3) and the codegen-generated factories (PR 5).

- `crates/modular/dsl/` with `package.json`, `tsconfig.json`, empty `src/index.ts` barrel, `src/runtime/.gitkeep`
- Wires package into root yarn workspaces glob

No behaviour change. Existing `./dsl/executor` and `./dsl/typescriptLibGen` imports from `src/main/main.ts` continue to work unchanged.

## Test plan
- [ ] `yarn install` completes
- [ ] `yarn typecheck` passes
- [ ] `yarn test:unit` passes (170 tests)

## Stack — PR 1 of 5
1. **(this)** Scaffold @modular/dsl package
2. Split GraphBuilder/factories/executor into single-responsibility modules
3. Relocate runtime to @modular/dsl with analyzer callback
4. Rust JSON Schema → TypeScript type resolver
5. Generate per-category factories + wire runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)