### PR TITLE
refactor(derive): 1-sample-delay reentrancy guard in wrapper

### DIFF
--- a/crates/modular_derive/src/module_attr.rs
+++ b/crates/modular_derive/src/module_attr.rs
@@ -789,17 +789,24 @@ fn impl_module_macro_attr(
             }
 
             fn get_value_at(&self, port: &str, ch: usize, index: usize) -> f32 {
-                // Reentrancy: block-mode module is mid-computation and a cycle
-                // has read back into it. Return the previous slot's value so
-                // feedback delay stays exactly 1 sample regardless of block size.
-                if self.computing.get() && index >= self.index.get() {
-                    let cur = self.index.get();
-                    let prev = if cur == 0 { self.block_size.saturating_sub(1).max(0) } else { cur - 1 };
-                    let outputs = unsafe { &*self.block_outputs.get() };
-                    let port_idx = match <#block_outputs_ty>::port_index(port) {
-                        Some(i) => i,
-                        None => return 0.0,
+                let port_idx = match <#block_outputs_ty>::port_index(port) {
+                    Some(i) => i,
+                    None => return 0.0,
+                };
+                // Reentrancy: a cycle has read back into this module while
+                // it is mid-computation. Return the slot one step *behind*
+                // the requested one (wrapping at the block boundary) so the
+                // feedback path sees exactly a 1-sample delay regardless of
+                // block size. Slots not yet written this block still hold
+                // the previous block's data, which preserves the 1-sample
+                // invariant across the boundary.
+                if self.computing.get() {
+                    let prev = if index == 0 {
+                        self.block_size.saturating_sub(1)
+                    } else {
+                        index - 1
                     };
+                    let outputs = unsafe { &*self.block_outputs.get() };
                     return outputs.get_at(port_idx, ch, prev);
                 }
                 match self.mode {
@@ -816,10 +823,6 @@ fn impl_module_macro_attr(
                     }
                 }
                 let outputs = unsafe { &*self.block_outputs.get() };
-                let port_idx = match <#block_outputs_ty>::port_index(port) {
-                    Some(i) => i,
-                    None => return 0.0,
-                };
                 outputs.get_at(port_idx, ch, index)
             }
 


### PR DESCRIPTION
PR4 kickoff. Aligns the block-buffered wrapper's reentrancy guard in `get_value_at` with the 1-sample-delay invariant the design relies on.

## The bug

PR3's guard fired only when the requested `index >= self.index.get()` (cursor) and returned `block_outputs[cursor - 1]` — a cursor-step delay, not a sample-step delay. For `block_size > 1` a feedback consumer reading a future slot would see a value N samples behind the requested time rather than 1.

## The fix

Match the feature-branch invariant: when the wrapper is mid-computation (`self.computing.get()`), always return the slot one step *behind the requested index*, wrapping at the block boundary.

```rust
if self.computing.get() {
    let prev = if index == 0 {
        self.block_size.saturating_sub(1)
    } else {
        index - 1
    };
    return outputs.get_at(port_idx, ch, prev);
}
```

Slots that haven't been written this block still hold the previous block's data, which preserves the 1-sample-prior semantics across the block boundary.

## Why now

Today `block_size = 1` everywhere, so the two variants collapse to the same behaviour and PR3's guard didn't cause an observable bug. PR4's audio-callback rewrite is what makes `block_size > 1` actually reachable, so the correct invariant needs to be in place before that lands.

## Tests

All 616 pre-existing tests green. `buffer_feedback_cycle_propagates_through_delay_read` still converges to the geometric steady state.

One pre-existing failure on master (`dsp::test_overlap::tests::test_overlapping_names_panics`) — same as PR3.

## Follow-ups still in PR4 scope

- Strip legacy `tick` / `update` / `get_poly_sample` from `Sampleable` once audio.rs migrates to `get_value_at`
- Reintroduce `start_block` / `tick_buffers` / `inject_audio_in_block` / `_block_index` alongside their actual callers in the audio rewrite
- Drop the `starting_idx` snapshot in wrapper.update once the legacy CAS guard goes away

🤖 Generated with [Claude Code](https://claude.com/claude-code)