### PR TITLE
perf(renderer): stop per-frame App re-render (route transport through external store)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -22,7 +22,6 @@ import type { QueuedTrigger } from '@modular/core';
 import type {
     FileTreeEntry,
     SourceLocationInfo,
-    TransportSnapshot,
     UpdateAvailableInfo,
 } from '../shared/ipcTypes';
 import type { SliderDefinition } from '../shared/dsl/sliderTypes';
@@ -37,6 +36,11 @@ import {
     scopeBufferKeyToString,
 } from './app/oscilloscope';
 import { useEditorBuffers } from './app/hooks/useEditorBuffers';
+import {
+    setTransport,
+    updateTransport,
+    useTransportLinkEnabled,
+} from './app/transportStore';
 import { useTheme } from './themes/ThemeContext';
 
 /**
@@ -141,8 +145,12 @@ function App() {
     const [scopeViews, setScopeViews] = useState<ScopeView[]>([]);
     const [runningBufferId, setRunningBufferId] = useState<string | null>(null);
     const [sliderDefs, setSliderDefs] = useState<SliderDefinition[]>([]);
-    const [transportState, setTransportState] =
-        useState<TransportSnapshot | null>(null);
+    // Per-frame transport lives in an external store (see transportStore) so
+    // updating it ~60×/s does not re-render the whole App tree — only the
+    // transport display, which subscribes directly. App only needs to know
+    // whether Link is enabled (to drive the Link-only poll loop below); that
+    // selector re-renders App only when the flag flips.
+    const linkEnabled = useTransportLinkEnabled();
 
     const [updateState, setUpdateState] = useState<UpdateNotificationState>({
         status: 'idle',
@@ -546,7 +554,7 @@ function App() {
                         }
                     }
 
-                    setTransportState(transport);
+                    setTransport(transport);
 
                     // Check if a pending UI state should be committed
                     const pending = pendingUIStateRef.current;
@@ -589,7 +597,6 @@ function App() {
     // The main tick loop only runs when isClockRunning; this fills the gap so
     // the phase indicator stays animated even before the user presses play.
     useEffect(() => {
-        const linkEnabled = transportState?.linkEnabled ?? false;
         if (!linkEnabled || isClockRunning) return;
         let cancelled = false;
         let rafId = 0;
@@ -597,7 +604,7 @@ function App() {
             if (cancelled) return;
             void electronAPI.synthesizer.getTransportState().then((t) => {
                 if (cancelled) return;
-                setTransportState(t);
+                setTransport(t);
                 rafId = requestAnimationFrame(tick);
             });
         };
@@ -606,7 +613,7 @@ function App() {
             cancelled = true;
             cancelAnimationFrame(rafId);
         };
-    }, [transportState?.linkEnabled, isClockRunning]);
+    }, [linkEnabled, isClockRunning]);
 
     const handleSaveFile = useCallback(
         async (id?: string) => {
@@ -933,19 +940,14 @@ function App() {
         <div className="app">
             <header className="app-header">
                 <TransportDisplay
-                    transport={transportState}
                     onToggleLink={(enabled) => {
                         void electronAPI.synthesizer.enableLink(enabled);
                         // Optimistically update UI — polling only runs while playing
-                        setTransportState((prev) =>
-                            prev
-                                ? {
-                                      ...prev,
-                                      linkEnabled: enabled,
-                                      linkPeers: enabled ? prev.linkPeers : 0,
-                                  }
-                                : prev,
-                        );
+                        updateTransport((prev) => ({
+                            ...prev,
+                            linkEnabled: enabled,
+                            linkPeers: enabled ? prev.linkPeers : 0,
+                        }));
                     }}
                 />
                 <AudioControls

--- a/src/renderer/app/__tests__/transportStore.test.ts
+++ b/src/renderer/app/__tests__/transportStore.test.ts
@@ -1,0 +1,139 @@
+// These cover the store layer that backs the transport hooks. The hooks
+// themselves (useTransport / useTransportLinkEnabled) are thin
+// useSyncExternalStore wrappers over the subscribe + getSnapshot functions
+// exercised here; the suite runs in a node environment with no DOM renderer,
+// so the hooks are not rendered directly.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TransportSnapshot } from '../../../shared/ipcTypes';
+import {
+    getLinkEnabledSnapshot,
+    getTransportSnapshot,
+    setTransport,
+    subscribeTransport,
+    updateTransport,
+} from '../transportStore';
+
+function makeSnapshot(
+    overrides: Partial<TransportSnapshot> = {},
+): TransportSnapshot {
+    return {
+        barPhase: 0,
+        bar: 0,
+        beatInBar: 0,
+        bpm: 120,
+        timeSigNumerator: 4,
+        timeSigDenominator: 4,
+        isPlaying: false,
+        hasQueuedUpdate: false,
+        lastAppliedUpdateId: 0,
+        linkEnabled: false,
+        linkPeers: 0,
+        linkPhase: 0,
+        linkPendingStart: false,
+        ...overrides,
+    };
+}
+
+// The store is a module singleton; reset it to null between tests via the
+// public API so cases don't leak state into one another.
+afterEach(() => {
+    setTransport(null);
+});
+
+describe('transportStore', () => {
+    it('starts with no snapshot', () => {
+        expect(getTransportSnapshot()).toBeNull();
+        expect(getLinkEnabledSnapshot()).toBe(false);
+    });
+
+    it('setTransport notifies subscribers and stores the snapshot by reference', () => {
+        const listener = vi.fn();
+        const unsubscribe = subscribeTransport(listener);
+
+        const snap = makeSnapshot({ bpm: 90 });
+        setTransport(snap);
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        // Stored by reference, not copied: useSyncExternalStore needs getSnapshot
+        // to return the same value when nothing changed, so the store must not
+        // allocate a fresh object on read.
+        expect(getTransportSnapshot()).toBe(snap);
+        unsubscribe();
+    });
+
+    it('updateTransport patches the snapshot and notifies', () => {
+        setTransport(makeSnapshot({ linkEnabled: false, linkPeers: 3 }));
+        const listener = vi.fn();
+        const unsubscribe = subscribeTransport(listener);
+
+        updateTransport((prev) => ({
+            ...prev,
+            linkEnabled: true,
+            linkPeers: prev.linkPeers,
+        }));
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(getTransportSnapshot()?.linkEnabled).toBe(true);
+        expect(getTransportSnapshot()?.linkPeers).toBe(3);
+        unsubscribe();
+    });
+
+    it('updateTransport is a no-op (and does not notify) with no snapshot', () => {
+        const listener = vi.fn();
+        const unsubscribe = subscribeTransport(listener);
+
+        updateTransport((prev) => ({ ...prev, linkEnabled: true }));
+
+        expect(listener).not.toHaveBeenCalled();
+        expect(getTransportSnapshot()).toBeNull();
+        unsubscribe();
+    });
+
+    it('getLinkEnabledSnapshot derives the primitive from the snapshot', () => {
+        setTransport(makeSnapshot({ linkEnabled: true }));
+        expect(getLinkEnabledSnapshot()).toBe(true);
+        setTransport(makeSnapshot({ linkEnabled: false }));
+        expect(getLinkEnabledSnapshot()).toBe(false);
+    });
+
+    it('keeps the link primitive Object.is-stable while snapshots churn', () => {
+        // Crux of the perf fix. React reads getSnapshot after every
+        // notification and re-renders only when Object.is reports a change.
+        // Sample both reads inside the subscriber — the notification is React's
+        // re-evaluation point — so this mirrors what the reconciler sees: each
+        // frame pushes a fresh snapshot object, so useTransport churns
+        // (re-render, by design), but linkEnabled is unchanged, so
+        // useTransportLinkEnabled dedups and App skips the re-render.
+        const snapshotReads: (TransportSnapshot | null)[] = [];
+        const linkReads: boolean[] = [];
+        const unsubscribe = subscribeTransport(() => {
+            snapshotReads.push(getTransportSnapshot());
+            linkReads.push(getLinkEnabledSnapshot());
+        });
+
+        setTransport(makeSnapshot({ linkEnabled: true, barPhase: 0.1 }));
+        setTransport(makeSnapshot({ linkEnabled: true, barPhase: 0.2 }));
+
+        expect(snapshotReads[0]).not.toBe(snapshotReads[1]); // ref churns
+        expect(Object.is(linkReads[0], linkReads[1])).toBe(true); // primitive does not
+        unsubscribe();
+    });
+
+    it('notifies all subscribers and stops after unsubscribe', () => {
+        const a = vi.fn();
+        const b = vi.fn();
+        const unsubA = subscribeTransport(a);
+        const unsubB = subscribeTransport(b);
+
+        setTransport(makeSnapshot());
+        expect(a).toHaveBeenCalledTimes(1);
+        expect(b).toHaveBeenCalledTimes(1);
+
+        unsubA();
+        setTransport(makeSnapshot());
+        expect(a).toHaveBeenCalledTimes(1); // no further calls
+        expect(b).toHaveBeenCalledTimes(2);
+        unsubB();
+    });
+});

--- a/src/renderer/app/transportStore.ts
+++ b/src/renderer/app/transportStore.ts
@@ -1,8 +1,7 @@
 // External store for the per-frame transport snapshot (BPM, bar/beat, Link
-// phase, ...). The transport is polled ~60×/s; holding it in App-root React
-// state re-rendered the entire App tree every frame. Routing it through an
-// external store (useSyncExternalStore) means only the components that
-// actually read it re-render — App itself does not.
+// phase, ...). The transport is polled ~60×/s; an external store
+// (useSyncExternalStore) confines those updates to the components that read
+// the snapshot, so the App tree does not re-render on every frame.
 
 import { useSyncExternalStore } from 'react';
 import type { TransportSnapshot } from '../../shared/ipcTypes';
@@ -14,11 +13,22 @@ function emit(): void {
     for (const listener of listeners) listener();
 }
 
-function subscribe(listener: () => void): () => void {
+/** Register a listener; returns an unsubscribe function. */
+export function subscribeTransport(listener: () => void): () => void {
     listeners.add(listener);
     return () => {
         listeners.delete(listener);
     };
+}
+
+/** Current transport snapshot, or null before the first poll. */
+export function getTransportSnapshot(): TransportSnapshot | null {
+    return snapshot;
+}
+
+/** Whether Ableton Link is enabled; a primitive derived from the snapshot. */
+export function getLinkEnabledSnapshot(): boolean {
+    return snapshot?.linkEnabled ?? false;
 }
 
 /**
@@ -33,7 +43,7 @@ export function setTransport(next: TransportSnapshot | null): void {
 
 /**
  * Merge an optimistic update into the current snapshot. No-op when there is no
- * snapshot yet (matches the prior `prev ? {...} : prev` behaviour).
+ * snapshot yet.
  */
 export function updateTransport(
     patch: (prev: TransportSnapshot) => TransportSnapshot,
@@ -45,7 +55,7 @@ export function updateTransport(
 
 /** Full snapshot; re-renders the caller on every transport change. */
 export function useTransport(): TransportSnapshot | null {
-    return useSyncExternalStore(subscribe, () => snapshot);
+    return useSyncExternalStore(subscribeTransport, getTransportSnapshot);
 }
 
 /**
@@ -53,8 +63,5 @@ export function useTransport(): TransportSnapshot | null {
  * re-renders only when it flips — not on every per-frame snapshot update.
  */
 export function useTransportLinkEnabled(): boolean {
-    return useSyncExternalStore(
-        subscribe,
-        () => snapshot?.linkEnabled ?? false,
-    );
+    return useSyncExternalStore(subscribeTransport, getLinkEnabledSnapshot);
 }

--- a/src/renderer/app/transportStore.ts
+++ b/src/renderer/app/transportStore.ts
@@ -1,0 +1,60 @@
+// External store for the per-frame transport snapshot (BPM, bar/beat, Link
+// phase, ...). The transport is polled ~60×/s; holding it in App-root React
+// state re-rendered the entire App tree every frame. Routing it through an
+// external store (useSyncExternalStore) means only the components that
+// actually read it re-render — App itself does not.
+
+import { useSyncExternalStore } from 'react';
+import type { TransportSnapshot } from '../../shared/ipcTypes';
+
+let snapshot: TransportSnapshot | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+    for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+}
+
+/**
+ * Replace the current transport snapshot and notify subscribers. Called from
+ * App's per-frame poll loop; re-renders only the subscribers (the transport
+ * display), not the App tree.
+ */
+export function setTransport(next: TransportSnapshot | null): void {
+    snapshot = next;
+    emit();
+}
+
+/**
+ * Merge an optimistic update into the current snapshot. No-op when there is no
+ * snapshot yet (matches the prior `prev ? {...} : prev` behaviour).
+ */
+export function updateTransport(
+    patch: (prev: TransportSnapshot) => TransportSnapshot,
+): void {
+    if (snapshot === null) return;
+    snapshot = patch(snapshot);
+    emit();
+}
+
+/** Full snapshot; re-renders the caller on every transport change. */
+export function useTransport(): TransportSnapshot | null {
+    return useSyncExternalStore(subscribe, () => snapshot);
+}
+
+/**
+ * Just whether Ableton Link is enabled. Returns a primitive, so the caller
+ * re-renders only when it flips — not on every per-frame snapshot update.
+ */
+export function useTransportLinkEnabled(): boolean {
+    return useSyncExternalStore(
+        subscribe,
+        () => snapshot?.linkEnabled ?? false,
+    );
+}

--- a/src/renderer/components/TransportDisplay.tsx
+++ b/src/renderer/components/TransportDisplay.tsx
@@ -1,14 +1,13 @@
-import type { TransportSnapshot } from '../../shared/ipcTypes';
+import { useTransport } from '../app/transportStore';
 
 interface TransportDisplayProps {
-    transport: TransportSnapshot | null;
     onToggleLink?: (enabled: boolean) => void;
 }
 
-export function TransportDisplay({
-    transport,
-    onToggleLink,
-}: TransportDisplayProps) {
+export function TransportDisplay({ onToggleLink }: TransportDisplayProps) {
+    // Subscribes directly to the per-frame transport store, so only this
+    // component re-renders on each frame — not the App tree.
+    const transport = useTransport();
     if (!transport) {
         return (
             <div className="transport-display">


### PR DESCRIPTION
## Problem

While the clock runs, App's tick calls `setTransportState(...)` **every animation frame** (`App.tsx`). That state lived at the App root, so the **entire App subtree re-rendered ~60×/s** — file tree, buffer tabs, sidebar, editor — even though only the transport display reads it.

Symptoms: wasted CPU, and React 19's dev performance-tracks emitting one `performance.measure` per component render with nothing clearing them → `performance.getEntriesByType('measure').length` in the **millions** (`TreeNode` 524k, `BufferItem` 297k in one session).

## Fix

Move the per-frame transport snapshot into an external store (`useSyncExternalStore`), so only components that read it re-render:

- New `src/renderer/app/transportStore.ts` — `setTransport` / `updateTransport` / `useTransport` / `useTransportLinkEnabled`.
- App's poll loops write via `setTransport()`; App no longer holds the state and **stops re-rendering per frame**. The tick's pending-UI-commit logic still reads the local `transport` variable, unchanged.
- `TransportDisplay` subscribes directly (`useTransport`) — now the only thing re-rendering each frame, which is correct (live bar.beat / Link phase).
- App reads only `linkEnabled` via a deduped selector to drive the Link-only poll loop; re-renders only when the flag flips.

No `React.memo` needed — removing the per-frame App state update stops the downstream re-renders at the source. Scope drawing, the transport display, and the Link-toggle optimistic update are behaviorally unchanged.

## Notes
- `TransportDisplay` still re-renders per frame by design (live display), so React 19's **dev-only** perf-track measures still grow slowly; production builds don't emit them. A dev-gated periodic `performance.clearMeasures()` could bound that further if wanted — left out here.

## Test plan
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test:unit` (188)
- [ ] Run the app, let the clock run, confirm transport position + scopes still update live
- [ ] Confirm `performance.getEntriesByType('measure').length` grows far slower (no `TreeNode`/`BufferItem` entries)
- [ ] Toggle Ableton Link on/off (incl. while stopped) — phase indicator animates, peers update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
