### PR TITLE
Phase 2.1a: cmdk command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
         "@fontsource/source-code-pro": "^5.2.7",
         "@fontsource/victor-mono": "^5.2.8",
         "@monaco-editor/react": "^4.7.0",
+        "cmdk": "^1.1.1",
         "electron-squirrel-startup": "^1.0.1",
         "monaco-editor": "^0.55.1",
         "prettier": "^3.4.2",

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -8,6 +8,7 @@ import { AudioPanicDialog } from './components/AudioPanicDialog';
 import { EngineHealth } from './components/EngineHealth';
 import type { UpdateNotificationState } from './components/UpdateNotification';
 import { UpdateNotification } from './components/UpdateNotification';
+import { CommandPalette } from './components/CommandPalette';
 import './App.css';
 // Import type { editor } from 'monaco-editor';
 import { editor } from 'monaco-editor';
@@ -129,6 +130,7 @@ function App() {
     const [isRecording, setIsRecording] = useState(false);
     const [isSettingsOpen, setIsSettingsOpen] = useState(false);
     const [isEngineHealthOpen, setIsEngineHealthOpen] = useState(false);
+    const [isPaletteOpen, setIsPaletteOpen] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [validationErrors, setValidationErrors] = useState<
         ValidationError[] | null
@@ -147,6 +149,11 @@ function App() {
     const pendingUpdateVersion = useRef('');
 
     const editorRef = useRef<editor.IStandaloneCodeEditor>(null);
+    // Mirror of editorRef as state so children that need to react when the
+    // editor mounts/unmounts (e.g., the command palette enumerating Monaco
+    // editor actions) can subscribe instead of reading the ref during render.
+    const [paletteEditor, setPaletteEditor] =
+        useState<editor.IStandaloneCodeEditor | null>(null);
     const scopeCanvasMapRef = useRef(new Map<string, HTMLCanvasElement>());
     const lastPatchResultRef = useRef<any>(null);
 
@@ -919,6 +926,13 @@ function App() {
             },
             { label: 'Open Settings', category: 'Preferences' },
         );
+        registerCommand(
+            'operator.showCommandPalette',
+            () => {
+                setIsPaletteOpen(true);
+            },
+            { label: 'Show Command Palette', category: 'View' },
+        );
 
         return () => {
             unregisterCommand('operator.updatePatch');
@@ -929,6 +943,7 @@ function App() {
             unregisterCommand('operator.save');
             unregisterCommand('operator.openWorkspace');
             unregisterCommand('operator.openSettings');
+            unregisterCommand('operator.showCommandPalette');
         };
     }, []);
 
@@ -1069,6 +1084,12 @@ function App() {
 
             <AudioPanicDialog />
 
+            <CommandPalette
+                open={isPaletteOpen}
+                onOpenChange={setIsPaletteOpen}
+                editor={paletteEditor}
+            />
+
             <main className="app-main">
                 {!workspaceRoot ? (
                     <div className="empty-state">
@@ -1088,6 +1109,7 @@ function App() {
                                 currentFile={activeBufferId}
                                 onChange={handlePatchChange}
                                 editorRef={editorRef}
+                                onEditorChange={setPaletteEditor}
                                 scopeViews={scopeViews}
                                 // oxlint-disable-next-line react-hooks-js/refs -- intentional: live Monaco decoration collection mutated outside React
                                 scopeDecorations={scopeDecorationsRef.current}

--- a/src/renderer/components/CommandPalette.css
+++ b/src/renderer/components/CommandPalette.css
@@ -1,0 +1,86 @@
+.command-palette-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 2000;
+}
+
+.command-palette-content {
+    position: fixed;
+    top: 15vh;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 600px;
+    max-width: 90vw;
+    max-height: 70vh;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-default);
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    z-index: 2001;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    outline: none;
+}
+
+.command-palette-input {
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--border-default);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 14px;
+    padding: 12px 16px;
+    outline: none;
+    width: 100%;
+}
+
+.command-palette-input::placeholder {
+    color: var(--text-muted);
+}
+
+.command-palette-list {
+    overflow-y: auto;
+    padding: 4px 0;
+    flex: 1;
+    min-height: 0;
+}
+
+.command-palette-empty {
+    padding: 16px;
+    color: var(--text-muted);
+    font-size: 13px;
+    text-align: center;
+}
+
+.command-palette-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 16px;
+    cursor: pointer;
+    color: var(--text-primary);
+    font-size: 13px;
+}
+
+.command-palette-item[data-selected='true'] {
+    background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+}
+
+.command-palette-item-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.command-palette-item-category {
+    color: var(--text-muted);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    flex-shrink: 0;
+}

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -1,0 +1,89 @@
+/**
+ * Workbench-level command palette (cmdk).
+ *
+ * Rendered at the App root so it works regardless of whether a Monaco editor
+ * is currently mounted. Sources its rows from `buildPaletteItems` — Operator
+ * registry commands plus, when an editor exists, every supported Monaco
+ * editor action.
+ *
+ * See `~/.claude/plans/operator-is-at-its-goofy-mist.md` Phase 2.1a.
+ */
+import { useMemo } from 'react';
+import { Command } from 'cmdk';
+import type { editor } from 'monaco-editor';
+
+import { buildPaletteItems, type PaletteItem } from '../keybindings/paletteItems';
+import './CommandPalette.css';
+
+export interface CommandPaletteProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** Currently mounted Monaco editor, if any. Used to enumerate editor actions. */
+    editor: editor.ICodeEditor | null;
+}
+
+/**
+ * Stable item value for cmdk's filter. cmdk filters on this string, so we
+ * concatenate label + id (so e.g. "Go to Line" matches and the internal id
+ * `editor.action.gotoLine` matches too).
+ */
+function itemValue(item: PaletteItem): string {
+    return `${item.label} ${item.id}`;
+}
+
+export function CommandPalette({
+    open,
+    onOpenChange,
+    editor,
+}: CommandPaletteProps) {
+    // Rebuild on every open so the registry and editor actions reflect the
+    // current frame. The build is cheap (linear in command count) and only
+    // runs when the user actually opens the palette.
+    const items = useMemo(() => {
+        if (!open) {
+            return [];
+        }
+        return buildPaletteItems(editor);
+    }, [open, editor]);
+
+    return (
+        <Command.Dialog
+            open={open}
+            onOpenChange={onOpenChange}
+            label="Command Palette"
+            overlayClassName="command-palette-overlay"
+            contentClassName="command-palette-content"
+        >
+            <Command.Input
+                placeholder="Type a command…"
+                className="command-palette-input"
+                autoFocus
+            />
+            <Command.List className="command-palette-list">
+                <Command.Empty className="command-palette-empty">
+                    No matching commands.
+                </Command.Empty>
+                {items.map((item) => (
+                    <Command.Item
+                        key={`${item.kind}:${item.id}`}
+                        value={itemValue(item)}
+                        onSelect={() => {
+                            onOpenChange(false);
+                            item.run();
+                        }}
+                        className="command-palette-item"
+                    >
+                        <span className="command-palette-item-label">
+                            {item.label}
+                        </span>
+                        {item.category && (
+                            <span className="command-palette-item-category">
+                                {item.category}
+                            </span>
+                        )}
+                    </Command.Item>
+                ))}
+            </Command.List>
+        </Command.Dialog>
+    );
+}

--- a/src/renderer/components/MonacoPatchEditor.tsx
+++ b/src/renderer/components/MonacoPatchEditor.tsx
@@ -25,12 +25,19 @@ import { startModuleStatePolling } from './monaco/moduleStateTracking';
 import { registerMidiCompletionProvider } from './monaco/midiCompletionProvider';
 import electronAPI from '../electronAPI';
 import type { Schemas } from '../../shared/dsl/schemaTypeResolver';
+import { executeCommand } from '../keybindings/commands';
 
 export interface PatchEditorProps {
     value: string;
     currentFile?: string;
     onChange: (value: string) => void;
     editorRef: React.RefObject<editor.IStandaloneCodeEditor | null>;
+    /**
+     * Notified when the editor instance becomes available (mount) or goes
+     * away (unmount, e.g. last buffer closed). Lets parents subscribe via
+     * state instead of reading `editorRef.current` during render.
+     */
+    onEditorChange?: (editor: editor.IStandaloneCodeEditor | null) => void;
     scopeViews?: ScopeView[];
     /** Tracked decoration collection whose ranges correspond 1:1 with scopeViews. */
     scopeDecorations?: editor.IEditorDecorationsCollection | null;
@@ -44,6 +51,7 @@ export function MonacoPatchEditor({
     currentFile,
     onChange,
     editorRef,
+    onEditorChange,
     scopeViews = [],
     scopeDecorations = null,
     onRegisterScopeCanvas,
@@ -74,6 +82,17 @@ export function MonacoPatchEditor({
     const [editor, setEditor] = useState<editor.IStandaloneCodeEditor | null>(
         null,
     );
+
+    // Mirror the local `editor` state up to the parent (for the command
+    // palette etc.). Cleans up to `null` when the inner Monaco Editor
+    // unmounts (e.g., when the last buffer closes and `currentFile` goes
+    // falsy).
+    useEffect(() => {
+        onEditorChange?.(editor);
+        return () => {
+            onEditorChange?.(null);
+        };
+    }, [editor, onEditorChange]);
 
     // Decoration collection for active module state highlighting (seq steps, etc.)
     const activeDecorationRef =
@@ -185,6 +204,20 @@ export function MonacoPatchEditor({
         ed.addCommand(ctrl | _monacoInstance.KeyCode.KeyW, () => {
             window.electronAPI.triggerMenuAction('CLOSE_BUFFER');
         });
+
+        // Override Monaco's built-in palette (F1, Ctrl+Shift+P) so both chords
+        // open the Operator workbench palette instead of `editor.action.quickCommand`.
+        // Outside the editor the same chord is caught by the window-level
+        // keymap (Phase 2.3). Single palette, one keybinding, no conflict.
+        ed.addCommand(_monacoInstance.KeyCode.F1, () => {
+            executeCommand('operator.showCommandPalette');
+        });
+        ed.addCommand(
+            ctrl | _monacoInstance.KeyMod.Shift | _monacoInstance.KeyCode.KeyP,
+            () => {
+                executeCommand('operator.showCommandPalette');
+            },
+        );
     };
 
     useEffect(() => {
@@ -341,6 +374,12 @@ export function MonacoPatchEditor({
                         folding: false,
                         matchBrackets: 'always',
                         automaticLayout: true,
+                        // Monaco's editor context menu hosts a "Command Palette"
+                        // entry that invokes `editor.action.quickCommand`
+                        // directly, bypassing our keybinding override. Disable
+                        // the built-in menu wholesale; Phase 2.1b replaces it
+                        // with a Radix context menu.
+                        contextmenu: false,
                         fontFamily: `${font}, monospace`,
                         fontLigatures: fontLigatures,
                         fontSize: fontSize,

--- a/src/renderer/keybindings/paletteItems.ts
+++ b/src/renderer/keybindings/paletteItems.ts
@@ -1,0 +1,103 @@
+/**
+ * Build the unified command-palette item list shown by `CommandPalette`.
+ *
+ * Sources merged each time the palette opens:
+ *   1. Every entry in the Operator command registry (label + category).
+ *   2. When a Monaco editor instance exists, every action returned by
+ *      `editor.getSupportedActions()` that reports `isSupported() === true`.
+ *
+ * Monaco actions get a fixed `"Editor"` category badge so they sort together
+ * in the palette UI and so users can quickly tell them apart from Operator
+ * commands.
+ *
+ * See `~/.claude/plans/operator-is-at-its-goofy-mist.md` Phase 2.1a.
+ */
+import type { editor } from 'monaco-editor';
+
+import {
+    executeCommand,
+    listCommands,
+    type CommandMetadata,
+} from './commands';
+
+/**
+ * A single row in the cmdk palette. `kind` discriminates between the two
+ * dispatch paths so the consumer doesn't need to know about Monaco actions
+ * directly.
+ */
+export type PaletteItem =
+    | {
+          kind: 'command';
+          id: string;
+          label: string;
+          category?: string;
+          when?: string;
+          run: () => void;
+      }
+    | {
+          kind: 'editor-action';
+          id: string;
+          label: string;
+          category: 'Editor';
+          run: () => void;
+      };
+
+function operatorItem(
+    id: string,
+    metadata: CommandMetadata | undefined,
+): PaletteItem {
+    return {
+        kind: 'command',
+        id,
+        label: metadata?.label ?? id,
+        category: metadata?.category,
+        when: metadata?.when,
+        run: () => {
+            executeCommand(id);
+        },
+    };
+}
+
+function editorActionItem(
+    action: editor.IEditorAction,
+): PaletteItem | null {
+    if (!action.isSupported()) {
+        return null;
+    }
+    const label = action.label?.trim() || action.id;
+    return {
+        kind: 'editor-action',
+        id: action.id,
+        label,
+        category: 'Editor',
+        run: () => {
+            void action.run();
+        },
+    };
+}
+
+/**
+ * Build the merged item list. Pass the current editor instance (if any) so
+ * Monaco's editor actions can be enumerated; with zero buffers open and
+ * therefore no editor, the result contains only Operator commands.
+ */
+export function buildPaletteItems(
+    activeEditor: editor.ICodeEditor | null,
+): PaletteItem[] {
+    const items: PaletteItem[] = [];
+
+    for (const { id, metadata } of listCommands()) {
+        items.push(operatorItem(id, metadata));
+    }
+
+    if (activeEditor) {
+        for (const action of activeEditor.getSupportedActions()) {
+            const item = editorActionItem(action);
+            if (item) {
+                items.push(item);
+            }
+        }
+    }
+
+    return items;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,6 +1910,7 @@ __metadata:
     "@types/electron-squirrel-startup": "npm:^1.0.2"
     "@types/react": "npm:^19.2.14"
     "@types/react-dom": "npm:^19.2.3"
+    cmdk: "npm:^1.1.1"
     concurrently: "npm:^9.2.1"
     electron: "npm:39.2.7"
     electron-squirrel-startup: "npm:^1.0.1"
@@ -3625,6 +3626,323 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/primitive@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/primitive@npm:1.1.3"
+  checksum: 10c0/88860165ee7066fa2c179f32ffcd3ee6d527d9dcdc0e8be85e9cb0e2c84834be8e3c1a976c74ba44b193f709544e12f54455d892b28e32f0708d89deda6b9f1d
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-compose-refs@npm:1.1.2, @radix-ui/react-compose-refs@npm:^1.1.1":
+  version: 1.1.2
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/d36a9c589eb75d634b9b139c80f916aadaf8a68a7c1c4b8c6c6b88755af1a92f2e343457042089f04cc3f23073619d08bb65419ced1402e9d4e299576d970771
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-context@npm:1.1.2":
+  version: 1.1.2
+  resolution: "@radix-ui/react-context@npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/cece731f8cc25d494c6589cc681e5c01a93867d895c75889973afa1a255f163c286e390baa7bc028858eaabe9f6b57270d0ca6377356f652c5557c1c7a41ccce
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dialog@npm:^1.1.6":
+  version: 1.1.15
+  resolution: "@radix-ui/react-dialog@npm:1.1.15"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
+    "@radix-ui/react-focus-guards": "npm:1.1.3"
+    "@radix-ui/react-focus-scope": "npm:1.1.7"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-portal": "npm:1.1.9"
+    "@radix-ui/react-presence": "npm:1.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-slot": "npm:1.2.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    aria-hidden: "npm:^1.2.4"
+    react-remove-scroll: "npm:^2.6.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/2f2c88e3c281acaea2fd9b96fa82132d59177d3aa5da2e7c045596fd4028e84e44ac52ac28f4f236910605dd7d9338c2858ba44a9ced2af2e3e523abbfd33014
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dismissable-layer@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.11"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
+    "@radix-ui/react-use-escape-keydown": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/c825572a64073c4d3853702029979f6658770ffd6a98eabc4984e1dee1b226b4078a2a4dc7003f96475b438985e9b21a58e75f51db74dd06848dcae1f2d395dc
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-guards@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/react-focus-guards@npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/0bab65eb8d7e4f72f685d63de7fbba2450e3cb15ad6a20a16b42195e9d335c576356f5a47cb58d1ffc115393e46d7b14b12c5d4b10029b0ec090861255866985
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-scope@npm:1.1.7":
+  version: 1.1.7
+  resolution: "@radix-ui/react-focus-scope@npm:1.1.7"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/8a6071331bdeeb79b223463de75caf759b8ad19339cab838e537b8dbb2db236891a1f4df252445c854d375d43d9d315dfcce0a6b01553a2984ec372bb8f1300e
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-id@npm:1.1.1, @radix-ui/react-id@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@radix-ui/react-id@npm:1.1.1"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/7d12e76818763d592c331277ef62b197e2e64945307e650bd058f0090e5ae48bbd07691b23b7e9e977901ef4eadcb3e2d5eaeb17a13859083384be83fc1292c7
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-portal@npm:1.1.9":
+  version: 1.1.9
+  resolution: "@radix-ui/react-portal@npm:1.1.9"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/45b432497c722720c72c493a29ef6085bc84b50eafe79d48b45c553121b63e94f9cdb77a3a74b9c49126f8feb3feee009fe400d48b7759d3552396356b192cd7
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-presence@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@radix-ui/react-presence@npm:1.1.5"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/d0e61d314250eeaef5369983cb790701d667f51734bafd98cf759072755562018052c594e6cdc5389789f4543cb0a4d98f03ff4e8f37338d6b5bf51a1700c1d1
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@radix-ui/react-primitive@npm:2.1.3"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/fdff9b84913bb4172ef6d3af7442fca5f9bba5f2709cba08950071f819d7057aec3a4a2d9ef44cf9cbfb8014d02573c6884a04cff175895823aaef809ebdb034
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:^2.0.2":
+  version: 2.1.4
+  resolution: "@radix-ui/react-primitive@npm:2.1.4"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.2.4"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/90d687b222a25975371ed1f9f08648d75237214b8dec4cbaf09ec9ac951339b17421278f1aff2fb7c5672ba8bd03774a94904efdba73805dd5cc947ce5be8c4a
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@radix-ui/react-slot@npm:1.2.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/5913aa0d760f505905779515e4b1f0f71a422350f077cc8d26d1aafe53c97f177fec0e6d7fbbb50d8b5e498aa9df9f707ca75ae3801540c283b26b0136138eef
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@radix-ui/react-slot@npm:1.2.4"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/8b719bb934f1ae5ac0e37214783085c17c2f1080217caf514c1c6cc3d9ca56c7e19d25470b26da79aa6e605ab36589edaade149b76f5fc0666f1063e2fc0a0dc
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-callback-ref@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-callback-ref@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/5f6aff8592dea6a7e46589808912aba3fb3b626cf6edd2b14f01638b61dbbe49eeb9f67cd5601f4c15b2fb547b9a7e825f7c4961acd4dd70176c969ae405f8d8
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-controllable-state@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.2"
+  dependencies:
+    "@radix-ui/react-use-effect-event": "npm:0.0.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/f55c4b06e895293aed4b44c9ef26fb24432539f5346fcd6519c7745800535b571058685314e83486a45bf61dc83887e24826490d3068acc317fb0a9010516e63
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-effect-event@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@radix-ui/react-use-effect-event@npm:0.0.2"
+  dependencies:
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/e84ff72a3e76c5ae9c94941028bb4b6472f17d4104481b9eab773deab3da640ecea035e54da9d6f4df8d84c18ef6913baf92b7511bee06930dc58bd0c0add417
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-escape-keydown@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.1"
+  dependencies:
+    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/bff53be99e940fef1d3c4df7d560e1d9133182e5a98336255d3063327d1d3dd4ec54a95dc5afe15cca4fb6c184f0a956c70de2815578c318cf995a7f9beabaa1
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-use-layout-effect@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/9f98fdaba008dfc58050de60a77670b885792df473cf82c1cef8daee919a5dd5a77d270209f5f0b0abfaac78cb1627396e3ff56c81b735be550409426fe8b040
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-android-arm-eabi@npm:4.57.1":
   version: 4.57.1
   resolution: "@rollup/rollup-android-arm-eabi@npm:4.57.1"
@@ -4554,6 +4872,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aria-hidden@npm:^1.2.4":
+  version: 1.2.6
+  resolution: "aria-hidden@npm:1.2.6"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  checksum: 10c0/7720cb539497a9f760f68f98a4b30f22c6767aa0e72fa7d58279f7c164e258fc38b2699828f8de881aab0fc8e9c56d1313a3f1a965046fc0381a554dbc72b54a
+  languageName: node
+  linkType: hard
+
 "assertion-error@npm:^2.0.1":
   version: 2.0.1
   resolution: "assertion-error@npm:2.0.1"
@@ -5034,6 +5361,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cmdk@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "cmdk@npm:1.1.1"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:^1.1.1"
+    "@radix-ui/react-dialog": "npm:^1.1.6"
+    "@radix-ui/react-id": "npm:^1.1.0"
+    "@radix-ui/react-primitive": "npm:^2.0.2"
+  peerDependencies:
+    react: ^18 || ^19 || ^19.0.0-rc
+    react-dom: ^18 || ^19 || ^19.0.0-rc
+  checksum: 10c0/5605ac4396ec9bc65c82f954da19dd89a0636a54026df72780e2470da1381f9d57434a80a53f2d57eaa4e759660a3ebba9232b74258dc09970576591eae03116
+  languageName: node
+  linkType: hard
+
 "code-block-writer@npm:^13.0.3":
   version: 13.0.3
   resolution: "code-block-writer@npm:13.0.3"
@@ -5284,6 +5626,13 @@ __metadata:
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
+  languageName: node
+  linkType: hard
+
+"detect-node-es@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "detect-node-es@npm:1.1.0"
+  checksum: 10c0/e562f00de23f10c27d7119e1af0e7388407eb4b06596a25f6d79a360094a109ff285de317f02b090faae093d314cf6e73ac3214f8a5bb3a0def5bece94557fbe
   languageName: node
   linkType: hard
 
@@ -6259,6 +6608,13 @@ __metadata:
   bin:
     get-folder-size: bin/get-folder-size
   checksum: 10c0/7d1c9436cbe5c921ade3437b71ad00ce45fcbb79259490753ffcf10fdc19c7cc7e1aa2bdd1586f321fc0ab81e6d835334e24c37e3127e33ebb427ed7742a8229
+  languageName: node
+  linkType: hard
+
+"get-nonce@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "get-nonce@npm:1.0.1"
+  checksum: 10c0/2d7df55279060bf0568549e1ffc9b84bc32a32b7541675ca092dce56317cdd1a59a98dcc4072c9f6a980779440139a3221d7486f52c488e69dc0fd27b1efb162
   languageName: node
   linkType: hard
 
@@ -8891,6 +9247,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-remove-scroll-bar@npm:^2.3.7":
+  version: 2.3.8
+  resolution: "react-remove-scroll-bar@npm:2.3.8"
+  dependencies:
+    react-style-singleton: "npm:^2.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/9a0675c66cbb52c325bdbfaed80987a829c4504cefd8ff2dd3b6b3afc9a1500b8ec57b212e92c1fb654396d07bbe18830a8146fe77677d2a29ce40b5e1f78654
+  languageName: node
+  linkType: hard
+
+"react-remove-scroll@npm:^2.6.3":
+  version: 2.7.2
+  resolution: "react-remove-scroll@npm:2.7.2"
+  dependencies:
+    react-remove-scroll-bar: "npm:^2.3.7"
+    react-style-singleton: "npm:^2.2.3"
+    tslib: "npm:^2.1.0"
+    use-callback-ref: "npm:^1.3.3"
+    use-sidecar: "npm:^1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/b5f3315bead75e72853f492c0b51ba8fb4fa09a4534d7fc42d6fcd59ca3e047cf213279ffc1e35b337e314ef5a04cb2b12544c85e0078802271731c27c09e5aa
+  languageName: node
+  linkType: hard
+
+"react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "react-style-singleton@npm:2.2.3"
+  dependencies:
+    get-nonce: "npm:^1.0.0"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/841938ff16d16a6b76895f4cb2e1fea957e5fe3b30febbf03a54892dae1c9153f2383e231dea0b3ba41192ad2f2849448fa859caccd288943bce32639e971bee
+  languageName: node
+  linkType: hard
+
 "react@npm:^19.2.6":
   version: 19.2.6
   resolution: "react@npm:19.2.6"
@@ -9951,7 +10358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.4.0":
+"tslib@npm:^2.0.0, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
@@ -10201,6 +10608,37 @@ __metadata:
   bin:
     update-browserslist-db: cli.js
   checksum: 10c0/13a00355ea822388f68af57410ce3255941d5fb9b7c49342c4709a07c9f230bbef7f7499ae0ca7e0de532e79a82cc0c4edbd125f1a323a1845bf914efddf8bec
+  languageName: node
+  linkType: hard
+
+"use-callback-ref@npm:^1.3.3":
+  version: 1.3.3
+  resolution: "use-callback-ref@npm:1.3.3"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/f887488c6e6075cdad4962979da1714b217bcb1ee009a9e57ce9a844bcfc4c3a99e93983dfc2e5af9e0913824d24e730090ff255e902c516dcb58d2d3837e01c
+  languageName: node
+  linkType: hard
+
+"use-sidecar@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "use-sidecar@npm:1.1.3"
+  dependencies:
+    detect-node-es: "npm:^1.1.0"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/161599bf921cfaa41c85d2b01c871975ee99260f3e874c2d41c05890d41170297bdcf314bc5185e7a700de2034ac5b888e3efc8e9f35724f4918f53538d717c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Stacked on PR #88. Bead op-7sn. Plan section 2.1a: workbench-level palette via cmdk, sourced from command registry + Monaco editor.getSupportedActions(). MonacoPatchEditor overrides F1 and Ctrl+Shift+P to open the Operator palette and sets contextmenu:false (Phase 2.1b will replace with Radix). 7 files, +779/-1.

Note: originally implemented by polecat 'furiosa' which rebased onto master. Salvaged via cherry-pick onto editorize/phase2.1-command-registry — applied cleanly (only auto-merge in package.json). Lint clean, 51/51 unit tests pass; 2 test files fail import due to missing native build env (`crates/modular/index.js` — unrelated).