### PR TITLE
refactor(clock): drop unused ExternalClockState::playing

### DIFF
--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1661,6 +1661,9 @@ impl AudioProcessor {
     // Advance Link's in-buffer frame index on every cpal frame; only sync
     // ROOT_CLOCK at the block boundary.
     let should_sync_clock = at_block_boundary;
+    // 1. Sync Link state into ROOT_CLOCK and run its block. The trigger
+    //    outputs need to be live before we inspect them for queued patch
+    //    swaps below.
     let root_clock = self.patch.sampleables.get(&*ROOT_CLOCK_ID);
     self.link.sync_frame(|bar_phase, tempo| {
       if should_sync_clock
@@ -1669,7 +1672,6 @@ impl AudioProcessor {
         clock.sync_external_clock(modular_core::types::ExternalClockState {
           bar_phase,
           bpm: tempo,
-          playing: true,
         });
       }
     });

--- a/crates/modular_core/src/dsp/core/clock.rs
+++ b/crates/modular_core/src/dsp/core/clock.rs
@@ -22,11 +22,6 @@ struct ClockParams {
 struct ExternalClockSync {
     bar_phase: f64,
     bpm: f64,
-    /// Peer-driven playing state. `false` short-circuits the inner update —
-    /// no phase advance, no trigger outputs — so a peer Stop on the Link
-    /// session reads as silence here without the audio thread having to
-    /// gate ROOT_CLOCK separately.
-    playing: bool,
 }
 
 struct ClockState {
@@ -115,7 +110,6 @@ impl Clock {
         self.state.external_sync = Some(ExternalClockSync {
             bar_phase: state.bar_phase,
             bpm: state.bpm,
-            playing: state.playing,
         });
     }
 
@@ -126,19 +120,6 @@ impl Clock {
     fn update(&mut self, sample_rate: f32) {
         // External clock sync: override free-running clock with Link data.
         if let Some(sync) = self.state.external_sync.take() {
-            // Peer transport stopped — freeze phase, zero triggers, return.
-            // The audio thread's separate `stopped` flag still gates whether
-            // process_frame runs at all; this path covers the case where
-            // ROOT_CLOCK is being eager-filled by the callback but the
-            // peer's Link session is paused.
-            if !sync.playing {
-                self.state.running = false;
-                self.outputs.bar_trigger = 0.0;
-                self.outputs.beat_trigger = 0.0;
-                self.outputs.ppq_trigger = 0.0;
-                return;
-            }
-
             self.state.running = true;
             self.params.tempo = sync.bpm;
 
@@ -630,7 +611,6 @@ mod tests {
         c.sync_external_clock_impl(ExternalClockState {
             bar_phase: 0.75,
             bpm: 140.0,
-            playing: true,
         });
         c.update(sr);
 
@@ -658,7 +638,6 @@ mod tests {
             c.sync_external_clock_impl(ExternalClockState {
                 bar_phase,
                 bpm: 120.0,
-                playing: true,
             });
             c.update(sr);
 
@@ -685,7 +664,6 @@ mod tests {
         c.sync_external_clock_impl(ExternalClockState {
             bar_phase: 0.5,
             bpm: 120.0,
-            playing: true,
         });
         c.update(sr);
 

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -178,8 +178,6 @@ pub struct ExternalClockState {
     pub bar_phase: f64,
     /// Tempo in BPM.
     pub bpm: f64,
-    /// Whether the Link session is playing.
-    pub playing: bool,
 }
 
 pub trait Sampleable: MessageHandler + Send {


### PR DESCRIPTION
## Summary

Stacks on [#83](https://github.com/HelveticaScenario/operator/pull/83). The \`playing\` flag on \`ExternalClockState\` was plumbed in [#80](https://github.com/HelveticaScenario/operator/pull/80) as a way to gate ROOT_CLOCK's trigger output across a peer Link Stop. Operator's transport is fully decoupled from peer Link state (peers never start/stop Operator), so the audio callback always passes \`playing: true\` and the inner short-circuit path in \`Clock::update\` is never reached.

Drop the dead surface.

## What changed

- **\`ExternalClockState\`** loses \`pub playing: bool\`.
- **\`Clock::ExternalClockSync\`** loses \`playing: bool\`; the \`if !sync.playing { ... return; }\` short-circuit in \`Clock::update\` is gone.
- **Audio callback** drops \`playing: true\` from the ROOT_CLOCK sync state constructor and the stale "playing" prose from the surrounding comment.
- **Clock unit tests** drop \`playing: true\` from each \`ExternalClockState\` literal.

## Behavior change

None. The short-circuit path was never taken in production.

## Test plan

- [x] \`cargo build -p modular_core -p modular -p modular_derive\` clean
- [x] \`cargo test -p modular_core --lib\` — 614/615 (pre-existing fail)
- [x] \`cargo test -p modular_core --tests\` — 64/64
- [x] \`cargo test -p modular -p modular_derive\` — 61/61

## Stack

- [#79](https://github.com/HelveticaScenario/operator/pull/79) PR6
- [#80](https://github.com/HelveticaScenario/operator/pull/80) PR7a
- [#81](https://github.com/HelveticaScenario/operator/pull/81) PR7b
- [#82](https://github.com/HelveticaScenario/operator/pull/82) PR8
- [#83](https://github.com/HelveticaScenario/operator/pull/83) PR9
- **this PR** PR10: drop unused playing field

🤖 Generated with [Claude Code](https://claude.com/claude-code)