### PR TITLE
feat(core): index_ptr back-pointer on Signal::Cable + Connect::inject_index_ptr

### DIFF
--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -2748,12 +2748,7 @@ mod tests {
       "dep".into(),
       PatchUpdateSensitiveModule::new(
         "dep",
-        Signal::Cable {
-          module: "src".into(),
-          resolved: None,
-          port: "out".into(),
-          channel: 0,
-        },
+        Signal::cable("src", "out", 0),
       ),
     );
 

--- a/crates/modular_core/src/dsp/seq/interval_seq.rs
+++ b/crates/modular_core/src/dsp/seq/interval_seq.rs
@@ -73,6 +73,7 @@ impl<E: deserr::DeserializeError> deserr::Deserr<E> for IntervalScaleParam {
 impl Connect for IntervalScaleParam {
     fn connect(&mut self, _patch: &Patch) {}
     fn collect_cables(&self, _sink: &mut Vec<String>) {}
+    fn inject_index_ptr(&mut self, _ptr: *const std::cell::Cell<usize>) {}
 }
 
 impl std::ops::Deref for IntervalScaleParam {
@@ -363,6 +364,7 @@ impl Connect for IntervalPatternParam {
         // IntervalPatternParam has no signals to connect
     }
     fn collect_cables(&self, _sink: &mut Vec<String>) {}
+    fn inject_index_ptr(&mut self, _ptr: *const std::cell::Cell<usize>) {}
 }
 
 impl<E: deserr::DeserializeError> deserr::Deserr<E> for IntervalPatternSource {

--- a/crates/modular_core/src/dsp/seq/seq_value.rs
+++ b/crates/modular_core/src/dsp/seq/seq_value.rs
@@ -274,6 +274,7 @@ impl<E: DeserializeError> deserr::Deserr<E> for SeqPatternParam {
 impl Connect for SeqPatternParam {
     fn connect(&mut self, _patch: &Patch) {}
     fn collect_cables(&self, _sink: &mut Vec<String>) {}
+    fn inject_index_ptr(&mut self, _ptr: *const std::cell::Cell<usize>) {}
 }
 
 #[cfg(test)]

--- a/crates/modular_core/src/dsp/utilities/math.rs
+++ b/crates/modular_core/src/dsp/utilities/math.rs
@@ -40,6 +40,7 @@ struct MathExpressionParam {
 impl Connect for Arc<MathCompiled> {
     fn connect(&mut self, _patch: &crate::Patch) {}
     fn collect_cables(&self, _sink: &mut Vec<String>) {}
+    fn inject_index_ptr(&mut self, _ptr: *const std::cell::Cell<usize>) {}
 }
 
 impl MathExpressionParam {

--- a/crates/modular_core/src/dsp/utilities/quantizer.rs
+++ b/crates/modular_core/src/dsp/utilities/quantizer.rs
@@ -47,6 +47,7 @@ impl Connect for ScaleParam {
         // ScaleParam has no signals to connect
     }
     fn collect_cables(&self, _sink: &mut Vec<String>) {}
+    fn inject_index_ptr(&mut self, _ptr: *const std::cell::Cell<usize>) {}
 }
 
 impl Default for ScaleParam {

--- a/crates/modular_core/src/poly.rs
+++ b/crates/modular_core/src/poly.rs
@@ -199,6 +199,11 @@ impl<const CAP: usize> crate::types::Connect for ArrayVec<Signal, CAP> {
             signal.collect_cables(sink);
         }
     }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        for signal in self.iter_mut() {
+            signal.inject_index_ptr(ptr);
+        }
+    }
 }
 
 impl PolySignal {

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -101,6 +101,7 @@ impl WellKnownModule {
             resolved: None,
             port: port.into(),
             channel,
+            index_ptr: std::ptr::null(),
         }
     }
 
@@ -382,8 +383,18 @@ pub trait Connect {
     /// (cables, buffer sources, table-internal signals) into `sink`.
     ///
     /// Used by graph_analysis to build SCC adjacency before module
-    /// construction
+    /// construction.
     fn collect_cables(&self, sink: &mut Vec<String>);
+
+    /// Walk this value and inject `ptr` as the back-pointer that every
+    /// `Signal::Cable` reads at sample-time to know which sample slot of
+    /// the upstream's `BlockPort` to fetch.
+    ///
+    /// `ptr` points to the consumer wrapper's per-block index `Cell<usize>`.
+    /// Containers forward; primitives and signal-free types are no-op via
+    /// their explicit impl. Every `Connect` impl must declare its behaviour
+    /// — same contract as `collect_cables`.
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>);
 }
 
 // ============================================================================
@@ -395,6 +406,7 @@ macro_rules! impl_connect_noop {
         $(impl Connect for $t {
             fn connect(&mut self, _patch: &Patch) {}
             fn collect_cables(&self, _sink: &mut Vec<String>) {}
+            fn inject_index_ptr(&mut self, _ptr: *const std::cell::Cell<usize>) {}
         })*
     };
 }
@@ -418,6 +430,11 @@ impl<T: Connect> Connect for Vec<T> {
             item.collect_cables(sink);
         }
     }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        for item in self {
+            item.inject_index_ptr(ptr);
+        }
+    }
 }
 
 impl<T: Connect> Connect for Option<T> {
@@ -431,6 +448,11 @@ impl<T: Connect> Connect for Option<T> {
             inner.collect_cables(sink);
         }
     }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        if let Some(inner) = self {
+            inner.inject_index_ptr(ptr);
+        }
+    }
 }
 
 impl<T: Connect> Connect for Box<T> {
@@ -439,6 +461,9 @@ impl<T: Connect> Connect for Box<T> {
     }
     fn collect_cables(&self, sink: &mut Vec<String>) {
         (**self).collect_cables(sink);
+    }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        (**self).inject_index_ptr(ptr);
     }
 }
 
@@ -451,6 +476,11 @@ impl<T: Connect, const N: usize> Connect for [T; N] {
     fn collect_cables(&self, sink: &mut Vec<String>) {
         for item in self {
             item.collect_cables(sink);
+        }
+    }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        for item in self {
+            item.inject_index_ptr(ptr);
         }
     }
 }
@@ -466,6 +496,11 @@ impl<V: Connect> Connect for std::collections::HashMap<String, V> {
             v.collect_cables(sink);
         }
     }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        for v in self.values_mut() {
+            v.inject_index_ptr(ptr);
+        }
+    }
 }
 
 impl<V: Connect> Connect for std::collections::BTreeMap<String, V> {
@@ -479,6 +514,11 @@ impl<V: Connect> Connect for std::collections::BTreeMap<String, V> {
             v.collect_cables(sink);
         }
     }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        for v in self.values_mut() {
+            v.inject_index_ptr(ptr);
+        }
+    }
 }
 
 // Tuples (arity 1-5)
@@ -488,6 +528,9 @@ impl<T1: Connect> Connect for (T1,) {
     }
     fn collect_cables(&self, sink: &mut Vec<String>) {
         self.0.collect_cables(sink);
+    }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        self.0.inject_index_ptr(ptr);
     }
 }
 
@@ -499,6 +542,10 @@ impl<T1: Connect, T2: Connect> Connect for (T1, T2) {
     fn collect_cables(&self, sink: &mut Vec<String>) {
         self.0.collect_cables(sink);
         self.1.collect_cables(sink);
+    }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        self.0.inject_index_ptr(ptr);
+        self.1.inject_index_ptr(ptr);
     }
 }
 
@@ -512,6 +559,11 @@ impl<T1: Connect, T2: Connect, T3: Connect> Connect for (T1, T2, T3) {
         self.0.collect_cables(sink);
         self.1.collect_cables(sink);
         self.2.collect_cables(sink);
+    }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        self.0.inject_index_ptr(ptr);
+        self.1.inject_index_ptr(ptr);
+        self.2.inject_index_ptr(ptr);
     }
 }
 
@@ -527,6 +579,12 @@ impl<T1: Connect, T2: Connect, T3: Connect, T4: Connect> Connect for (T1, T2, T3
         self.1.collect_cables(sink);
         self.2.collect_cables(sink);
         self.3.collect_cables(sink);
+    }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        self.0.inject_index_ptr(ptr);
+        self.1.inject_index_ptr(ptr);
+        self.2.inject_index_ptr(ptr);
+        self.3.inject_index_ptr(ptr);
     }
 }
 
@@ -546,6 +604,13 @@ impl<T1: Connect, T2: Connect, T3: Connect, T4: Connect, T5: Connect> Connect
         self.2.collect_cables(sink);
         self.3.collect_cables(sink);
         self.4.collect_cables(sink);
+    }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        self.0.inject_index_ptr(ptr);
+        self.1.inject_index_ptr(ptr);
+        self.2.inject_index_ptr(ptr);
+        self.3.inject_index_ptr(ptr);
+        self.4.inject_index_ptr(ptr);
     }
 }
 
@@ -979,6 +1044,9 @@ impl Connect for Wav {
     }
     fn collect_cables(&self, _sink: &mut Vec<String>) {
         // Wav references a file path, not a module — no graph edge.
+    }
+    fn inject_index_ptr(&mut self, _ptr: *const std::cell::Cell<usize>) {
+        // No cables — nothing to back-point.
     }
 }
 
@@ -1570,6 +1638,10 @@ impl Connect for Buffer {
         // `source_module` is a producer dependency, equivalent to a cable.
         sink.push(self.source_module.clone());
     }
+    fn inject_index_ptr(&mut self, _ptr: *const std::cell::Cell<usize>) {
+        // Buffer reads `BufferData` directly via cached pointer, not via a
+        // sample-indexed cable. No back-pointer needed.
+    }
 }
 
 impl std::fmt::Debug for Buffer {
@@ -1929,6 +2001,19 @@ pub enum Signal {
         port: String,
         /// Which channel of the output to read (0-indexed)
         channel: usize,
+        /// Back-pointer to the consumer wrapper's per-block sample-index
+        /// counter, populated during `connect()`. Read at sample-time to
+        /// know which slot of the upstream's `BlockPort` to fetch.
+        ///
+        /// Null when not yet connected (or after a disconnect). Reading
+        /// through a null pointer is UB, so consumers must check for the
+        /// null case before deref. Held as raw pointer because:
+        ///   1. The pointee is owned by the consumer wrapper, never the
+        ///      cable, so a borrow would be unsound across the audio
+        ///      thread boundary.
+        ///   2. The cable is `Clone` and `Send`; raw pointers satisfy both
+        ///      without further unsafe machinery.
+        index_ptr: *const std::cell::Cell<usize>,
     },
 }
 
@@ -1936,6 +2021,21 @@ pub enum Signal {
 // is only dereferenced from the audio thread after connection finishes, but `Signal` values still
 // need to cross from main-thread deserialization into audio-thread-owned params.
 unsafe impl Send for Signal {}
+
+impl Signal {
+    /// Build an unresolved `Signal::Cable`. The `resolved` and `index_ptr`
+    /// fields are populated later by `Connect::connect` and
+    /// `Connect::inject_index_ptr`.
+    pub fn cable(module: impl Into<String>, port: impl Into<String>, channel: usize) -> Self {
+        Signal::Cable {
+            module: module.into(),
+            resolved: None,
+            port: port.into(),
+            channel,
+            index_ptr: std::ptr::null(),
+        }
+    }
+}
 
 // Custom serde deserialization to allow a bare number as shorthand for volts.
 //
@@ -1988,6 +2088,7 @@ impl<'de> Deserialize<'de> for Signal {
                     resolved: None,
                     port,
                     channel,
+                    index_ptr: std::ptr::null(),
                 },
             }),
         }
@@ -2086,6 +2187,7 @@ impl<E: DeserializeError> deserr::Deserr<E> for Signal {
                             resolved: None,
                             port,
                             channel,
+                            index_ptr: std::ptr::null(),
                         })
                     }
                     Some(other) => Err(deserr::take_cf_content(E::error::<V>(
@@ -2221,6 +2323,13 @@ impl Connect for Signal {
     fn collect_cables(&self, sink: &mut Vec<String>) {
         if let Signal::Cable { module, .. } = self {
             sink.push(module.clone());
+        }
+    }
+    fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+        // Cable reads from upstream's BlockPort at sample index *ptr — store
+        // the back-pointer so `get_value(ch)` knows which slot to fetch.
+        if let Signal::Cable { index_ptr, .. } = self {
+            *index_ptr = ptr;
         }
     }
 }

--- a/crates/modular_core/tests/types_tests.rs
+++ b/crates/modular_core/tests/types_tests.rs
@@ -133,6 +133,7 @@ fn signal_deserialize_tagged_variants_still_work() {
             port,
             resolved,
             channel,
+            ..
         } => {
             assert_eq!(module, "m1");
             assert_eq!(port, "out");
@@ -149,12 +150,7 @@ fn signal_cable_connect_and_read() {
         Box::new(DummySampleable::new("m1", "dummy", [("out", 3.5)]));
     let patch = make_patch_with_sampleable(sampleable);
 
-    let mut s = Signal::Cable {
-        module: "m1".to_string(),
-        resolved: None,
-        port: "out".to_string(),
-        channel: 0,
-    };
+    let mut s = Signal::cable("m1", "out", 0);
 
     // Before connect, cable reads 0.0 because the cache is unresolved.
     approx_eq(s.get_value(), 0.0, 1e-6);
@@ -176,12 +172,7 @@ fn signal_cable_reconnect_to_missing_source_clears_resolved_and_reads_zero() {
     let patch = make_patch_with_sampleable(sampleable);
     let empty_patch = make_empty_patch();
 
-    let mut s = Signal::Cable {
-        module: "m1".to_string(),
-        resolved: None,
-        port: "out".to_string(),
-        channel: 0,
-    };
+    let mut s = Signal::cable("m1", "out", 0);
 
     s.connect(&patch);
     approx_eq(s.get_value(), 3.5, 1e-6);
@@ -204,12 +195,7 @@ fn signal_cable_reconnect_to_replacement_source_rebinds_resolved_and_reads_new_v
     let first_patch = make_patch_with_sampleable(first);
     let second_patch = make_patch_with_sampleable(second);
 
-    let mut s = Signal::Cable {
-        module: "m1".to_string(),
-        resolved: None,
-        port: "out".to_string(),
-        channel: 0,
-    };
+    let mut s = Signal::cable("m1", "out", 0);
 
     s.connect(&first_patch);
     let first_resolved = match &s {
@@ -320,12 +306,7 @@ fn collect_cables_volts_emits_nothing() {
 #[test]
 fn collect_cables_cable_emits_module_id() {
     use modular_core::types::Connect;
-    let s = Signal::Cable {
-        module: "OSC1".to_string(),
-        resolved: None,
-        port: "out".to_string(),
-        channel: 0,
-    };
+    let s = Signal::cable("OSC1", "out", 0);
     let mut sink = Vec::new();
     s.collect_cables(&mut sink);
     assert_eq!(sink, vec!["OSC1".to_string()]);
@@ -336,18 +317,8 @@ fn collect_cables_container_forwarding() {
     use modular_core::types::Connect;
     let signals: Vec<Signal> = vec![
         Signal::Volts(0.0),
-        Signal::Cable {
-            module: "A".into(),
-            resolved: None,
-            port: "out".into(),
-            channel: 0,
-        },
-        Signal::Cable {
-            module: "B".into(),
-            resolved: None,
-            port: "trig".into(),
-            channel: 1,
-        },
+        Signal::cable("A", "out", 0),
+        Signal::cable("B", "trig", 1),
     ];
     let mut sink = Vec::new();
     signals.collect_cables(&mut sink);
@@ -378,12 +349,7 @@ fn collect_cables_table_with_signal_cable() {
     use modular_core::poly::PolySignal;
     use modular_core::types::{Connect, Table};
     let table = Table::Bend {
-        amount: PolySignal::mono(Signal::Cable {
-            module: "LFO".into(),
-            resolved: None,
-            port: "out".into(),
-            channel: 0,
-        }),
+        amount: PolySignal::mono(Signal::cable("LFO", "out", 0)),
     };
     let mut sink = Vec::new();
     table.collect_cables(&mut sink);
@@ -397,20 +363,10 @@ fn collect_cables_table_pipe_recurses() {
     // Pipe(Bend{amount: cable→A}, Sync{ratio: cable→B})
     let table = Table::Pipe {
         first: Box::new(Table::Bend {
-            amount: PolySignal::mono(Signal::Cable {
-                module: "A".into(),
-                resolved: None,
-                port: "out".into(),
-                channel: 0,
-            }),
+            amount: PolySignal::mono(Signal::cable("A", "out", 0)),
         }),
         second: Box::new(Table::Sync {
-            ratio: PolySignal::mono(Signal::Cable {
-                module: "B".into(),
-                resolved: None,
-                port: "out".into(),
-                channel: 0,
-            }),
+            ratio: PolySignal::mono(Signal::cable("B", "out", 0)),
         }),
     };
     let mut sink = Vec::new();
@@ -424,4 +380,104 @@ fn collect_cables_table_identity_emits_nothing() {
     let mut sink = Vec::new();
     Table::Identity.collect_cables(&mut sink);
     assert!(sink.is_empty());
+}
+
+#[test]
+fn inject_index_ptr_sets_field_on_cable() {
+    use modular_core::types::Connect;
+    use std::cell::Cell;
+
+    let cell = Cell::new(7usize);
+    let ptr: *const Cell<usize> = &cell;
+
+    let mut s = Signal::cable("m1", "out", 0);
+    s.inject_index_ptr(ptr);
+
+    match &s {
+        Signal::Cable { index_ptr, .. } => {
+            assert!(!index_ptr.is_null());
+            // Round-trip through the pointer to confirm it points at our cell.
+            let read = unsafe { (*(*index_ptr)).get() };
+            assert_eq!(read, 7);
+        }
+        _ => panic!("expected Signal::Cable"),
+    }
+}
+
+#[test]
+fn inject_index_ptr_noop_on_volts() {
+    use modular_core::types::Connect;
+    use std::cell::Cell;
+
+    let cell = Cell::new(0usize);
+    let mut s = Signal::Volts(2.5);
+    s.inject_index_ptr(&cell);
+    // Volts has no `index_ptr` field — call must be a no-op (just verify it
+    // doesn't panic, and that the value is preserved).
+    match s {
+        Signal::Volts(v) => assert_eq!(v, 2.5),
+        _ => panic!("expected Signal::Volts"),
+    }
+}
+
+#[test]
+fn inject_index_ptr_through_polysignal_reaches_inner_cables() {
+    use modular_core::poly::PolySignal;
+    use modular_core::types::Connect;
+    use std::cell::Cell;
+
+    let cell = Cell::new(42usize);
+    let ptr: *const Cell<usize> = &cell;
+
+    let mut poly = PolySignal::poly(&[
+        Signal::cable("A", "out", 0),
+        Signal::Volts(1.0),
+        Signal::cable("B", "trig", 1),
+    ]);
+    poly.inject_index_ptr(ptr);
+
+    // Both cable channels should now point at our cell.
+    for ch in 0..poly.channels() {
+        if let Some(Signal::Cable { index_ptr, .. }) = poly.get(ch) {
+            assert!(!index_ptr.is_null());
+            assert_eq!(unsafe { (*(*index_ptr)).get() }, 42);
+        }
+    }
+}
+
+#[test]
+fn inject_index_ptr_through_table_pipe_reaches_nested_cables() {
+    use modular_core::poly::PolySignal;
+    use modular_core::types::{Connect, Table};
+    use std::cell::Cell;
+
+    let cell = Cell::new(99usize);
+    let ptr: *const Cell<usize> = &cell;
+
+    let mut table = Table::Pipe {
+        first: Box::new(Table::Bend {
+            amount: PolySignal::mono(Signal::cable("A", "out", 0)),
+        }),
+        second: Box::new(Table::Sync {
+            ratio: PolySignal::mono(Signal::cable("B", "out", 0)),
+        }),
+    };
+    table.inject_index_ptr(ptr);
+
+    // Reach into nested cables and verify both got the pointer.
+    if let Table::Pipe { first, second } = &table {
+        for inner in [first.as_ref(), second.as_ref()] {
+            let cable = match inner {
+                Table::Bend { amount } => amount.get(0),
+                Table::Sync { ratio } => ratio.get(0),
+                _ => panic!("unexpected inner variant"),
+            };
+            if let Some(Signal::Cable { index_ptr, .. }) = cable {
+                assert!(!index_ptr.is_null());
+                assert_eq!(unsafe { (*(*index_ptr)).get() }, 99);
+            } else {
+                panic!("expected Cable inside table");
+            }
+        }
+    }
 }

--- a/crates/modular_derive/src/connect.rs
+++ b/crates/modular_derive/src/connect.rs
@@ -72,13 +72,14 @@ fn parse_default_connection_attr(attr: &Attribute) -> syn::Result<DefaultConnect
 }
 
 /// Per-struct-field codegen: emits `default_connection` defaulting plus
-/// `connect` and `collect_cables` calls. Used by both struct-with-named-fields
-/// and per-variant logic (variant fields don't carry `default_connection`).
+/// `connect`, `collect_cables`, and `inject_index_ptr` calls. Used by
+/// struct-with-named-fields (variant fields don't carry `default_connection`).
 fn emit_field_named_struct(
     field: &syn::Field,
     default_stmts: &mut TokenStream2,
     connect_stmts: &mut TokenStream2,
     collect_cables_stmts: &mut TokenStream2,
+    inject_index_stmts: &mut TokenStream2,
 ) -> Result<(), syn::Error> {
     let Some(field_ident) = &field.ident else {
         return Ok(());
@@ -158,11 +159,14 @@ fn emit_field_named_struct(
     collect_cables_stmts.extend(quote_spanned! {field.span()=>
         crate::types::Connect::collect_cables(&self.#field_ident, sink);
     });
+    inject_index_stmts.extend(quote_spanned! {field.span()=>
+        crate::types::Connect::inject_index_ptr(&mut self.#field_ident, ptr);
+    });
 
     Ok(())
 }
 
-/// For one enum variant, build (pattern, connect-body, collect-body) tokens.
+/// For one enum variant, build (connect-arm, collect-arm, inject-arm) tokens.
 /// Bindings are named `field_<ident>` for named fields and `field_<n>` for unnamed.
 fn emit_variant_arms(
     enum_name: &Ident,
@@ -184,17 +188,17 @@ fn emit_variant_arms(
     match &variant.fields {
         Fields::Unit => {
             let pat = quote! { #enum_name::#var_name };
-            let pat_ref = quote! { #enum_name::#var_name };
             Ok((
                 quote! { #pat => {} },
-                quote! { #pat_ref => {} },
-                quote! { #pat_ref => {} },
+                quote! { #pat => {} },
+                quote! { #pat => {} },
             ))
         }
         Fields::Named(fields) => {
             let mut binds = Vec::new();
             let mut connect_calls = TokenStream2::new();
             let mut collect_calls = TokenStream2::new();
+            let mut inject_calls = TokenStream2::new();
             for f in fields.named.iter() {
                 let ident = f.ident.clone().expect("named field");
                 binds.push(ident.clone());
@@ -204,20 +208,22 @@ fn emit_variant_arms(
                 collect_calls.extend(quote_spanned! {f.span()=>
                     crate::types::Connect::collect_cables(#ident, sink);
                 });
+                inject_calls.extend(quote_spanned! {f.span()=>
+                    crate::types::Connect::inject_index_ptr(#ident, ptr);
+                });
             }
-            // For `connect` we need `&mut`; for `collect_cables` we need `&`.
-            let connect_pat = quote! { #enum_name::#var_name { #(#binds),* } };
-            let collect_pat = quote! { #enum_name::#var_name { #(#binds),* } };
+            let pat = quote! { #enum_name::#var_name { #(#binds),* } };
             Ok((
-                quote! { #connect_pat => { #connect_calls } },
-                quote! { #collect_pat => { #collect_calls } },
-                quote! { #connect_pat => {} },
+                quote! { #pat => { #connect_calls } },
+                quote! { #pat => { #collect_calls } },
+                quote! { #pat => { #inject_calls } },
             ))
         }
         Fields::Unnamed(fields) => {
             let mut binds = Vec::new();
             let mut connect_calls = TokenStream2::new();
             let mut collect_calls = TokenStream2::new();
+            let mut inject_calls = TokenStream2::new();
             for (i, f) in fields.unnamed.iter().enumerate() {
                 let ident = Ident::new(&format!("field_{}", i), Span::call_site());
                 binds.push(ident.clone());
@@ -227,13 +233,15 @@ fn emit_variant_arms(
                 collect_calls.extend(quote_spanned! {f.span()=>
                     crate::types::Connect::collect_cables(#ident, sink);
                 });
+                inject_calls.extend(quote_spanned! {f.span()=>
+                    crate::types::Connect::inject_index_ptr(#ident, ptr);
+                });
             }
-            let connect_pat = quote! { #enum_name::#var_name(#(#binds),*) };
-            let collect_pat = quote! { #enum_name::#var_name(#(#binds),*) };
+            let pat = quote! { #enum_name::#var_name(#(#binds),*) };
             Ok((
-                quote! { #connect_pat => { #connect_calls } },
-                quote! { #collect_pat => { #collect_calls } },
-                quote! { #connect_pat => {} },
+                quote! { #pat => { #connect_calls } },
+                quote! { #pat => { #collect_calls } },
+                quote! { #pat => { #inject_calls } },
             ))
         }
     }
@@ -242,12 +250,14 @@ fn emit_variant_arms(
 pub fn impl_connect_macro(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;
 
-    let (default_connection_stmts, connect_body, collect_cables_body) = match &ast.data {
+    let (default_connection_stmts, connect_body, collect_cables_body, inject_index_body) =
+        match &ast.data {
         Data::Struct(data) => match &data.fields {
             Fields::Named(fields) => {
                 let mut default_stmts = TokenStream2::new();
                 let mut connect_stmts = TokenStream2::new();
                 let mut collect_cables_stmts = TokenStream2::new();
+                let mut inject_index_stmts = TokenStream2::new();
 
                 for field in fields.named.iter() {
                     if let Err(e) = emit_field_named_struct(
@@ -255,12 +265,13 @@ pub fn impl_connect_macro(ast: &DeriveInput) -> TokenStream {
                         &mut default_stmts,
                         &mut connect_stmts,
                         &mut collect_cables_stmts,
+                        &mut inject_index_stmts,
                     ) {
                         return e.to_compile_error().into();
                     }
                 }
 
-                (default_stmts, connect_stmts, collect_cables_stmts)
+                (default_stmts, connect_stmts, collect_cables_stmts, inject_index_stmts)
             }
             Fields::Unnamed(_) | Fields::Unit => {
                 return syn::Error::new(
@@ -274,13 +285,16 @@ pub fn impl_connect_macro(ast: &DeriveInput) -> TokenStream {
         Data::Enum(data) => {
             let mut connect_arms = TokenStream2::new();
             let mut collect_arms = TokenStream2::new();
+            let mut inject_arms = TokenStream2::new();
             for variant in data.variants.iter() {
                 match emit_variant_arms(name, variant) {
-                    Ok((c_arm, cc_arm, _)) => {
+                    Ok((c_arm, cc_arm, ii_arm)) => {
                         connect_arms.extend(c_arm);
                         connect_arms.extend(quote! { , });
                         collect_arms.extend(cc_arm);
                         collect_arms.extend(quote! { , });
+                        inject_arms.extend(ii_arm);
+                        inject_arms.extend(quote! { , });
                     }
                     Err(e) => return e.to_compile_error().into(),
                 }
@@ -289,6 +303,7 @@ pub fn impl_connect_macro(ast: &DeriveInput) -> TokenStream {
                 TokenStream2::new(),
                 quote! { match self { #connect_arms } },
                 quote! { match self { #collect_arms } },
+                quote! { match self { #inject_arms } },
             )
         }
         Data::Union(_) => {
@@ -308,6 +323,9 @@ pub fn impl_connect_macro(ast: &DeriveInput) -> TokenStream {
             }
             fn collect_cables(&self, sink: &mut Vec<String>) {
                 #collect_cables_body
+            }
+            fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
+                #inject_index_body
             }
         }
     };


### PR DESCRIPTION
## Summary

PR2a of the dynamic-buffer-processing split. Foundational infrastructure for sample-indexed cable reads in the upcoming block-buffered runtime. Pure addition — no caller invokes \`inject_index_ptr\` yet, so the field is always null at runtime. **Zero behavioural delta on master.**

## Why

In the block-buffered model, each consumer wrapper will hold a per-block sample index \`Cell<usize>\` that advances as it processes its block. Cables embedded in the consumer's params need to know which sample slot of the upstream's \`BlockPort\` to read at any moment. The cleanest path is for each cable to hold a back-pointer to the consumer's index Cell and dereference it inline during \`Signal::get_value\`.

## What's added

- \`Signal::Cable.index_ptr: *const Cell<usize>\` — back-pointer set by \`connect()\`. Null until injected.
- \`Signal::cable(module, port, channel)\` canonical constructor — defaults \`resolved\` and \`index_ptr\` to \`None\`/\`null\`.
- \`Connect::inject_index_ptr(&mut self, ptr)\` — required trait method, parallel to \`collect_cables\`. Walks the params struct and writes the pointer into every embedded \`Signal::Cable\`.

## Implementations

- All container impls (\`Vec\`, \`Option\`, \`Box\`, \`[T;N]\`, \`HashMap\`, \`BTreeMap\`, tuples 1-5) and the \`ArrayVec<Signal, CAP>\` generic forward.
- \`Signal::Cable\` writes the field; \`Signal::Volts\` is a no-op.
- \`Wav\`/\`Buffer\`/\`InterpolationType\`/\`IntervalScaleParam\`/\`IntervalPatternParam\`/\`SeqPatternParam\`/\`Arc<MathCompiled>\`/\`ScaleParam\` are no-op (hold no cables themselves).
- \`#[derive(Connect)]\` emits \`inject_index_ptr\` body alongside \`connect\` and \`collect_cables\`, for both struct and enum forms.

## Tests

4 new cases in \`types_tests.rs\` (now 23 total):

- \`inject_index_ptr_sets_field_on_cable\` — direct override on Signal::Cable
- \`inject_index_ptr_noop_on_volts\` — Volts variant unaffected
- \`inject_index_ptr_through_polysignal_reaches_inner_cables\` — ArrayVec forwarding
- \`inject_index_ptr_through_table_pipe_reaches_nested_cables\` — \`Box<Table>\` recursive forwarding through derived enum impl

Cable construction sites in tests + \`audio.rs\` converted to use \`Signal::cable(...)\` helper. Pattern matches on Cable use \`..\` where they don't need the new field.

## Test plan

- [x] \`cargo test -p modular_core -p modular -p modular_derive\` green (61 modular, 599 modular_core, 23 types_tests, 6 block_outputs, 29 dsp_fresh)
- [x] \`cargo build\` clean
- [ ] Reviewer confirms zero impact on audio path

## Behaviour delta on master

Zero. The field is set but no consumer reads it yet; \`Signal::get_value\` still uses the existing \`get_poly_sample\` API. The wrapper proc-macro rewrite that calls \`inject_index_ptr\` and the \`Sampleable\` trait flip that consumes \`index_ptr\` land in the next PR.

## Follow-ups

- PR2b: Sampleable trait flip + wrapper rewrite + 5-arg \`SampleableConstructor\` + DSP module updates
- PR3: Audio callback rewrite + integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)