### PR TITLE
refactor(clock): flip external sync API to ExternalClockState

### DIFF
--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1598,10 +1598,20 @@ impl AudioProcessor {
     // 1. Sync Link state into ROOT_CLOCK and run its block. The trigger
     //    outputs need to be live before we inspect them for queued patch
     //    swaps below.
+    //
+    // We're past the `is_stopped` early-return, so the Operator-local
+    // transport is playing — set `playing: true` in the injected state.
+    // Once the block-aware audio callback lands and ROOT_CLOCK eager-fills
+    // per sample, this will pick up the peer's actual `is_playing` from
+    // the Link session state instead.
     let root_clock = self.patch.sampleables.get(&*ROOT_CLOCK_ID);
     self.link.sync_frame(|bar_phase, tempo| {
       if let Some(clock) = root_clock {
-        clock.sync_external_clock(bar_phase, tempo);
+        clock.sync_external_clock(modular_core::types::ExternalClockState {
+          bar_phase,
+          bpm: tempo,
+          playing: true,
+        });
       }
     });
 

--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1299,6 +1299,11 @@ struct AudioProcessor {
   /// callbacks. Initialised to `block_size` so the first cpal frame
   /// triggers block-level work immediately.
   block_pos: usize,
+  /// Pre-allocated scratch buffer for one internal block's worth of host
+  /// audio input. Filled at the block boundary from `input_reader` and
+  /// injected into `HiddenAudioIn` via `inject_audio_in_block`. Sized to
+  /// `block_size` once in `new()` so the audio thread never allocates.
+  input_block_scratch: Vec<[f32; PORT_MAX_CHANNELS]>,
   /// Ableton Link integration (audio-thread side). Owns the live
   /// `rusty_link` resources when active and exposes only RT-safe operations.
   link: crate::link::LinkState,
@@ -1327,6 +1332,7 @@ impl AudioProcessor {
       sample_rate,
       block_size,
       block_pos: block_size,
+      input_block_scratch: vec![[0.0f32; PORT_MAX_CHANNELS]; block_size],
       link: crate::link::LinkState::new(),
     }
   }
@@ -1592,6 +1598,37 @@ impl AudioProcessor {
       for (key, buffer) in scope_adds {
         scope_collection.insert(key, buffer);
       }
+    }
+  }
+
+  /// Pull host audio input from `input_reader` and inject it into
+  /// `HiddenAudioIn` once per internal block. Called by the cpal callback
+  /// before `process_frame`, so the block-level work inside `process_frame`
+  /// sees up-to-date per-slot input.
+  ///
+  /// At a block boundary while running, pulls `block_size` cpal frames in
+  /// one tight loop and hands them to `HiddenAudioIn` via
+  /// `inject_audio_in_block`. Mid-block (running) does nothing — the same
+  /// block has already been injected. While stopped, drains one cpal frame
+  /// to keep the ring buffer flowing; the audio thread never injects so
+  /// inner modules don't react to ghost input.
+  fn before_process_frame(&mut self, input_reader: &mut InputBufferReader) {
+    use modular_core::types::WellKnownModule;
+    if self.is_stopped() {
+      let _ = input_reader.read_frame();
+      return;
+    }
+    if self.block_pos < self.block_size {
+      return;
+    }
+    for slot in self.input_block_scratch.iter_mut() {
+      let frame = input_reader.read_frame();
+      for ch in 0..PORT_MAX_CHANNELS {
+        slot[ch] = frame[ch] * AUDIO_INPUT_GAIN;
+      }
+    }
+    if let Some(audio_in) = self.patch.sampleables.get(WellKnownModule::HiddenAudioIn.id()) {
+      audio_in.inject_audio_in_block(&self.input_block_scratch);
     }
   }
 
@@ -1869,18 +1906,9 @@ where
           {
             profiling::scope!("process_frames");
             for frame in output.chunks_mut(num_channels) {
-              // Read from the input buffer and update audio_in
-              {
-                let mut audio_in = audio_processor.patch.audio_in.lock();
-                let input_samples = input_reader.read_frame();
-
-                // Set channel count so that get() returns values instead of 0.0
-                audio_in.set_channels(PORT_MAX_CHANNELS);
-                for i in 0..PORT_MAX_CHANNELS {
-                  // Apply gain to bring input from [-1, 1] to [-5, 5] volt range
-                  audio_in.set(i, input_samples[i] * AUDIO_INPUT_GAIN);
-                }
-              }
+              // Pull host input + inject into HiddenAudioIn once per
+              // internal block, before block-level work runs.
+              audio_processor.before_process_frame(&mut input_reader);
 
               // Process frame and get multi-channel output
               let samples = final_state_processor

--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1661,6 +1661,9 @@ impl AudioProcessor {
     // Advance Link's in-buffer frame index on every cpal frame; only sync
     // ROOT_CLOCK at the block boundary.
     let should_sync_clock = at_block_boundary;
+    // 1. Sync Link state into ROOT_CLOCK and run its block. The trigger
+    //    outputs need to be live before we inspect them for queued patch
+    //    swaps below.
     let root_clock = self.patch.sampleables.get(&*ROOT_CLOCK_ID);
     self.link.sync_frame(|bar_phase, tempo| {
       if should_sync_clock
@@ -1669,7 +1672,6 @@ impl AudioProcessor {
         clock.sync_external_clock(modular_core::types::ExternalClockState {
           bar_phase,
           bpm: tempo,
-          playing: true,
         });
       }
     });

--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1291,6 +1291,14 @@ struct AudioProcessor {
   transport_meter: Arc<TransportMeter>,
   /// Sample rate of the audio stream
   sample_rate: f32,
+  /// Internal block size used for module construction (matches the
+  /// `block_size` each wrapper allocates `BlockPort`s for). The audio
+  /// callback drains `block_size` cpal frames per block-level pass.
+  block_size: usize,
+  /// Position within the current internal block. Persists across CPAL
+  /// callbacks. Initialised to `block_size` so the first cpal frame
+  /// triggers block-level work immediately.
+  block_pos: usize,
   /// Ableton Link integration (audio-thread side). Owns the live
   /// `rusty_link` resources when active and exposes only RT-safe operations.
   link: crate::link::LinkState,
@@ -1303,6 +1311,7 @@ impl AudioProcessor {
     garbage_tx: GarbageProducer,
     shared: AudioSharedState,
     sample_rate: f32,
+    block_size: usize,
   ) -> Self {
     Self {
       patch: Patch::new(),
@@ -1316,6 +1325,8 @@ impl AudioProcessor {
       queued_update: None,
       transport_meter: shared.transport_meter,
       sample_rate,
+      block_size,
+      block_pos: block_size,
       link: crate::link::LinkState::new(),
     }
   }
@@ -1584,29 +1595,40 @@ impl AudioProcessor {
     }
   }
 
-  /// Process a single frame, returning multi-channel output
+  /// Process one cpal frame. At a block boundary (`block_pos >= block_size`)
+  /// this runs the heavy block-level work (link sync, ROOT_CLOCK update,
+  /// queued patch swap, `ensure_processed` on every module, transport-meter
+  /// write) and resets the cursor; otherwise it just reads the pre-computed
+  /// output at the current slot. `link.sync_frame` advances the in-buffer
+  /// frame index on every call so Link's timeline stays accurate, but the
+  /// closure body only fires at block boundaries — ROOT_CLOCK is synced
+  /// once per block. Per-sample eager-fill of ROOT_CLOCK lands separately.
   fn process_frame(&mut self, num_channels: usize) -> [f32; PORT_MAX_CHANNELS] {
     use modular_core::types::{ROOT_CLOCK_ID, ROOT_ID};
     profiling::scope!("process_frame");
 
     let mut output = [0.0f32; PORT_MAX_CHANNELS];
 
+    let at_block_boundary = self.block_pos >= self.block_size;
+
     if self.is_stopped() {
-      return output; // Skip processing when stopped
+      // Keep block alignment after a stop/start cycle by forcing the next
+      // unmuted frame to start a fresh block.
+      self.block_pos = self.block_size;
+      // Still advance Link's frame counter so the timeline stays in sync
+      // with cpal frames consumed by the silence path.
+      self.link.sync_frame(|_bar_phase, _tempo| {});
+      return output;
     }
 
-    // 1. Sync Link state into ROOT_CLOCK and run its block. The trigger
-    //    outputs need to be live before we inspect them for queued patch
-    //    swaps below.
-    //
-    // We're past the `is_stopped` early-return, so the Operator-local
-    // transport is playing — set `playing: true` in the injected state.
-    // Once the block-aware audio callback lands and ROOT_CLOCK eager-fills
-    // per sample, this will pick up the peer's actual `is_playing` from
-    // the Link session state instead.
+    // Advance Link's in-buffer frame index on every cpal frame; only sync
+    // ROOT_CLOCK at the block boundary.
+    let should_sync_clock = at_block_boundary;
     let root_clock = self.patch.sampleables.get(&*ROOT_CLOCK_ID);
     self.link.sync_frame(|bar_phase, tempo| {
-      if let Some(clock) = root_clock {
+      if should_sync_clock
+        && let Some(clock) = root_clock
+      {
         clock.sync_external_clock(modular_core::types::ExternalClockState {
           bar_phase,
           bpm: tempo,
@@ -1615,97 +1637,109 @@ impl AudioProcessor {
       }
     });
 
-    for module in self.patch.sampleables.values() {
-      module.start_block();
-    }
-    if let Some(root_clock) = self.patch.sampleables.get(&*ROOT_CLOCK_ID) {
-      root_clock.ensure_processed();
-    }
+    if at_block_boundary {
+      profiling::scope!("process_block");
+      self.block_pos = 0;
 
-    // 2. Check queued update trigger against ROOT_CLOCK outputs.
-    let should_apply = if let Some((_, trigger)) = self.queued_update.as_ref() {
-      match trigger {
-        QueuedTrigger::Immediate => true,
-        QueuedTrigger::NextBar => self
-          .patch
-          .sampleables
-          .get(&*ROOT_CLOCK_ID)
-          .map(|c| c.get_value_at("barTrigger", 0, 0) >= 1.0)
-          .unwrap_or(true),
-        QueuedTrigger::NextBeat => self
-          .patch
-          .sampleables
-          .get(&*ROOT_CLOCK_ID)
-          .map(|c| c.get_value_at("beatTrigger", 0, 0) >= 1.0)
-          .unwrap_or(true),
-      }
-    } else {
-      false
-    };
-
-    // 3. If triggered, apply the patch update.
-    if should_apply {
-      let (update, _) = self.queued_update.take().unwrap();
-      let applied_id = update.update_id;
-      self.apply_patch_update(update);
-      self.transport_meter.write_applied_update_id(applied_id);
-      // Newly-constructed modules need a fresh block reset before their
-      // first ensure_processed below.
       for module in self.patch.sampleables.values() {
         module.start_block();
       }
-    }
-
-    // 4. Drive every module to completion (idempotent; ROOT_CLOCK and any
-    //    cable-pulled modules short-circuit on `self.index >= block_size`).
-    {
-      profiling::scope!("ensure_processed");
-      for module in self.patch.sampleables.values() {
-        module.ensure_processed();
+      if let Some(root_clock) = self.patch.sampleables.get(&*ROOT_CLOCK_ID) {
+        root_clock.ensure_processed();
       }
-    }
 
-    // 4.5 Write transport state from ROOT_CLOCK outputs.
-    {
-      let has_queued = self.queued_update.is_some();
-      if let Some(clock) = self.patch.sampleables.get(&*ROOT_CLOCK_ID) {
-        let bar_phase = clock.get_value_at("playhead", 0, 0) as f64;
-        let bar_count = clock.get_value_at("playhead", 1, 0) as u64;
-        let beat_in_bar = clock.get_value_at("beatInBar", 0, 0) as u32;
-        let is_playing = !self.is_stopped();
-        self.transport_meter.write_from_audio(
-          bar_phase,
-          bar_count,
-          beat_in_bar,
-          is_playing,
-          has_queued,
-        );
+      // Check queued update trigger against ROOT_CLOCK outputs. At
+      // `block_size > 1` the trigger may fire on any slot within the
+      // block, so scan every slot rather than just slot 0. Latency is
+      // bounded by `block_size` samples (still sub-millisecond at the
+      // default 64-sample block @ 48 kHz).
+      let block_size = self.block_size;
+      let should_apply = if let Some((_, trigger)) = self.queued_update.as_ref() {
+        match trigger {
+          QueuedTrigger::Immediate => true,
+          QueuedTrigger::NextBar => self
+            .patch
+            .sampleables
+            .get(&*ROOT_CLOCK_ID)
+            .map(|c| (0..block_size).any(|slot| c.get_value_at("barTrigger", 0, slot) >= 1.0))
+            .unwrap_or(true),
+          QueuedTrigger::NextBeat => self
+            .patch
+            .sampleables
+            .get(&*ROOT_CLOCK_ID)
+            .map(|c| (0..block_size).any(|slot| c.get_value_at("beatTrigger", 0, slot) >= 1.0))
+            .unwrap_or(true),
+        }
       } else {
-        self
-          .transport_meter
-          .write_from_audio(0.0, 0, 0, false, has_queued);
+        false
+      };
+
+      if should_apply {
+        let (update, _) = self.queued_update.take().unwrap();
+        let applied_id = update.update_id;
+        self.apply_patch_update(update);
+        self.transport_meter.write_applied_update_id(applied_id);
+        // Newly-constructed modules need a fresh block reset before
+        // their first ensure_processed below.
+        for module in self.patch.sampleables.values() {
+          module.start_block();
+        }
+      }
+
+      {
+        profiling::scope!("ensure_processed");
+        for module in self.patch.sampleables.values() {
+          module.ensure_processed();
+        }
+      }
+
+      // Write transport state from ROOT_CLOCK outputs (slot 0 of the new
+      // block; meter doesn't need per-sample precision).
+      {
+        let has_queued = self.queued_update.is_some();
+        if let Some(clock) = self.patch.sampleables.get(&*ROOT_CLOCK_ID) {
+          let bar_phase = clock.get_value_at("playhead", 0, 0) as f64;
+          let bar_count = clock.get_value_at("playhead", 1, 0) as u64;
+          let beat_in_bar = clock.get_value_at("beatInBar", 0, 0) as u32;
+          let is_playing = !self.is_stopped();
+          self.transport_meter.write_from_audio(
+            bar_phase,
+            bar_count,
+            beat_in_bar,
+            is_playing,
+            has_queued,
+          );
+        } else {
+          self
+            .transport_meter
+            .write_from_audio(0.0, 0, 0, false, has_queued);
+        }
       }
     }
 
-    // Capture audio for scopes.
+    let slot = self.block_pos;
+
+    // Capture audio for scopes at this slot.
     {
       profiling::scope!("capture_scopes");
       let mut scope_lock = self.scope_collection.lock();
       for (key, scope_buffer) in scope_lock.iter_mut() {
         if let Some(module) = self.patch.sampleables.get(&key.module_id) {
-          let sample = module.get_value_at(&key.port_name, key.channel as usize, 0);
+          let sample = module.get_value_at(&key.port_name, key.channel as usize, slot);
           scope_buffer.push(sample);
         }
       }
     }
 
-    // Get output from root module.
+    // Get output from root module at this slot.
     if let Some(root) = self.patch.sampleables.get(&*ROOT_ID) {
       for ch in 0..num_channels.min(PORT_MAX_CHANNELS) {
-        output[ch] = root.get_value_at(&ROOT_OUTPUT_PORT, ch, 0) * AUDIO_OUTPUT_ATTENUATION;
+        output[ch] =
+          root.get_value_at(&ROOT_OUTPUT_PORT, ch, slot) * AUDIO_OUTPUT_ATTENUATION;
       }
     }
 
+    self.block_pos += 1;
     output
   }
 
@@ -1752,6 +1786,7 @@ pub fn make_stream<T>(
   garbage_tx: GarbageProducer,
   shared: AudioSharedState,
   mut input_reader: InputBufferReader,
+  block_size: usize,
 ) -> Result<cpal::Stream>
 where
   T: SizedSample + FromSample<f32> + hound::Sample,
@@ -1770,8 +1805,14 @@ where
 
   // Create the audio processor that owns the patch
   let sample_rate = config.sample_rate as f32;
-  let mut audio_processor =
-    AudioProcessor::new(command_rx, error_tx, garbage_tx, shared, sample_rate);
+  let mut audio_processor = AudioProcessor::new(
+    command_rx,
+    error_tx,
+    garbage_tx,
+    shared,
+    sample_rate,
+    block_size,
+  );
 
   let mut final_state_processor = FinalStateProcessor::new(num_channels);
 
@@ -2408,6 +2449,7 @@ mod tests {
       garbage_producer,
       shared,
       44100.0,
+      1,
     );
 
     // Processor starts with empty patch (may have hidden audio_in)
@@ -2605,6 +2647,7 @@ mod tests {
       garbage_producer,
       shared,
       44100.0,
+      1,
     );
 
     (cmd_producer, processor)

--- a/crates/modular/src/lib.rs
+++ b/crates/modular/src/lib.rs
@@ -664,6 +664,7 @@ fn build_output_stream(
   garbage_tx: GarbageProducer,
   shared: AudioSharedState,
   input_reader: InputBufferReader,
+  block_size: usize,
 ) -> Result<cpal::Stream> {
   match sample_format {
     cpal::SampleFormat::I8 => make_stream::<i8>(
@@ -674,6 +675,7 @@ fn build_output_stream(
       garbage_tx,
       shared,
       input_reader,
+      block_size,
     ),
     cpal::SampleFormat::I16 => make_stream::<i16>(
       device,
@@ -683,6 +685,7 @@ fn build_output_stream(
       garbage_tx,
       shared,
       input_reader,
+      block_size,
     ),
     cpal::SampleFormat::I32 => make_stream::<i32>(
       device,
@@ -692,6 +695,7 @@ fn build_output_stream(
       garbage_tx,
       shared,
       input_reader,
+      block_size,
     ),
     cpal::SampleFormat::F32 => make_stream::<f32>(
       device,
@@ -701,6 +705,7 @@ fn build_output_stream(
       garbage_tx,
       shared,
       input_reader,
+      block_size,
     ),
     _ => Err(napi::Error::from_reason(format!(
       "Unsupported output sample format: {:?}",
@@ -772,12 +777,19 @@ fn setup_streams(params: StreamSetupParams) -> Result<StreamSetupResult> {
   let (command_tx, command_rx, error_tx, error_rx, garbage_tx, garbage_rx) =
     create_audio_channels();
 
-  // Create audio state handle (main thread side).
+  // Internal block size. The audio callback drains `block_size` cpal
+  // frames per block-level pass (link sync, queued patch swap,
+  // `ensure_processed` on every module, transport-meter write). CPAL's
+  // own buffer size is independent — the callback handles any count of
+  // cpal frames per invocation, splitting them across internal blocks
+  // via `block_pos`.
   //
-  // `block_size = 1` keeps the audio callback running per-sample. The
-  // block-aware callback rewrite (and the CPAL-driven `block_size` value
-  // that comes with it) lands separately; for now this just plumbs the
-  // field through the constructor surface so module creation can use it.
+  // 64 samples @ 48 kHz = ~1.33 ms per block. Chosen as a balance
+  // between block-amortised CPU savings and per-bar-trigger jitter
+  // (triggers fire at block granularity until per-sample eager-fill of
+  // ROOT_CLOCK lands).
+  const BLOCK_SIZE: usize = 64;
+
   let state = Arc::new(AudioState::new_with_channels(
     command_tx,
     error_rx,
@@ -785,7 +797,7 @@ fn setup_streams(params: StreamSetupParams) -> Result<StreamSetupResult> {
     params.sample_rate as f32,
     channels,
     params.midi_manager.clone(),
-    1,
+    BLOCK_SIZE,
   ));
 
   // Get shared state for audio processor
@@ -811,6 +823,7 @@ fn setup_streams(params: StreamSetupParams) -> Result<StreamSetupResult> {
     garbage_tx,
     shared,
     input_reader,
+    BLOCK_SIZE,
   )?;
 
   output_stream

--- a/crates/modular_core/src/dsp/core/audio_in.rs
+++ b/crates/modular_core/src/dsp/core/audio_in.rs
@@ -2,20 +2,67 @@
 //!
 //! This module allows reading audio from the system's audio input device.
 
+use std::cell::UnsafeCell;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
 
 use crate::{
     Sampleable,
-    poly::PolyOutput,
+    poly::{PORT_MAX_CHANNELS, PolyOutput},
     types::{MessageHandler, WellKnownModule},
 };
 
-#[derive(Default)]
+/// Upper bound on per-block input frames the module can store. Pre-allocated
+/// once so the audio thread never touches the heap on `inject_audio_in_block`.
+const AUDIO_IN_MAX_BLOCK: usize = 4096;
+
+/// Hidden audio-input module. The audio callback pulls one CPAL frame per
+/// slot of the current internal block into `block` via
+/// `inject_audio_in_block`, and consumers read per-slot values via
+/// `get_value_at(_, ch, slot)`.
 pub struct AudioIn {
+    /// Shared with `Patch::audio_in` so `Patch::insert_audio_in` can
+    /// reconstruct the module pointing at the patch's `Arc<Mutex<PolyOutput>>`.
+    /// Held but unused for sample reads now that `block` is the source of
+    /// truth — kept for backwards-compat with existing `Patch` construction.
     pub input: Arc<Mutex<PolyOutput>>,
+    /// Per-block input frames, one entry per slot, each holding all
+    /// channels. Layout mirrors `BlockPort`: `block[sample_index][channel_index]`.
+    ///
+    /// Heap-allocated (`Box<[_]>`) so that constructing `AudioIn` does not
+    /// push a 256 KB array through the stack. `Patch::insert_audio_in` runs
+    /// on the CoreAudio IO thread (stack ≈ 512 KB), and a stack-resident
+    /// `[[f32; 16]; 4096]` temp would overflow the guard page → SIGBUS.
+    ///
+    /// # Safety
+    ///
+    /// Accessed only from the audio thread:
+    ///   - Written during `inject_audio_in_block` (block boundary, before
+    ///     any module processing).
+    ///   - Read during `get_value_at` (inside module processing).
+    /// These phases are serialised on the same thread — no concurrent access.
+    block: UnsafeCell<Box<[[f32; PORT_MAX_CHANNELS]]>>,
+    /// Number of valid samples in `block` (= current internal block size).
+    block_len: UnsafeCell<usize>,
 }
+
+fn make_empty_block() -> Box<[[f32; PORT_MAX_CHANNELS]]> {
+    vec![[0.0f32; PORT_MAX_CHANNELS]; AUDIO_IN_MAX_BLOCK].into_boxed_slice()
+}
+
+impl Default for AudioIn {
+    fn default() -> Self {
+        Self {
+            input: Arc::new(Mutex::new(PolyOutput::default())),
+            block: UnsafeCell::new(make_empty_block()),
+            block_len: UnsafeCell::new(0),
+        }
+    }
+}
+
+// SAFETY: See `block` field documentation above.
+unsafe impl Sync for AudioIn {}
 
 impl Sampleable for AudioIn {
     fn get_id(&self) -> &str {
@@ -28,23 +75,47 @@ impl Sampleable for AudioIn {
 
     fn connect(&self, _patch: &crate::Patch) {}
 
-    /// Reset the per-block cursor. `AudioIn`'s input is a single snapshot
-    /// owned by the audio thread — there's nothing per-sample to advance.
     fn start_block(&self) {}
 
     fn ensure_processed_to(&self, _target: usize) {}
 
     fn ensure_processed(&self) {}
 
-    /// Snapshot read of the current host audio input frame. The audio
-    /// callback writes `self.input` once per block before pulling outputs,
-    /// so `get_value_at` returns the same value for every slot in a block.
-    fn get_value_at(&self, _port: &str, ch: usize, _index: usize) -> f32 {
-        self.input.lock().get(ch)
+    /// Store one block's worth of host input frames. `block.len()` is
+    /// clamped to `AUDIO_IN_MAX_BLOCK`.
+    fn inject_audio_in_block(&self, block: &[[f32; PORT_MAX_CHANNELS]]) {
+        let len = block.len().min(AUDIO_IN_MAX_BLOCK);
+        unsafe {
+            let stored = &mut *self.block.get();
+            stored[..len].copy_from_slice(&block[..len]);
+            *self.block_len.get() = len;
+        }
+    }
+
+    /// Per-slot read of the injected block. Returns 0.0 for out-of-range
+    /// slot/channel indices, including when no block has been injected yet.
+    fn get_value_at(&self, _port: &str, ch: usize, index: usize) -> f32 {
+        let len = unsafe { *self.block_len.get() };
+        if index >= len || ch >= PORT_MAX_CHANNELS {
+            return 0.0;
+        }
+        unsafe { (*self.block.get())[index][ch] }
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+impl AudioIn {
+    /// Construct an `AudioIn` sharing an existing `input` Arc. Used by
+    /// `Patch::insert_audio_in` to keep the legacy field hooked up.
+    pub fn with_input(input: Arc<Mutex<PolyOutput>>) -> Self {
+        Self {
+            input,
+            block: UnsafeCell::new(make_empty_block()),
+            block_len: UnsafeCell::new(0),
+        }
     }
 }
 

--- a/crates/modular_core/src/dsp/core/audio_in.rs
+++ b/crates/modular_core/src/dsp/core/audio_in.rs
@@ -3,13 +3,10 @@
 //! This module allows reading audio from the system's audio input device.
 
 use std::cell::UnsafeCell;
-use std::sync::Arc;
-
-use parking_lot::Mutex;
 
 use crate::{
     Sampleable,
-    poly::{PORT_MAX_CHANNELS, PolyOutput},
+    poly::PORT_MAX_CHANNELS,
     types::{MessageHandler, WellKnownModule},
 };
 
@@ -22,11 +19,6 @@ const AUDIO_IN_MAX_BLOCK: usize = 4096;
 /// `inject_audio_in_block`, and consumers read per-slot values via
 /// `get_value_at(_, ch, slot)`.
 pub struct AudioIn {
-    /// Shared with `Patch::audio_in` so `Patch::insert_audio_in` can
-    /// reconstruct the module pointing at the patch's `Arc<Mutex<PolyOutput>>`.
-    /// Held but unused for sample reads now that `block` is the source of
-    /// truth — kept for backwards-compat with existing `Patch` construction.
-    pub input: Arc<Mutex<PolyOutput>>,
     /// Per-block input frames, one entry per slot, each holding all
     /// channels. Layout mirrors `BlockPort`: `block[sample_index][channel_index]`.
     ///
@@ -54,7 +46,6 @@ fn make_empty_block() -> Box<[[f32; PORT_MAX_CHANNELS]]> {
 impl Default for AudioIn {
     fn default() -> Self {
         Self {
-            input: Arc::new(Mutex::new(PolyOutput::default())),
             block: UnsafeCell::new(make_empty_block()),
             block_len: UnsafeCell::new(0),
         }
@@ -104,18 +95,6 @@ impl Sampleable for AudioIn {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
-    }
-}
-
-impl AudioIn {
-    /// Construct an `AudioIn` sharing an existing `input` Arc. Used by
-    /// `Patch::insert_audio_in` to keep the legacy field hooked up.
-    pub fn with_input(input: Arc<Mutex<PolyOutput>>) -> Self {
-        Self {
-            input,
-            block: UnsafeCell::new(make_empty_block()),
-            block_len: UnsafeCell::new(0),
-        }
     }
 }
 

--- a/crates/modular_core/src/dsp/core/clock.rs
+++ b/crates/modular_core/src/dsp/core/clock.rs
@@ -22,11 +22,6 @@ struct ClockParams {
 struct ExternalClockSync {
     bar_phase: f64,
     bpm: f64,
-    /// Peer-driven playing state. `false` short-circuits the inner update —
-    /// no phase advance, no trigger outputs — so a peer Stop on the Link
-    /// session reads as silence here without the audio thread having to
-    /// gate ROOT_CLOCK separately.
-    playing: bool,
 }
 
 struct ClockState {
@@ -115,7 +110,6 @@ impl Clock {
         self.state.external_sync = Some(ExternalClockSync {
             bar_phase: state.bar_phase,
             bpm: state.bpm,
-            playing: state.playing,
         });
     }
 
@@ -126,19 +120,6 @@ impl Clock {
     fn update(&mut self, sample_rate: f32) {
         // External clock sync: override free-running clock with Link data.
         if let Some(sync) = self.state.external_sync.take() {
-            // Peer transport stopped — freeze phase, zero triggers, return.
-            // The audio thread's separate `stopped` flag still gates whether
-            // process_frame runs at all; this path covers the case where
-            // ROOT_CLOCK is being eager-filled by the callback but the
-            // peer's Link session is paused.
-            if !sync.playing {
-                self.state.running = false;
-                self.outputs.bar_trigger = 0.0;
-                self.outputs.beat_trigger = 0.0;
-                self.outputs.ppq_trigger = 0.0;
-                return;
-            }
-
             self.state.running = true;
             self.params.tempo = sync.bpm;
 
@@ -630,7 +611,6 @@ mod tests {
         c.sync_external_clock_impl(ExternalClockState {
             bar_phase: 0.75,
             bpm: 140.0,
-            playing: true,
         });
         c.update(sr);
 
@@ -658,7 +638,6 @@ mod tests {
             c.sync_external_clock_impl(ExternalClockState {
                 bar_phase,
                 bpm: 120.0,
-                playing: true,
             });
             c.update(sr);
 
@@ -685,7 +664,6 @@ mod tests {
         c.sync_external_clock_impl(ExternalClockState {
             bar_phase: 0.5,
             bpm: 120.0,
-            playing: true,
         });
         c.update(sr);
 

--- a/crates/modular_core/src/dsp/core/clock.rs
+++ b/crates/modular_core/src/dsp/core/clock.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 
 use crate::PolyOutput;
 use crate::dsp::utils::{SchmittTrigger, TempGate, TempGateState, min_gate_samples};
-use crate::types::ClockMessages;
+use crate::types::{ClockMessages, ExternalClockState};
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
 #[serde(rename_all = "camelCase")]
@@ -22,6 +22,11 @@ struct ClockParams {
 struct ExternalClockSync {
     bar_phase: f64,
     bpm: f64,
+    /// Peer-driven playing state. `false` short-circuits the inner update —
+    /// no phase advance, no trigger outputs — so a peer Stop on the Link
+    /// session reads as silence here without the audio thread having to
+    /// gate ROOT_CLOCK separately.
+    playing: bool,
 }
 
 struct ClockState {
@@ -103,8 +108,15 @@ message_handlers!(impl Clock {
 });
 
 impl Clock {
-    pub fn sync_external_clock(&mut self, bar_phase: f64, bpm: f64) {
-        self.state.external_sync = Some(ExternalClockSync { bar_phase, bpm });
+    /// Inject one sample's worth of Link transport state. Called by the
+    /// audio callback before each inner `update`, so the clock can resolve
+    /// triggers on the exact sample boundary the peer's timeline lands on.
+    pub fn sync_external_clock_impl(&mut self, state: ExternalClockState) {
+        self.state.external_sync = Some(ExternalClockSync {
+            bar_phase: state.bar_phase,
+            bpm: state.bpm,
+            playing: state.playing,
+        });
     }
 
     pub fn clear_external_sync(&mut self) {
@@ -113,9 +125,20 @@ impl Clock {
 
     fn update(&mut self, sample_rate: f32) {
         // External clock sync: override free-running clock with Link data.
-        // Whether the clock produces output is gated by the enclosing
-        // Operator `stopped` flag, not by the peer's playing state.
         if let Some(sync) = self.state.external_sync.take() {
+            // Peer transport stopped — freeze phase, zero triggers, return.
+            // The audio thread's separate `stopped` flag still gates whether
+            // process_frame runs at all; this path covers the case where
+            // ROOT_CLOCK is being eager-filled by the callback but the
+            // peer's Link session is paused.
+            if !sync.playing {
+                self.state.running = false;
+                self.outputs.bar_trigger = 0.0;
+                self.outputs.beat_trigger = 0.0;
+                self.outputs.ppq_trigger = 0.0;
+                return;
+            }
+
             self.state.running = true;
             self.params.tempo = sync.bpm;
 
@@ -604,7 +627,11 @@ mod tests {
         assert!(free_phase > 0.0);
 
         // Now sync to a specific phase externally
-        c.sync_external_clock(0.75, 140.0);
+        c.sync_external_clock_impl(ExternalClockState {
+            bar_phase: 0.75,
+            bpm: 140.0,
+            playing: true,
+        });
         c.update(sr);
 
         // Phase should be near 0.75 (the externally-set value), not free-running
@@ -628,7 +655,11 @@ mod tests {
 
         for i in 0..samples_per_bar {
             let bar_phase = i as f64 / samples_per_bar as f64;
-            c.sync_external_clock(bar_phase, 120.0);
+            c.sync_external_clock_impl(ExternalClockState {
+                bar_phase,
+                bpm: 120.0,
+                playing: true,
+            });
             c.update(sr);
 
             let is_high = c.outputs.beat_trigger == 5.0;
@@ -651,7 +682,11 @@ mod tests {
         let sr = 48_000.0;
 
         // Sync externally
-        c.sync_external_clock(0.5, 120.0);
+        c.sync_external_clock_impl(ExternalClockState {
+            bar_phase: 0.5,
+            bpm: 120.0,
+            playing: true,
+        });
         c.update(sr);
 
         // Clear external sync

--- a/crates/modular_core/src/patch.rs
+++ b/crates/modular_core/src/patch.rs
@@ -4,9 +4,6 @@
 //! connected audio modules. The patch contains sampleable modules and tracks
 //! that can be processed to generate audio.
 
-use parking_lot::Mutex;
-
-use crate::PolyOutput;
 use crate::dsp::core::audio_in::AudioIn;
 use crate::types::{
     Message, MessageTag, ROOT_ID, ROOT_OUTPUT_PORT, Sampleable, SampleableMap, WavData,
@@ -18,7 +15,6 @@ use std::sync::Arc;
 
 /// The core patch structure containing the DSP graph
 pub struct Patch {
-    pub audio_in: Arc<Mutex<PolyOutput>>,
     pub sampleables: SampleableMap,
     pub wav_data: HashMap<String, Arc<WavData>>,
     message_listeners: HashMap<MessageTag, Vec<String>>,
@@ -28,16 +24,13 @@ impl Patch {
     /// Create a new empty patch
     pub fn new() -> Self {
         let mut sampleables: SampleableMap = Default::default();
-        let audio_in_sampleable: AudioIn = Default::default();
-        let audio_in = audio_in_sampleable.input.clone();
+        let audio_in_sampleable = AudioIn::default();
 
         sampleables.insert(
             audio_in_sampleable.get_id().to_string(),
             Box::new(audio_in_sampleable),
         );
-        println!("sampleables {:?}", sampleables.keys());
         let mut patch = Patch {
-            audio_in,
             sampleables,
             wav_data: HashMap::new(),
             message_listeners: HashMap::new(),
@@ -49,7 +42,7 @@ impl Patch {
     /// Re-insert the AudioIn module into sampleables.
     /// Called after sampleables.clear() to restore the hidden audio input module.
     pub fn insert_audio_in(&mut self) {
-        let audio_in_sampleable = AudioIn::with_input(self.audio_in.clone());
+        let audio_in_sampleable = AudioIn::default();
         let id = WellKnownModule::HiddenAudioIn.id().to_string();
         self.sampleables.insert(id, Box::new(audio_in_sampleable));
     }

--- a/crates/modular_core/src/patch.rs
+++ b/crates/modular_core/src/patch.rs
@@ -49,9 +49,7 @@ impl Patch {
     /// Re-insert the AudioIn module into sampleables.
     /// Called after sampleables.clear() to restore the hidden audio input module.
     pub fn insert_audio_in(&mut self) {
-        let audio_in_sampleable = AudioIn {
-            input: self.audio_in.clone(),
-        };
+        let audio_in_sampleable = AudioIn::with_input(self.audio_in.clone());
         let id = WellKnownModule::HiddenAudioIn.id().to_string();
         self.sampleables.insert(id, Box::new(audio_in_sampleable));
     }

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -178,8 +178,6 @@ pub struct ExternalClockState {
     pub bar_phase: f64,
     /// Tempo in BPM.
     pub bpm: f64,
-    /// Whether the Link session is playing.
-    pub playing: bool,
 }
 
 pub trait Sampleable: MessageHandler + Send {

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -189,9 +189,13 @@ pub trait Sampleable: MessageHandler + Send {
     /// Called after the patch is updated and all modules are connected.
     /// Modules can override this to refresh caches or perform other post-update work.
     fn on_patch_update(&self) {}
-    /// Provide external clock synchronization data.
-    /// Only ROOT_CLOCK overrides this. Default: no-op.
-    fn sync_external_clock(&self, _bar_phase: f64, _bpm: f64) {}
+    /// Inject one sample's worth of external clock state. Only ROOT_CLOCK's
+    /// wrapper overrides this (via the `#[module(clock_sync)]` attribute);
+    /// every other module is a no-op. Called per sample by the audio
+    /// callback's eager-fill loop so the inner [`crate::dsp::core::clock::Clock`]
+    /// can resolve trigger crossings on the exact sample boundary the
+    /// peer's Link timeline lands on.
+    fn sync_external_clock(&self, _state: ExternalClockState) {}
     /// Clear external clock synchronization, returning to free-running mode.
     fn clear_external_sync(&self) {}
 

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -199,6 +199,13 @@ pub trait Sampleable: MessageHandler + Send {
     /// Clear external clock synchronization, returning to free-running mode.
     fn clear_external_sync(&self) {}
 
+    /// Inject one block's worth of host audio input frames. Only
+    /// `HiddenAudioIn` overrides this; everyone else is a no-op. The audio
+    /// callback pulls one CPAL frame per slot into `block` and hands the
+    /// whole thing in once per internal block, so the inner module can
+    /// serve per-slot reads via `get_value_at(_, ch, slot)`.
+    fn inject_audio_in_block(&self, _block: &[[f32; crate::poly::PORT_MAX_CHANNELS]]) {}
+
     /// Reset the per-block sample cursor to 0 at the start of an internal
     /// `block_size` block. Cache slots in `block_outputs` keep their
     /// previous-block values for reentrancy reads until they are overwritten.

--- a/crates/modular_derive/src/module_attr.rs
+++ b/crates/modular_derive/src/module_attr.rs
@@ -559,9 +559,9 @@ fn impl_module_macro_attr(
     // Check for clock_sync flag
     let clock_sync_impl = if attr_args.clock_sync {
         quote! {
-            fn sync_external_clock(&self, bar_phase: f64, bpm: f64) {
+            fn sync_external_clock(&self, state: crate::types::ExternalClockState) {
                 let module = unsafe { &mut *self.module.get() };
-                module.sync_external_clock(bar_phase, bpm);
+                module.sync_external_clock_impl(state);
             }
 
             fn clear_external_sync(&self) {


### PR DESCRIPTION
## Summary

Stacks on [#79](https://github.com/HelveticaScenario/operator/pull/79). Flips \`Sampleable::sync_external_clock\` from \`(bar_phase: f64, bpm: f64)\` to \`(state: ExternalClockState)\`. The struct (already on master from PR1) bundles \`bar_phase\`, \`bpm\`, and a new \`playing\` flag.

## What changed

- **\`Clock::sync_external_clock\`** renamed to \`sync_external_clock_impl\` and takes \`ExternalClockState\`. When \`playing == false\` the inner update short-circuits: phase frozen, all triggers zeroed. Lets the block-aware audio callback (next PR) eager-fill ROOT_CLOCK during a peer Link Stop without spurious triggers.
- **Wrapper macro** \`clock_sync\` branch emits the trait method with the new signature and forwards to \`sync_external_clock_impl\`.
- **Audio callback** builds the struct with \`playing: true\` — we're past the \`is_stopped\` early-return at that point. Block-aware callback will inject the real per-sample \`playing\` from the Link session.
- Three \`Clock\` unit tests updated.

## Behavior change

None at the existing single-sample-per-callback path. \`playing: true\` always feeds an always-was-playing state into a flow already gated by Operator's local \`is_stopped\`.

## Test plan

- [x] \`cargo test -p modular_core --lib dsp::core::clock\` — 17/17
- [x] \`cargo test -p modular_core --lib\` — 614/615 (sole failure pre-existing \`test_overlapping_names_panics\`)
- [x] \`cargo test -p modular_core --tests\` — all green
- [x] \`cargo test -p modular -p modular_derive\` — 61/61

## Stack

- [#79](https://github.com/HelveticaScenario/operator/pull/79) (PR6: plumb block_size + ProcessingMode through patch construction)
- **this PR** (PR7a: external clock state API)
- PR7b (coming): block-aware audio callback (block_pos cursor, eager-fill ROOT_CLOCK, real block_size)
- PR8 (coming): DSP modules + wrapper additions
- PR9 (coming): cleanup + e2e baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)