### PR TITLE
fix(buffer/delay): per-slot write/read cursor at block_size > 1

### DIFF
--- a/crates/modular_core/src/dsp/core/clock.rs
+++ b/crates/modular_core/src/dsp/core/clock.rs
@@ -345,6 +345,7 @@ impl Default for Clock {
             state: ClockState::default(),
             params: ClockParams::default(),
             _channel_count: 2,
+            _block_index: Default::default(),
         }
     }
 }

--- a/crates/modular_core/src/dsp/core/mix.rs
+++ b/crates/modular_core/src/dsp/core/mix.rs
@@ -203,6 +203,7 @@ mod tests {
             params,
             outputs,
             _channel_count: channels,
+            _block_index: Default::default(),
             state: MixState::default(),
         }
     }

--- a/crates/modular_core/src/dsp/fx/overdrive.rs
+++ b/crates/modular_core/src/dsp/fx/overdrive.rs
@@ -222,6 +222,7 @@ mod tests {
             params,
             outputs,
             _channel_count: 1,
+            _block_index: Default::default(),
             state: OverdriveState::default(),
         };
         od.init(48000.0);

--- a/crates/modular_core/src/dsp/oscillators/supersaw.rs
+++ b/crates/modular_core/src/dsp/oscillators/supersaw.rs
@@ -215,6 +215,7 @@ mod tests {
             params,
             outputs,
             _channel_count: channels,
+            _block_index: Default::default(),
             state: SupersawState::default(),
         }
     }

--- a/crates/modular_core/src/dsp/oscillators/wavetable.rs
+++ b/crates/modular_core/src/dsp/oscillators/wavetable.rs
@@ -245,6 +245,7 @@ mod tests {
             outputs,
             state: WavetableOscState::default(),
             _channel_count: channels,
+            _block_index: Default::default(),
         }
     }
 

--- a/crates/modular_core/src/dsp/seq/interval_seq.rs
+++ b/crates/modular_core/src/dsp/seq/interval_seq.rs
@@ -1068,6 +1068,7 @@ impl Default for IntervalSeq {
             state: IntervalSeqState::default(),
             params: IntervalSeqParams::default(),
             _channel_count: 4,
+            _block_index: Default::default(),
         }
     }
 }

--- a/crates/modular_core/src/dsp/utilities/buffer.rs
+++ b/crates/modular_core/src/dsp/utilities/buffer.rs
@@ -73,6 +73,20 @@ impl crate::types::OutputStruct for BufferWriteOutputs {
             _ => None,
         }
     }
+
+    /// Advance the circular buffer write position by `block_size` once per
+    /// internal block. Called from the wrapper's `start_block()` before
+    /// any per-sample `update()` runs, so `read_write_index()` becomes the
+    /// base offset for the new block — `BufferWrite::update` adds
+    /// `current_block_index()` for the per-slot write position.
+    fn tick_buffers(&mut self, block_size: usize) {
+        let frame_count = self.buffer.frame_count();
+        if frame_count == 0 {
+            return;
+        }
+        let new_index = self.buffer.read_write_index().wrapping_add(block_size);
+        self.buffer.set_write_index(new_index);
+    }
 }
 
 /// Manual `{Name}BlockOutputs` companion for `BufferWriteOutputs`. Mirrors
@@ -147,9 +161,12 @@ impl BufferWrite {
             return;
         }
 
-        let write_index = self.outputs.buffer.read_write_index().wrapping_add(1);
-        self.outputs.buffer.set_write_index(write_index);
-        let frame = write_index % frame_count;
+        // `tick_buffers` advanced the write cursor by `block_size` at the
+        // block boundary. Inside the per-sample loop the effective write
+        // position for slot `i` is `read_write_index() + i`.
+        let base = self.outputs.buffer.read_write_index();
+        let offset = self.current_block_index();
+        let frame = base.wrapping_add(offset) % frame_count;
         let buffer_channels = self.outputs.buffer.channel_count();
 
         for channel in 0..channels {
@@ -324,6 +341,7 @@ mod tests {
             params,
             outputs,
             _channel_count: channels,
+            _block_index: Default::default(),
         }
     }
 

--- a/crates/modular_core/src/dsp/utilities/delay.rs
+++ b/crates/modular_core/src/dsp/utilities/delay.rs
@@ -33,8 +33,14 @@ pub struct DelayRead {
 
 impl DelayRead {
     fn update(&mut self, sample_rate: f32) {
-        // Ensure the $buffer module has processed this block first.
-        self.params.buffer.ensure_source_updated();
+        // Drive the source up through this reader's current slot so the
+        // writer's per-slot cursor lands at the same position the reader
+        // is about to read. Calling `ensure_processed()` (full block)
+        // breaks feedback cycles: the writer races ahead of this reader's
+        // interleave and pulls stale `block_outputs` slots back via the
+        // 1-sample-delay reentrancy path.
+        let slot = self.current_block_index();
+        self.params.buffer.ensure_source_updated_to(slot + 1);
 
         // Effective write position for this slot = base (set by the
         // source's `tick_buffers` at block start) + `current_block_index`.
@@ -42,7 +48,7 @@ impl DelayRead {
         // the same delay position — 64× sample-and-hold artefact at
         // `block_size = 64`.
         let write_index =
-            (self.params.buffer.read_write_index() as f64) + (self.current_block_index() as f64);
+            (self.params.buffer.read_write_index() as f64) + (slot as f64);
         let frame_count = self.params.buffer.frame_count();
         let channels = self.channel_count();
 

--- a/crates/modular_core/src/dsp/utilities/delay.rs
+++ b/crates/modular_core/src/dsp/utilities/delay.rs
@@ -33,11 +33,16 @@ pub struct DelayRead {
 
 impl DelayRead {
     fn update(&mut self, sample_rate: f32) {
-        // Ensure the $buffer module has processed this frame first.
-        // This triggers $buffer.update() which writes the sample and increments write_index.
+        // Ensure the $buffer module has processed this block first.
         self.params.buffer.ensure_source_updated();
 
-        let write_index = self.params.buffer.read_write_index() as f64;
+        // Effective write position for this slot = base (set by the
+        // source's `tick_buffers` at block start) + `current_block_index`.
+        // Without the per-slot offset every slot in the block would read
+        // the same delay position — 64× sample-and-hold artefact at
+        // `block_size = 64`.
+        let write_index =
+            (self.params.buffer.read_write_index() as f64) + (self.current_block_index() as f64);
         let frame_count = self.params.buffer.frame_count();
         let channels = self.channel_count();
 

--- a/crates/modular_core/src/dsp/utilities/unison.rs
+++ b/crates/modular_core/src/dsp/utilities/unison.rs
@@ -120,6 +120,7 @@ mod tests {
             params,
             outputs,
             _channel_count: channels,
+            _block_index: Default::default(),
         }
     }
 

--- a/crates/modular_core/src/dsp/utilities/wrap.rs
+++ b/crates/modular_core/src/dsp/utilities/wrap.rs
@@ -80,6 +80,7 @@ mod tests {
                 max: PolySignal::mono(Signal::Volts(max)),
             },
             _channel_count: 1,
+            _block_index: Default::default(),
         };
         module.outputs.sample.set_channels(1);
         module.update(44100.0);

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -1486,12 +1486,19 @@ impl Buffer {
         self.cached_buffer.map(|ptr| unsafe { ptr.as_ref() })
     }
 
-    /// Ensure the source module has been updated this tick (demand-driven ordering).
-    /// This triggers the $buffer module's `update()` which writes the current sample
-    /// and increments write_index. Must be called before reading the buffer.
-    pub fn ensure_source_updated(&self) {
+    /// Ensure the source module has produced output up through (but not
+    /// including) sample `target` within the current internal block.
+    /// Demand-driven ordering — readers call this with their own current
+    /// slot + 1 so the source's write cursor lands at the same slot the
+    /// reader will read this iteration.
+    ///
+    /// Calling with the full `block_size` (the old behaviour) breaks
+    /// feedback cycles at `block_size > 1`: the source races ahead of the
+    /// reader's per-slot interleave and pulls stale `block_outputs` slots
+    /// from the reader via the 1-sample-delay reentrancy path.
+    pub fn ensure_source_updated_to(&self, target: usize) {
         if let Some(module_ptr) = self.cached_source_ptr {
-            unsafe { module_ptr.as_ref().ensure_processed() };
+            unsafe { module_ptr.as_ref().ensure_processed_to(target) };
         }
     }
 
@@ -3303,7 +3310,7 @@ mod tests {
         let mut buffer = Buffer::new("buf".to_string(), "buffer".to_string(), 1);
 
         buffer.connect(&patch);
-        buffer.ensure_source_updated();
+        buffer.ensure_source_updated_to(1);
 
         assert_eq!(update_count.load(Ordering::SeqCst), 1);
     }
@@ -3329,11 +3336,11 @@ mod tests {
         let mut buffer = Buffer::new("buf".to_string(), "buffer".to_string(), 1);
 
         buffer.connect(&patch);
-        buffer.ensure_source_updated();
+        buffer.ensure_source_updated_to(1);
         assert_eq!(update_count.load(Ordering::SeqCst), 1);
 
         buffer.connect(&empty_patch);
-        buffer.ensure_source_updated();
+        buffer.ensure_source_updated_to(1);
 
         assert!(buffer.cached_source_ptr.is_none());
         assert!(buffer.cached_buffer.is_none());
@@ -3346,7 +3353,7 @@ mod tests {
         let mut buffer = Buffer::new("buf".to_string(), "missing".to_string(), 1);
 
         buffer.connect(&patch);
-        buffer.ensure_source_updated();
+        buffer.ensure_source_updated_to(1);
 
         assert!(buffer.cached_source_ptr.is_none());
         assert!(buffer.cached_buffer.is_none());

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -2510,6 +2510,12 @@ pub trait OutputStruct: Default + Send + 'static {
     fn get_buffer_output(&self, _port: &str) -> Option<&BufferData> {
         None
     }
+    /// Advance any owned circular buffers by `block_size` once per internal
+    /// block. Called from the wrapper's `start_block()` before any per-sample
+    /// `update()` runs. Default: no-op. `BufferWrite` overrides this to bump
+    /// its write cursor by the block; inner `update` then offsets the
+    /// per-sample write position by `current_block_index()`.
+    fn tick_buffers(&mut self, _block_size: usize) {}
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/modular_derive/src/module_attr.rs
+++ b/crates/modular_derive/src/module_attr.rs
@@ -231,6 +231,19 @@ pub fn module_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
+    // Inject `_block_index: Cell<usize>` so inner DSP can read the current
+    // sample position within the block via `self.current_block_index()`.
+    // The wrapper's `ensure_processed_to` writes the slot index here before
+    // each `inner.update` call.
+    if let Data::Struct(ref mut data_struct) = ast.data {
+        if let Fields::Named(ref mut fields) = data_struct.fields {
+            let field: syn::Field = syn::parse_quote! {
+                pub _block_index: std::cell::Cell<usize>
+            };
+            fields.named.push(field);
+        }
+    }
+
     match impl_module_macro_attr(&ast, &attr_args) {
         Ok(generated) => {
             let mut output = quote!(#ast);
@@ -376,6 +389,9 @@ fn impl_module_macro_attr(
                                 "params" => Ok(quote! { params: *concrete_params }),
                                 "_channel_count" => {
                                     Ok(quote! { _channel_count: deserialized.channel_count })
+                                }
+                                "_block_index" => {
+                                    Ok(quote! { _block_index: Default::default() })
                                 }
                                 "outputs" | "state" => {
                                     Ok(quote! { #field_name: Default::default() })
@@ -665,6 +681,15 @@ fn impl_module_macro_attr(
             pub fn channel_count(&self) -> usize {
                 self._channel_count
             }
+
+            /// Returns the current sample slot index within the block being
+            /// processed. Only valid to call from inside `update()` — the
+            /// wrapper writes the slot index here before each per-sample
+            /// inner update.
+            #[inline]
+            pub fn current_block_index(&self) -> usize {
+                self._block_index.get()
+            }
         }
 
         /// Generated wrapper struct for audio-thread-only module access.
@@ -731,6 +756,17 @@ fn impl_module_macro_attr(
         impl crate::types::Sampleable for #struct_name {
             fn start_block(&self) {
                 self.index.set(0);
+                // Let modules with circular-buffer outputs (e.g. BufferWrite)
+                // advance their write cursor once per internal block. Inner
+                // `update` then offsets the per-sample write position by
+                // `current_block_index()`.
+                unsafe {
+                    let module = &mut *self.module.get();
+                    crate::types::OutputStruct::tick_buffers(
+                        &mut module.outputs,
+                        self.block_size,
+                    );
+                }
             }
 
             fn set_initial_index(&self, slot: usize) {
@@ -754,6 +790,13 @@ fn impl_module_macro_attr(
                     let i = self.index.get();
                     unsafe {
                         let module = &mut *self.module.get();
+                        // Expose the current slot index to the inner DSP
+                        // via `self.current_block_index()` before running
+                        // the per-sample update. Used by modules that
+                        // need slot-aware reads/writes against shared
+                        // resources (BufferWrite / DelayRead's circular
+                        // buffer cursor, etc).
+                        module._block_index.set(i);
                         module.update(self.sample_rate);
                         (*self.block_outputs.get()).copy_from_inner(&module.outputs, i);
                     }


### PR DESCRIPTION
## Summary

Stacks on PR6 (which now includes PR11 via merge). Fixes "bit reduction" / heavy sample-and-hold artefact in delay output at \`block_size = 64\`.

## The bug

At \`block_size > 1\`:
1. \`BufferWrite.update\` bumps \`write_index += 1\` per call, called 64× per block by the wrapper's \`ensure_processed_to\` loop.
2. \`DelayRead.update\` calls \`buffer.ensure_source_updated()\` which drives the source's FULL block (all 64 writes happen in one shot).
3. DelayRead's 64 per-slot calls then all read \`write_index - delay_frames\` — same position 64 times.

Result: every block of 64 output samples is the same delayed sample repeated 64×. Sounds like a 64× sample-and-hold / "bit reduction" effect on top of the delay.

## The fix

Give inner DSP access to the wrapper's per-slot index. BufferWrite writes to \`(base + slot)\`; DelayRead reads at \`(base + slot) - delay_frames\`. Both walk \`block_size\` distinct positions per block.

### Plumbing

- **\`_block_index: Cell<usize>\`** injected into every inner struct by the \`#[module]\` proc-macro (alongside the existing \`_channel_count\`). Wrapper's \`ensure_processed_to\` writes the current slot via \`module._block_index.set(i)\` before each per-sample \`inner.update\`.
- **\`current_block_index()\`** generated as an inline accessor on the inner module — returns the slot the wrapper is currently driving.
- **\`OutputStruct::tick_buffers(block_size)\`** added as a default-no-op trait method. Wrapper's \`start_block\` calls it before any per-sample work so modules with circular-buffer outputs advance their write cursor once per block instead of once per slot.

### DSP updates

- **\`BufferWrite\`** overrides \`tick_buffers\` to bump \`buffer.write_index += block_size\`. \`update()\` writes at \`(read_write_index() + current_block_index()) % frame_count\`.
- **\`DelayRead::update\`** reads at \`(read_write_index() + current_block_index()) - delay_frames\`, matching the writer's per-slot offset model.

Manual struct initializers (Clock, Mix, Overdrive, Wavetable, Supersaw, IntervalSeq, Unison, Wrap, BufferWrite, BufRead) gain \`_block_index: Default::default()\` in their \`Default\` impls — mechanical, follows the existing \`_channel_count\` pattern.

## Test plan

- [x] \`cargo build -p modular_core -p modular -p modular_derive\` clean
- [x] \`cargo test -p modular_core --lib\` — 614/614
- [x] \`cargo test -p modular_core --tests\` — 64/64
- [x] \`cargo test -p modular -p modular_derive\` — 61/61
- [x] Bumped \`TEST_BLOCK_SIZE\` to 8 in \`dsp_fresh_tests\` — all 35 tests still pass (verified buffer/delay block-aware behavior)
- [ ] End-to-end audio — \`$buffer($sine('c4')) >> $delayRead(0.2).out()\` should sound like a clean 200 ms delay, no granular/bit-reduced artefact

## Stack

- PR6 (#79) — block_size + ProcessingMode plumbing
- PR11 (#85, merged into PR6) — per-sample eager-fill + mid-block patch swap
- **this PR** — per-slot buffer/delay cursor (closes the bit-reduction regression introduced by PR7b's block_size=64 bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)