### PR TITLE
Phase 1: MonacoPatchEditor bug fixes

### DIFF
--- a/src/renderer/components/MonacoPatchEditor.tsx
+++ b/src/renderer/components/MonacoPatchEditor.tsx
@@ -322,6 +322,45 @@ export function MonacoPatchEditor({
         return 'javascript';
     }, [currentFile]);
 
+    // Memoize options so the @monaco-editor/react wrapper's [options] effect
+    // does not fire on every parent render (App.tsx re-renders at ~60Hz via
+    // the scope-polling RAF loop, which would otherwise cause a constant
+    // editor.updateOptions storm). Also: fixedOverflowWidgets lets the
+    // suggest widget escape the .app-main { overflow: hidden } clipping
+    // ancestor by reparenting to document.body.
+    const editorOptions = useMemo<editor.IStandaloneEditorConstructionOptions>(
+        () => ({
+            minimap: { enabled: false },
+            lineNumbers: 'on',
+            folding: false,
+            matchBrackets: 'always',
+            automaticLayout: true,
+            fontFamily: `${font}, monospace`,
+            fontLigatures: fontLigatures,
+            fontSize: fontSize,
+            // LineHeight: 1.6,
+            padding: { bottom: 8, top: 8 },
+            renderLineHighlight: 'line',
+            cursorBlinking: 'solid',
+            cursorStyle: cursorStyle,
+            scrollbar: {
+                horizontal: 'auto',
+                horizontalScrollbarSize: 8,
+                vertical: 'auto',
+                verticalScrollbarSize: 8,
+            },
+            overviewRulerBorder: false,
+            hideCursorInOverviewRuler: true,
+            renderLineHighlightOnlyWhenFocus: false,
+            guides: {
+                bracketPairs: false,
+                indentation: true,
+            },
+            fixedOverflowWidgets: true,
+        }),
+        [font, fontLigatures, fontSize, cursorStyle],
+    );
+
     return (
         <div className="patch-editor" style={{ height: '100%' }}>
             {currentFile && (
@@ -335,34 +374,8 @@ export function MonacoPatchEditor({
                         onChange(val ?? '');
                     }}
                     onMount={handleMount}
-                    options={{
-                        minimap: { enabled: false },
-                        lineNumbers: 'on',
-                        folding: false,
-                        matchBrackets: 'always',
-                        automaticLayout: true,
-                        fontFamily: `${font}, monospace`,
-                        fontLigatures: fontLigatures,
-                        fontSize: fontSize,
-                        // LineHeight: 1.6,
-                        padding: { bottom: 8, top: 8 },
-                        renderLineHighlight: 'line',
-                        cursorBlinking: 'solid',
-                        cursorStyle: cursorStyle,
-                        scrollbar: {
-                            horizontal: 'auto',
-                            horizontalScrollbarSize: 8,
-                            vertical: 'auto',
-                            verticalScrollbarSize: 8,
-                        },
-                        overviewRulerBorder: false,
-                        hideCursorInOverviewRuler: true,
-                        renderLineHighlightOnlyWhenFocus: false,
-                        guides: {
-                            bracketPairs: false,
-                            indentation: true,
-                        },
-                    }}
+                    keepCurrentModel
+                    options={editorOptions}
                 />
             )}
         </div>


### PR DESCRIPTION
## Summary
Three concrete user complaints, smallest shippable patch.

- **Cursor jump in dev mode** — `<Editor>` now gets `keepCurrentModel`; wrapper saves view state on StrictMode/HMR cleanup. Options object is `useMemo`d so the 60Hz `updateOptions` storm stops.
- **Autocomplete clipped by header** — `fixedOverflowWidgets:true` reparents the suggest widget out from under `.app-main { overflow:hidden }`.

Phase 1 of the editor modernization plan.

> **Note:** This PR's intended base is `feature/editorize`, which is not yet published to origin. Retarget once that branch is pushed. The diff against `master` is otherwise identical.

## Test plan
- [x] yarn typecheck (pre-existing unrelated ControlPanel.tsx error on feature/editorize; MonacoPatchEditor.tsx itself is clean)
- [x] yarn lint
- [x] yarn test:unit (179 passed)
- [ ] yarn start, observe cursor stays put through HMR
- [ ] yarn start, trigger suggest near top, observe it overlays header