### PR TITLE
Phase 2.1: command registry

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -36,6 +36,11 @@ import {
     scopeBufferKeyToString,
 } from './app/oscilloscope';
 import { useEditorBuffers } from './app/hooks/useEditorBuffers';
+import {
+    executeCommand,
+    registerCommand,
+    unregisterCommand,
+} from './keybindings/commands';
 
 /**
  * Transform validation errors to use source line numbers instead of module IDs
@@ -832,31 +837,128 @@ function App() {
         [closeBuffer],
     );
 
+    // Refs keep command handlers stable across renders so the registration
+    // effect below only needs to run once. Anything captured by closure must
+    // funnel through a ref or it goes stale between renders.
+    const activeBufferIdRef = useRef(activeBufferId);
     useEffect(() => {
-        const cleanupNewFile = electronAPI.onMenuNewFile(() => {
-            createUntitledFile();
-        });
-        const cleanupSave = electronAPI.onMenuSave(() => {
-            handleSaveFileRef.current();
-        });
-        const cleanupStop = electronAPI.onMenuStop(() => {
-            handleStopRef.current();
-        });
-        const cleanupUpdate = electronAPI.onMenuUpdatePatch(() => {
-            handleSubmitRef.current('NextBar');
-        });
-        const cleanupUpdateNextBeat = electronAPI.onMenuUpdatePatchNextBeat(
+        activeBufferIdRef.current = activeBufferId;
+    }, [activeBufferId]);
+
+    const handleCloseBufferRef = useRef(handleCloseBuffer);
+    useEffect(() => {
+        handleCloseBufferRef.current = handleCloseBuffer;
+    }, [handleCloseBuffer]);
+
+    const createUntitledFileRef = useRef(createUntitledFile);
+    useEffect(() => {
+        createUntitledFileRef.current = createUntitledFile;
+    }, [createUntitledFile]);
+
+    // Register operator.* commands in the global registry. The Electron menu
+    // IPC dispatchers below, the future cmdk palette (2.1a), the Radix context
+    // menu (2.1b), and the tinykeys keymap (2.3) all dispatch through
+    // `executeCommand` — single source of truth for what each command does.
+    useEffect(() => {
+        registerCommand(
+            'operator.updatePatch',
+            () => {
+                handleSubmitRef.current('NextBar');
+            },
+            { label: 'Update Patch', category: 'Patch' },
+        );
+        registerCommand(
+            'operator.updatePatchNextBeat',
             () => {
                 handleSubmitRef.current('NextBeat');
             },
+            { label: 'Update Patch (Next Beat)', category: 'Patch' },
+        );
+        registerCommand(
+            'operator.stop',
+            () => {
+                handleStopRef.current();
+            },
+            { label: 'Stop', category: 'Patch' },
+        );
+        registerCommand(
+            'operator.newFile',
+            () => {
+                createUntitledFileRef.current();
+            },
+            { label: 'New File', category: 'File' },
+        );
+        registerCommand(
+            'operator.closeBuffer',
+            () => {
+                const id = activeBufferIdRef.current;
+                if (id) {
+                    void handleCloseBufferRef.current(id);
+                }
+            },
+            { label: 'Close Buffer', category: 'File' },
+        );
+        registerCommand(
+            'operator.save',
+            () => {
+                handleSaveFileRef.current();
+            },
+            { label: 'Save', category: 'File' },
+        );
+        registerCommand(
+            'operator.openWorkspace',
+            () => {
+                handleOpenWorkspaceRef.current();
+            },
+            { label: 'Open Workspace…', category: 'File' },
+        );
+        registerCommand(
+            'operator.openSettings',
+            () => {
+                setIsSettingsOpen(true);
+            },
+            { label: 'Open Settings', category: 'Preferences' },
+        );
+
+        return () => {
+            unregisterCommand('operator.updatePatch');
+            unregisterCommand('operator.updatePatchNextBeat');
+            unregisterCommand('operator.stop');
+            unregisterCommand('operator.newFile');
+            unregisterCommand('operator.closeBuffer');
+            unregisterCommand('operator.save');
+            unregisterCommand('operator.openWorkspace');
+            unregisterCommand('operator.openSettings');
+        };
+    }, []);
+
+    useEffect(() => {
+        // Electron menu items dispatch through the registry so each handler
+        // body lives in exactly one place. Recording is not (yet) in the
+        // registry — toggling it depends on render-state isRecording, which
+        // belongs to Phase 2.2's context-key service.
+        const cleanupNewFile = electronAPI.onMenuNewFile(() => {
+            executeCommand('operator.newFile');
+        });
+        const cleanupSave = electronAPI.onMenuSave(() => {
+            executeCommand('operator.save');
+        });
+        const cleanupStop = electronAPI.onMenuStop(() => {
+            executeCommand('operator.stop');
+        });
+        const cleanupUpdate = electronAPI.onMenuUpdatePatch(() => {
+            executeCommand('operator.updatePatch');
+        });
+        const cleanupUpdateNextBeat = electronAPI.onMenuUpdatePatchNextBeat(
+            () => {
+                executeCommand('operator.updatePatchNextBeat');
+            },
         );
         const cleanupOpenWorkspace = electronAPI.onMenuOpenWorkspace(() => {
-            handleOpenWorkspaceRef.current();
+            executeCommand('operator.openWorkspace');
         });
         const cleanupCloseBuffer = electronAPI.onMenuCloseBuffer(() => {
-            if (activeBufferId) {
-                void handleCloseBuffer(activeBufferId);
-            }
+            executeCommand('operator.closeBuffer');
         });
         const cleanupToggleRecording = electronAPI.onMenuToggleRecording(() => {
             if (isRecording) {
@@ -870,7 +972,7 @@ function App() {
 
         // Handle opening settings from menu (Cmd+,)
         const cleanupOpenSettings = electronAPI.onMenuOpenSettings(() => {
-            setIsSettingsOpen(true);
+            executeCommand('operator.openSettings');
         });
         const cleanupOpenEngineHealth = electronAPI.onMenuOpenEngineHealth(
             () => {
@@ -890,13 +992,7 @@ function App() {
             cleanupOpenSettings();
             cleanupOpenEngineHealth();
         };
-    }, [
-        activeBufferId,
-        handleCloseBuffer,
-        isRecording,
-        buffers,
-        createUntitledFile,
-    ]);
+    }, [isRecording]);
 
     // Ctrl+Enter (and Ctrl+Shift+Enter) are reserved for patch updates.
     // Browsers activate a focused <button> on Enter regardless of modifier

--- a/src/renderer/keybindings/commands.test.ts
+++ b/src/renderer/keybindings/commands.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for the Operator command registry. The registry is a global
+ * singleton, so each test cleans up after itself via `unregisterCommand`.
+ */
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+    executeCommand,
+    getCommand,
+    listCommands,
+    registerCommand,
+    unregisterCommand,
+} from './commands';
+
+const TEST_IDS = [
+    'test.cmd.a',
+    'test.cmd.b',
+    'test.cmd.c',
+    'test.cmd.async',
+];
+
+afterEach(() => {
+    for (const id of TEST_IDS) {
+        unregisterCommand(id);
+    }
+    vi.restoreAllMocks();
+});
+
+describe('command registry', () => {
+    test('register + execute round-trip invokes the handler with args', () => {
+        const handler = vi.fn();
+        registerCommand('test.cmd.a', handler, {
+            label: 'Test A',
+            category: 'Tests',
+        });
+
+        executeCommand('test.cmd.a', 1, 'two', { three: true });
+
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(handler).toHaveBeenCalledWith(1, 'two', { three: true });
+    });
+
+    test('execute awaits an async handler via the returned promise', async () => {
+        let resolved = false;
+        registerCommand('test.cmd.async', async () => {
+            await Promise.resolve();
+            resolved = true;
+        });
+        await (executeCommand('test.cmd.async') as Promise<void>);
+        expect(resolved).toBe(true);
+    });
+
+    test('executeCommand on unknown id throws with id in the message', () => {
+        expect(() => executeCommand('test.cmd.missing')).toThrowError(
+            /test\.cmd\.missing/,
+        );
+    });
+
+    test('unregisterCommand removes the entry', () => {
+        registerCommand('test.cmd.b', () => {});
+        expect(getCommand('test.cmd.b')).toBeDefined();
+
+        const removed = unregisterCommand('test.cmd.b');
+        expect(removed).toBe(true);
+        expect(getCommand('test.cmd.b')).toBeUndefined();
+        expect(() => executeCommand('test.cmd.b')).toThrowError(/test\.cmd\.b/);
+    });
+
+    test('unregisterCommand on unknown id returns false', () => {
+        expect(unregisterCommand('test.cmd.never-registered')).toBe(false);
+    });
+
+    test('re-registering an id warns and overwrites with the new handler', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const first = vi.fn();
+        const second = vi.fn();
+
+        registerCommand('test.cmd.a', first);
+        registerCommand('test.cmd.a', second);
+
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0]?.[0]).toMatch(/test\.cmd\.a/);
+
+        executeCommand('test.cmd.a');
+        expect(first).not.toHaveBeenCalled();
+        expect(second).toHaveBeenCalledTimes(1);
+    });
+
+    test('getCommand returns handler and metadata for registered ids', () => {
+        const handler = () => {};
+        const metadata = {
+            label: 'Test C',
+            category: 'Tests',
+            when: 'editorFocused',
+            contextMenu: { group: 'navigation', order: 1 },
+        };
+        registerCommand('test.cmd.c', handler, metadata);
+
+        const entry = getCommand('test.cmd.c');
+        expect(entry).toBeDefined();
+        expect(entry?.handler).toBe(handler);
+        expect(entry?.metadata).toEqual(metadata);
+    });
+
+    test('listCommands returns every registered id and metadata', () => {
+        registerCommand('test.cmd.a', () => {}, { label: 'Test A' });
+        registerCommand('test.cmd.b', () => {}, {
+            label: 'Test B',
+            category: 'Tests',
+        });
+
+        const ids = new Map(
+            listCommands().map((c) => [c.id, c.metadata] as const),
+        );
+        expect(ids.get('test.cmd.a')).toEqual({ label: 'Test A' });
+        expect(ids.get('test.cmd.b')).toEqual({
+            label: 'Test B',
+            category: 'Tests',
+        });
+    });
+});

--- a/src/renderer/keybindings/commands.ts
+++ b/src/renderer/keybindings/commands.ts
@@ -1,0 +1,106 @@
+/**
+ * Operator command registry.
+ *
+ * Global, process-wide map of command id -> handler + metadata. Modeled
+ * after VS Code's `CommandsRegistry`. Pure JS: no Monaco / Electron coupling
+ * lives in this file.
+ *
+ * Surfaces that dispatch commands (cmdk palette, Radix context menu,
+ * tinykeys keymap, Electron menu IPC, in-editor key bindings) all funnel
+ * through `executeCommand` so the body of each operation lives in exactly
+ * one place.
+ *
+ * See `~/.claude/plans/operator-is-at-its-goofy-mist.md` Phase 2.1.
+ */
+
+export type CommandHandler = (...args: unknown[]) => void | Promise<void>;
+
+export type CommandMetadata = {
+    /** Human-readable label shown in the palette / context menu. */
+    label: string;
+    /** Optional grouping label, e.g. "Patch", "File". */
+    category?: string;
+    /**
+     * Optional when-clause string. Stored verbatim here; parsed and
+     * evaluated against the context-key service in Phase 2.2.
+     */
+    when?: string;
+    /**
+     * Optional placement hint for the editor context menu (Phase 2.1b).
+     * `group` matches Monaco's existing group ids
+     * (`navigation`, `1_modification`, `9_cutcopypaste`, ...).
+     */
+    contextMenu?: { group: string; order: number };
+};
+
+type RegistryEntry = {
+    handler: CommandHandler;
+    metadata?: CommandMetadata;
+};
+
+/**
+ * Internal singleton. Not exported: callers must go through the
+ * functional API so we can later add change events, scopes, etc.
+ */
+const commandRegistry: Map<string, RegistryEntry> = new Map();
+
+/**
+ * Register (or replace) a command. Replacing an existing id logs a
+ * `console.warn` to help catch accidental duplicate registrations across
+ * modules.
+ */
+export function registerCommand(
+    id: string,
+    handler: CommandHandler,
+    metadata?: CommandMetadata,
+): void {
+    if (commandRegistry.has(id)) {
+        console.warn(
+            `[commands] overwriting existing command registration for "${id}"`,
+        );
+    }
+    commandRegistry.set(id, { handler, metadata });
+}
+
+/**
+ * Unregister a command. No-op if the id is not registered. Returns
+ * whether anything was removed (useful for cleanup assertions in tests).
+ */
+export function unregisterCommand(id: string): boolean {
+    return commandRegistry.delete(id);
+}
+
+/**
+ * Look up a command without invoking it. Returns `undefined` for unknown
+ * ids — callers that want a strict lookup should use `executeCommand`.
+ */
+export function getCommand(id: string): RegistryEntry | undefined {
+    return commandRegistry.get(id);
+}
+
+/**
+ * Invoke a registered command. Throws if the id is not registered; the
+ * thrown error includes the id so dispatch sites surface useful messages.
+ *
+ * Returns whatever the handler returns (commonly `void` or a Promise),
+ * so async commands can be awaited at the call site.
+ */
+export function executeCommand(id: string, ...args: unknown[]): unknown {
+    const entry = commandRegistry.get(id);
+    if (!entry) {
+        throw new Error(`[commands] unknown command id: "${id}"`);
+    }
+    return entry.handler(...args);
+}
+
+/**
+ * Snapshot of every registered command. Used to populate the cmdk
+ * palette and the read-only "Keyboard Shortcuts" settings tab.
+ */
+export function listCommands(): Array<{ id: string; metadata?: CommandMetadata }> {
+    const out: Array<{ id: string; metadata?: CommandMetadata }> = [];
+    for (const [id, entry] of commandRegistry) {
+        out.push({ id, metadata: entry.metadata });
+    }
+    return out;
+}


### PR DESCRIPTION
## Summary
- New `src/renderer/keybindings/commands.ts` with `registerCommand` / `executeCommand` / `listCommands`.
- Migrated 8 menu-action dispatchers (`operator.updatePatch`, `.updatePatchNextBeat`, `.stop`, `.newFile`, `.closeBuffer`, `.save`, `.openWorkspace`, `.openSettings`) into the registry.
- Existing `electronAPI.onMenu*` IPC handlers in App.tsx now delegate to `executeCommand` — single source of truth.
- Phase 2.4 (deleting the duplicate `addCommand` block + window keydown shim) is a follow-up; this PR only adds the registry.

Foundation for stacked sub-PRs: 2.1a cmdk palette, 2.1b Radix context menu, 2.2 context-key service, 2.3 tinykeys keymap loader.

## Test plan
- [x] `yarn typecheck` (only pre-existing ControlPanel.tsx error remains)
- [x] `yarn lint` (0 errors, 0 warnings)
- [x] `yarn test:unit` (187 tests pass; new commands.test.ts adds 8 cases covering register/execute/unregister/overwrite/list)
- [ ] `yarn start`, exercise menu items (Update Patch, Stop, New File, …), confirm they still fire.