### PR TITLE
fix(mini): align mini-notation parser with Tidal/krill (replicate, weight, separators)

### DIFF
--- a/crates/modular_core/src/pattern_system/__fixtures__/peggy_parser_parity.json
+++ b/crates/modular_core/src/pattern_system/__fixtures__/peggy_parser_parity.json
@@ -1264,5 +1264,47 @@
         0
       ]
     }
+  },
+  {
+    "label": "replicate !! accumulates to 3",
+    "input": "0!!",
+    "peggy_ast": {
+      "Replicate": [
+        {
+          "Pure": {
+            "node": {
+              "Number": 0
+            },
+            "span": {
+              "start": 0,
+              "end": 1
+            }
+          }
+        },
+        3
+      ]
+    }
+  },
+  {
+    "label": "weight bare @ defaults to 2",
+    "input": "0@",
+    "peggy_ast": {
+      "Sequence": [
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 0
+              },
+              "span": {
+                "start": 0,
+                "end": 1
+              }
+            }
+          },
+          2
+        ]
+      ]
+    }
   }
 ]

--- a/crates/modular_core/src/pattern_system/__fixtures__/peggy_parser_parity.json
+++ b/crates/modular_core/src/pattern_system/__fixtures__/peggy_parser_parity.json
@@ -1015,5 +1015,254 @@
         0
       ]
     }
+  },
+  {
+    "label": "choice of space-separated sequences",
+    "input": "0 1 | 2 3",
+    "peggy_ast": {
+      "RandomChoice": [
+        [
+          {
+            "Sequence": [
+              [
+                {
+                  "Pure": {
+                    "node": {
+                      "Number": 0
+                    },
+                    "span": {
+                      "start": 0,
+                      "end": 1
+                    }
+                  }
+                },
+                null
+              ],
+              [
+                {
+                  "Pure": {
+                    "node": {
+                      "Number": 1
+                    },
+                    "span": {
+                      "start": 2,
+                      "end": 3
+                    }
+                  }
+                },
+                null
+              ]
+            ]
+          },
+          {
+            "Sequence": [
+              [
+                {
+                  "Pure": {
+                    "node": {
+                      "Number": 2
+                    },
+                    "span": {
+                      "start": 6,
+                      "end": 7
+                    }
+                  }
+                },
+                null
+              ],
+              [
+                {
+                  "Pure": {
+                    "node": {
+                      "Number": 3
+                    },
+                    "span": {
+                      "start": 8,
+                      "end": 9
+                    }
+                  }
+                },
+                null
+              ]
+            ]
+          }
+        ],
+        0
+      ]
+    }
+  },
+  {
+    "label": "choice of fast subsequences",
+    "input": "[0 1] | [2 3]",
+    "peggy_ast": {
+      "RandomChoice": [
+        [
+          {
+            "FastCat": [
+              [
+                {
+                  "Pure": {
+                    "node": {
+                      "Number": 0
+                    },
+                    "span": {
+                      "start": 1,
+                      "end": 2
+                    }
+                  }
+                },
+                null
+              ],
+              [
+                {
+                  "Pure": {
+                    "node": {
+                      "Number": 1
+                    },
+                    "span": {
+                      "start": 3,
+                      "end": 4
+                    }
+                  }
+                },
+                null
+              ]
+            ]
+          },
+          {
+            "FastCat": [
+              [
+                {
+                  "Pure": {
+                    "node": {
+                      "Number": 2
+                    },
+                    "span": {
+                      "start": 9,
+                      "end": 10
+                    }
+                  }
+                },
+                null
+              ],
+              [
+                {
+                  "Pure": {
+                    "node": {
+                      "Number": 3
+                    },
+                    "span": {
+                      "start": 11,
+                      "end": 12
+                    }
+                  }
+                },
+                null
+              ]
+            ]
+          }
+        ],
+        0
+      ]
+    }
+  },
+  {
+    "label": "choice of comma-chord subsequences",
+    "input": "[0,0,0] | [0,-7,0]",
+    "peggy_ast": {
+      "RandomChoice": [
+        [
+          {
+            "FastCat": [
+              [
+                {
+                  "Stack": [
+                    {
+                      "Pure": {
+                        "node": {
+                          "Number": 0
+                        },
+                        "span": {
+                          "start": 1,
+                          "end": 2
+                        }
+                      }
+                    },
+                    {
+                      "Pure": {
+                        "node": {
+                          "Number": 0
+                        },
+                        "span": {
+                          "start": 3,
+                          "end": 4
+                        }
+                      }
+                    },
+                    {
+                      "Pure": {
+                        "node": {
+                          "Number": 0
+                        },
+                        "span": {
+                          "start": 5,
+                          "end": 6
+                        }
+                      }
+                    }
+                  ]
+                },
+                null
+              ]
+            ]
+          },
+          {
+            "FastCat": [
+              [
+                {
+                  "Stack": [
+                    {
+                      "Pure": {
+                        "node": {
+                          "Number": 0
+                        },
+                        "span": {
+                          "start": 11,
+                          "end": 12
+                        }
+                      }
+                    },
+                    {
+                      "Pure": {
+                        "node": {
+                          "Number": -7
+                        },
+                        "span": {
+                          "start": 13,
+                          "end": 15
+                        }
+                      }
+                    },
+                    {
+                      "Pure": {
+                        "node": {
+                          "Number": 0
+                        },
+                        "span": {
+                          "start": 16,
+                          "end": 17
+                        }
+                      }
+                    }
+                  ]
+                },
+                null
+              ]
+            ]
+          }
+        ],
+        0
+      ]
+    }
   }
 ]

--- a/crates/modular_core/src/pattern_system/mini/convert.rs
+++ b/crates/modular_core/src/pattern_system/mini/convert.rs
@@ -2233,18 +2233,22 @@ mod tests {
 
     #[test]
     fn test_random_choice_in_sequence_has_onsets() {
-        // "a b|c d" parses as a (b|c) d — all three positions should produce
-        // discrete events with onsets.
+        // "1 2|3 4" chooses between the whole sequences `1 2` and `3 4` each
+        // cycle (`|` binds looser than the space-separated sequence). Each
+        // chosen sequence yields two discrete, onset-bearing events.
         let ast = parse("1 2|3 4").unwrap();
         let pat: Pattern<Option<f64>> = convert(&ast).unwrap();
 
-        for cycle in 0..20 {
+        let mut saw_first = false;
+        let mut saw_second = false;
+
+        for cycle in 0..40 {
             let haps = pat.query_arc(
                 Fraction::from_integer(cycle),
                 Fraction::from_integer(cycle + 1),
             );
 
-            // All haps should be discrete
+            // All haps should be discrete.
             for (i, hap) in haps.iter().enumerate() {
                 assert!(
                     hap.whole.is_some(),
@@ -2254,25 +2258,29 @@ mod tests {
                 );
             }
 
-            // Should have 3 onset-bearing haps per cycle
+            // Whichever sequence is chosen, it contributes two onsets.
             let onsets: Vec<_> = haps.iter().filter(|h| h.has_onset()).collect();
             assert_eq!(
                 onsets.len(),
-                3,
-                "cycle {}: expected 3 onsets, got {}",
+                2,
+                "cycle {}: expected 2 onsets, got {}",
                 cycle,
                 onsets.len()
             );
 
-            // First and third should be 1.0 and 4.0; middle is 2.0 or 3.0
-            assert_eq!(onsets[0].value, Some(1.0));
+            let values: Vec<_> = onsets.iter().map(|h| h.value).collect();
             assert!(
-                onsets[1].value == Some(2.0) || onsets[1].value == Some(3.0),
-                "middle value should be 2 or 3, got {:?}",
-                onsets[1].value
+                values == vec![Some(1.0), Some(2.0)] || values == vec![Some(3.0), Some(4.0)],
+                "cycle {}: expected `1 2` or `3 4`, got {:?}",
+                cycle,
+                values
             );
-            assert_eq!(onsets[2].value, Some(4.0));
+            saw_first |= values == vec![Some(1.0), Some(2.0)];
+            saw_second |= values == vec![Some(3.0), Some(4.0)];
         }
+
+        assert!(saw_first, "should choose `1 2` over 40 cycles");
+        assert!(saw_second, "should choose `3 4` over 40 cycles");
     }
 
     #[test]

--- a/crates/modular_core/src/pattern_system/mini/test_parser.rs
+++ b/crates/modular_core/src/pattern_system/mini/test_parser.rs
@@ -123,14 +123,14 @@ impl<'a> Parser<'a> {
     }
 
     fn stack_expr(&mut self) -> ParseResult<MiniAST> {
-        let head = self.sequence_expr()?;
+        let head = self.choice_expr()?;
         let mut items = vec![head];
         loop {
             self.skip_ws();
             if self.peek() == Some(b',') {
                 self.pos += 1;
                 self.skip_ws();
-                items.push(self.sequence_expr()?);
+                items.push(self.choice_expr()?);
             } else {
                 break;
             }
@@ -142,11 +142,43 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// Random choice: `a b | c d` picks one whole sequence per cycle.
+    /// Operands are full sequences (space-separated), so `|` binds looser
+    /// than a sequence but tighter than stack (`,`). Mirrors the grammar's
+    /// `ChoiceExpr` rule.
+    fn choice_expr(&mut self) -> ParseResult<MiniAST> {
+        let head = self.sequence_expr()?;
+        let mut choices = vec![head];
+        loop {
+            self.skip_ws();
+            if self.peek() == Some(b'|') {
+                self.pos += 1;
+                self.skip_ws();
+                choices.push(self.sequence_expr()?);
+            } else {
+                break;
+            }
+        }
+        if choices.len() == 1 {
+            Ok(choices.pop().unwrap())
+        } else {
+            let seed = self.next_seed();
+            Ok(MiniAST::RandomChoice(choices, seed))
+        }
+    }
+
     fn sequence_expr(&mut self) -> ParseResult<MiniAST> {
         let mut elems: Vec<(MiniAST, Option<f64>)> = Vec::new();
         loop {
             self.skip_ws();
-            if self.at_end() || matches!(self.peek(), Some(b']') | Some(b'>') | Some(b')') | Some(b',')) {
+            // `|` ends a sequence so the enclosing `choice_expr` can pick it
+            // up as a random-choice separator between whole sequences.
+            if self.at_end()
+                || matches!(
+                    self.peek(),
+                    Some(b']') | Some(b'>') | Some(b')') | Some(b',') | Some(b'|')
+                )
+            {
                 break;
             }
             let (base, weight) = self.element_with_weight()?;
@@ -236,7 +268,7 @@ impl<'a> Parser<'a> {
         match self.peek() {
             Some(b'[') => self.fast_sub(),
             Some(b'<') => self.slow_sub(),
-            _ => self.atom_or_choice(),
+            _ => self.atom(),
         }
     }
 
@@ -270,28 +302,7 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn atom_or_choice(&mut self) -> ParseResult<MiniAST> {
-        let first = self.choice_element()?;
-        let mut choices = vec![first];
-        loop {
-            self.skip_ws();
-            if self.peek() == Some(b'|') {
-                self.pos += 1;
-                self.skip_ws();
-                choices.push(self.choice_element()?);
-            } else {
-                break;
-            }
-        }
-        if choices.len() == 1 {
-            Ok(choices.pop().unwrap())
-        } else {
-            let seed = self.next_seed();
-            Ok(MiniAST::RandomChoice(choices, seed))
-        }
-    }
-
-    fn choice_element(&mut self) -> ParseResult<MiniAST> {
+    fn atom(&mut self) -> ParseResult<MiniAST> {
         self.skip_ws();
         match self.peek() {
             Some(b'~') => {

--- a/crates/modular_core/src/pattern_system/mini/test_parser.rs
+++ b/crates/modular_core/src/pattern_system/mini/test_parser.rs
@@ -202,7 +202,8 @@ impl<'a> Parser<'a> {
                 Some(b'@') => {
                     self.pos += 1;
                     let n = self.maybe_number()?;
-                    weight = Some(n.unwrap_or(1.0));
+                    // Bare `@` is weight 2 (matches Tidal/krill and `_`).
+                    weight = Some(n.unwrap_or(2.0));
                 }
                 Some(b'*') => {
                     self.pos += 1;
@@ -215,12 +216,19 @@ impl<'a> Parser<'a> {
                     ast = MiniAST::Slow(Box::new(ast), Box::new(op));
                 }
                 Some(b'!') => {
-                    self.pos += 1;
-                    let count = self.maybe_integer()?.unwrap_or(2);
-                    if count < 0 {
+                    // Accumulate consecutive `!`/`!n` into one Replicate:
+                    // total copies = 1 + Σ(value - 1), bare `!` = 2, `!n` = n.
+                    // Matches Tidal's `pRepeat = 1 + sum es` and krill. No
+                    // whitespace handling — the twin only sees adjacent `!`.
+                    let mut total: i64 = 1;
+                    while self.peek() == Some(b'!') {
+                        self.pos += 1;
+                        total += self.maybe_integer()?.unwrap_or(2) - 1;
+                    }
+                    if total < 0 {
                         return Err(ParseError("negative replicate count".into()));
                     }
-                    ast = MiniAST::Replicate(Box::new(ast), count as u32);
+                    ast = MiniAST::Replicate(Box::new(ast), total as u32);
                 }
                 Some(b'?') => {
                     self.pos += 1;

--- a/scripts/gen-sp-fixture.mjs
+++ b/scripts/gen-sp-fixture.mjs
@@ -46,6 +46,7 @@ const CASES = [
     { label: 'fast_2', source: '0*2' },
     { label: 'slow_2', source: '0/2' },
     { label: 'replicate_3', source: '0!3' },
+    { label: 'replicate_double', source: '0!!' },
     { label: 'euclidean_3_8', source: '0(3,8)' },
 ];
 

--- a/src/main/dsl/miniNotation/__tests__/parser.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/parser.test.ts
@@ -222,6 +222,26 @@ describe('modifiers', () => {
         }
     });
 
+    test('replicate !! accumulates to 3 (one flat Replicate, not nested)', () => {
+        // Tidal `pRepeat = 1 + sum es` / krill: `0!!` is 3 copies, not 4.
+        const r = $p('0!!');
+        if (!('Replicate' in r.ast)) return expect.fail('expected Replicate');
+        expect(r.ast.Replicate[1]).toBe(3);
+        expect('Replicate' in r.ast.Replicate[0]).toBe(false);
+    });
+
+    test('replicate `! !` with spaces also accumulates to 3', () => {
+        const r = $p('0 ! !');
+        if (!('Replicate' in r.ast)) return expect.fail('expected Replicate');
+        expect(r.ast.Replicate[1]).toBe(3);
+    });
+
+    test('replicate !2!3 accumulates to 4', () => {
+        const r = $p('0!2!3');
+        if (!('Replicate' in r.ast)) return expect.fail('expected Replicate');
+        expect(r.ast.Replicate[1]).toBe(4);
+    });
+
     test('degrade ? with probability', () => {
         const r = $p('0?0.3');
         expect('Degrade' in r.ast).toBe(true);
@@ -269,6 +289,14 @@ describe('modifiers', () => {
         expect(entries.length).toBe(2);
         expect(entries[0][1]).toBeCloseTo(3);
         expect(entries[1][1]).toBeNull();
+    });
+
+    test('bare `@` defaults weight to 2', () => {
+        // Matches Tidal `pElongate = 1 + sum` / krill, and `_` elongation.
+        const r = $p('0@');
+        if (!('Sequence' in r.ast)) return expect.fail('expected Sequence');
+        expect(r.ast.Sequence).toHaveLength(1);
+        expect(r.ast.Sequence[0][1]).toBe(2);
     });
 });
 
@@ -557,6 +585,31 @@ describe('feet `.`', () => {
             expect(r.ast.Sequence).toHaveLength(2);
             expect(r.ast.Sequence.every(([, w]) => w === null)).toBe(true);
         }
+    });
+});
+
+// Top-level `,` (stack) and `|` (choice) are mutually exclusive, with feet
+// (`.`) living inside each operand — matching Tidal stackTail/chooseTail and
+// krill. `<...>`/`{...}` are comma-only voices.
+describe('separator model (Tidal/krill parity)', () => {
+    test('`|` binds looser than feet: `0 | 1 . 2` is choose(0, feet(1,2))', () => {
+        const r = $p('0 | 1 . 2');
+        if (!('RandomChoice' in r.ast))
+            return expect.fail('expected RandomChoice');
+        const [choices] = r.ast.RandomChoice;
+        expect(choices.length).toBe(2);
+        // The second choice is the feet sub-sequence `1 . 2`, not a bare atom.
+        if (!('Sequence' in choices[1]))
+            return expect.fail('second choice should be a feet Sequence');
+        expect(choices[1].Sequence).toHaveLength(2);
+    });
+
+    test('mixing `,` and `|` at the top level is a parse error', () => {
+        expect(() => $p('0 , 1 | 2')).toThrow(MiniParseError);
+    });
+
+    test('`|` inside `<...>` is a parse error (comma-only voices)', () => {
+        expect(() => $p('<0 | 1>')).toThrow(MiniParseError);
     });
 });
 

--- a/src/main/dsl/miniNotation/__tests__/parser.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/parser.test.ts
@@ -362,14 +362,43 @@ describe('random choice', () => {
         expect('Rest' in r.ast.RandomChoice[0][1]).toBe(true);
     });
 
+    test('| chooses between whole bracketed subsequences', () => {
+        // Regression: `|` must alternate whole subsequences, not bind to a
+        // single neighbouring atom. `[0,0,0]` / `[0,-7,0]` are comma-chords.
+        const r = $p('[0,0,0] | [0,-7,0]');
+        if (!('RandomChoice' in r.ast))
+            return expect.fail('expected RandomChoice');
+        const [choices] = r.ast.RandomChoice;
+        expect(choices.length).toBe(2);
+        for (const c of choices) {
+            if (!('FastCat' in c))
+                return expect.fail('each choice should be a FastCat');
+            expect('Stack' in c.FastCat[0][0]).toBe(true);
+        }
+    });
+
+    test('| chooses between whole space-separated sequences', () => {
+        const r = $p('0 1 | 2 3');
+        if (!('RandomChoice' in r.ast))
+            return expect.fail('expected RandomChoice');
+        const [choices] = r.ast.RandomChoice;
+        expect(choices.length).toBe(2);
+        expect('Sequence' in choices[0]).toBe(true);
+        expect('Sequence' in choices[1]).toBe(true);
+    });
+
     test('seeds are assigned depth-first, left-to-right', () => {
-        const r = $p('0|1 2?');
-        // Walk the tree to collect seeds; expect RandomChoice first (0), Degrade second (1).
+        // `[0|1]` is parsed before `2?`, so the choice gets seed 0 and the
+        // degrade gets seed 1.
+        const r = $p('[0|1] 2?');
         if (!('Sequence' in r.ast)) return expect.fail('expected Sequence');
         const [first, second] = r.ast.Sequence;
-        if (!('RandomChoice' in first[0]))
-            return expect.fail('first element should be RandomChoice');
-        expect(first[0].RandomChoice[1]).toBe(0);
+        if (!('FastCat' in first[0]))
+            return expect.fail('first element should be FastCat');
+        const inner = first[0].FastCat[0][0];
+        if (!('RandomChoice' in inner))
+            return expect.fail('FastCat should wrap a RandomChoice');
+        expect(inner.RandomChoice[1]).toBe(0);
         if (!('Degrade' in second[0]))
             return expect.fail('second element should be Degrade');
         expect(second[0].Degrade[2]).toBe(1);

--- a/src/main/dsl/miniNotation/__tests__/peggy_parser_parity_fixture.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/peggy_parser_parity_fixture.test.ts
@@ -83,6 +83,9 @@ const PARITY_CASES: Array<{ label: string; input: string }> = [
     { label: 'weight @n positional', input: '0@2 1' },
     { label: 'random choice |', input: '0|1|2' },
     { label: 'rest inside choice', input: '0|~|2' },
+    { label: 'choice of space-separated sequences', input: '0 1 | 2 3' },
+    { label: 'choice of fast subsequences', input: '[0 1] | [2 3]' },
+    { label: 'choice of comma-chord subsequences', input: '[0,0,0] | [0,-7,0]' },
 ];
 
 /**

--- a/src/main/dsl/miniNotation/__tests__/peggy_parser_parity_fixture.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/peggy_parser_parity_fixture.test.ts
@@ -86,6 +86,8 @@ const PARITY_CASES: Array<{ label: string; input: string }> = [
     { label: 'choice of space-separated sequences', input: '0 1 | 2 3' },
     { label: 'choice of fast subsequences', input: '[0 1] | [2 3]' },
     { label: 'choice of comma-chord subsequences', input: '[0,0,0] | [0,-7,0]' },
+    { label: 'replicate !! accumulates to 3', input: '0!!' },
+    { label: 'weight bare @ defaults to 2', input: '0@' },
 ];
 
 /**

--- a/src/main/dsl/miniNotation/grammar.generated.ts
+++ b/src/main/dsl/miniNotation/grammar.generated.ts
@@ -213,8 +213,8 @@ function peg$parse(input, options) {
   let peg$startRuleFunction = peg$parseStart;
 
   const peg$c0 = ",";
-  const peg$c1 = ".";
-  const peg$c2 = "|";
+  const peg$c1 = "|";
+  const peg$c2 = ".";
   const peg$c3 = "_";
   const peg$c4 = "{";
   const peg$c5 = "}";
@@ -244,8 +244,8 @@ function peg$parse(input, options) {
   const peg$r3 = /^[ \t\r\n]/;
 
   const peg$e0 = peg$literalExpectation(",", false);
-  const peg$e1 = peg$literalExpectation(".", false);
-  const peg$e2 = peg$literalExpectation("|", false);
+  const peg$e1 = peg$literalExpectation("|", false);
+  const peg$e2 = peg$literalExpectation(".", false);
   const peg$e3 = peg$literalExpectation("_", false);
   const peg$e4 = peg$literalExpectation("{", false);
   const peg$e5 = peg$literalExpectation("}", false);
@@ -277,28 +277,26 @@ function peg$parse(input, options) {
 
   function peg$f0(s) {    return s;  }
   function peg$f1(head, tail) {
-    if (tail.length === 0) return head;
-    return { Stack: [head, ...tail] };
+    if (!tail) return head;
+    if (tail.kind === 'stack') return { Stack: [head, ...tail.items] };
+    return { RandomChoice: [[head, ...tail.items], ctx.nextSeed()] };
   }
-  function peg$f2(head, tail) {
+  function peg$f2(items) {    return { kind: 'stack', items };  }
+  function peg$f3(items) {    return { kind: 'rand', items };  }
+  function peg$f4(head, tail) {
     if (tail.length === 0) return head;
     return { Sequence: [head, ...tail].map(s => [s, null]) };
   }
-  function peg$f3(head, tail) {
-    if (tail.length === 0) return head;
-    const seed = ctx.nextSeed();
-    return { RandomChoice: [[head, ...tail], seed] };
-  }
-  function peg$f4(elems) {
+  function peg$f5(elems) {
     const out = applyElongation(elems);
     if (out.length === 1 && out[0][1] === null) {
       return out[0][0];
     }
     return { Sequence: out };
   }
-  function peg$f5() {    return { kind: 'elongation' };  }
-  function peg$f6(e) {    return { kind: 'element', entry: e };  }
-  function peg$f7(base, parts) {
+  function peg$f6() {    return { kind: 'elongation' };  }
+  function peg$f7(e) {    return { kind: 'element', entry: e };  }
+  function peg$f8(base, parts) {
     let ast = base;
     let weight = null;
     for (const part of parts) {
@@ -311,27 +309,29 @@ function peg$parse(input, options) {
     }
     return [ast, weight];
   }
-  function peg$f8(w) {    return { kind: 'weight', value: w };  }
-  function peg$f9(m) {    return { kind: 'mod', apply: m };  }
-  function peg$f10(head, tail, steps) {
+  function peg$f9(w) {    return { kind: 'weight', value: w };  }
+  function peg$f10(m) {    return { kind: 'mod', apply: m };  }
+  function peg$f11(head, tail, steps) {
     const children = [head, ...tail];
     return { Polymeter: { children, steps_per_cycle: steps } };
   }
-  function peg$f11(op) {    return op;  }
-  function peg$f12(s) {
+  function peg$f12(op) {    return op;  }
+  function peg$f13(s) {
     // Keep `[...]` as FastCat (explicit fast subsequence) rather than
-    // letting StackExpr flatten. When `s` is a Stack, wrap it as a
-    // single-element FastCat so nesting semantics match the Rust parser.
+    // letting the inner Group flatten. The Group body allows `,` XOR `|`
+    // with feet inside; a Stack/RandomChoice is wrapped as a single-element
+    // FastCat so nesting semantics match the Rust parser.
     if (s && s.Stack) {
       return { FastCat: [[s, null]] };
     }
     if (s && s.Sequence) {
       return { FastCat: s.Sequence };
     }
-    // Single element: wrap in FastCat with one entry.
+    // Single element (atom, or a `|` choice voice): wrap in one entry.
     return { FastCat: [[s, null]] };
   }
-  function peg$f13(s) {
+  function peg$f14(head, tail) {
+    const s = tail.length === 0 ? head : { Stack: [head, ...tail] };
     if (s && s.Stack) {
       return { SlowCat: [[s, null]] };
     }
@@ -340,14 +340,14 @@ function peg$parse(input, options) {
     }
     return { SlowCat: [[s, null]] };
   }
-  function peg$f14() {    return { Rest: spanOf(location()) };  }
-  function peg$f15(n) {
+  function peg$f15() {    return { Rest: spanOf(location()) };  }
+  function peg$f16(n) {
     return { Pure: located({ Hz: n }, location()) };
   }
-  function peg$f16(n) {
+  function peg$f17(n) {
     return { Pure: located({ Number: n }, location()) };
   }
-  function peg$f17(letter, acc, oct) {
+  function peg$f18(letter, acc, oct) {
     return {
       Pure: located(
         {
@@ -361,29 +361,30 @@ function peg$parse(input, options) {
       ),
     };
   }
-  function peg$f18() {    return "#";  }
   function peg$f19() {    return "#";  }
-  function peg$f20() {    return "b";  }
+  function peg$f20() {    return "#";  }
   function peg$f21() {    return "b";  }
-  function peg$f22(sign, digits) {
+  function peg$f22() {    return "b";  }
+  function peg$f23(sign, digits) {
     return parseInt((sign || "") + digits, 10);
   }
-  function peg$f23(n) {    return n === null ? 1 : n;  }
-  function peg$f24(op) {
+  function peg$f24(n) {    return n === null ? 2 : n;  }
+  function peg$f25(op) {
     return (ast, _c) => ({ Fast: [ast, op] });
   }
-  function peg$f25(op) {
+  function peg$f26(op) {
     return (ast, _c) => ({ Slow: [ast, op] });
   }
-  function peg$f26(n) {
-    const count = n === null ? 2 : n;
-    if (count < 0) error("Replicate count must be a non-negative integer");
-    return (ast, _c) => ({ Replicate: [ast, count] });
+  function peg$f27(n) {    return n === null ? 2 : n;  }
+  function peg$f28(parts) {
+    const total = parts.reduce((acc, v) => acc + (v - 1), 1);
+    if (total < 0) error("Replicate count must be a non-negative integer");
+    return (ast, _c) => ({ Replicate: [ast, total] });
   }
-  function peg$f27(p) {
+  function peg$f29(p) {
     return (ast, c) => ({ Degrade: [ast, p, c.nextSeed()] });
   }
-  function peg$f28(pulses, steps, rot) {
+  function peg$f30(pulses, steps, rot) {
     return (ast, _c) => ({
       Euclidean: {
         pattern: ast,
@@ -393,26 +394,26 @@ function peg$parse(input, options) {
       },
     });
   }
-  function peg$f29(r) {    return r;  }
-  function peg$f30(n) {
+  function peg$f31(r) {    return r;  }
+  function peg$f32(n) {
     return { Pure: located(n, location()) };
   }
-  function peg$f31(s) {    return s.fast;  }
-  function peg$f32(s) {    return s.slow;  }
-  function peg$f33(r) {    return r;  }
-  function peg$f34(n) {
+  function peg$f33(s) {    return s.fast;  }
+  function peg$f34(s) {    return s.slow;  }
+  function peg$f35(r) {    return r;  }
+  function peg$f36(n) {
     if (n < 0) error("Euclidean pulses/steps must be non-negative integers");
     return { Pure: located(n, location()) };
   }
-  function peg$f35(s) {    return s.fast;  }
-  function peg$f36(s) {    return s.slow;  }
-  function peg$f37(r) {    return r;  }
-  function peg$f38(n) {
+  function peg$f37(s) {    return s.fast;  }
+  function peg$f38(s) {    return s.slow;  }
+  function peg$f39(r) {    return r;  }
+  function peg$f40(n) {
     return { Pure: located(n, location()) };
   }
-  function peg$f39(s) {    return s.fast;  }
-  function peg$f40(s) {    return s.slow;  }
-  function peg$f41(first, tail) {
+  function peg$f41(s) {    return s.fast;  }
+  function peg$f42(s) {    return s.slow;  }
+  function peg$f43(first, tail) {
     if (tail.length === 0) {
       return { fast: { FastCat: first.asCat }, slow: { SlowCat: first.asCat } };
     }
@@ -422,10 +423,10 @@ function peg$parse(input, options) {
       slow: { Stack: all.map(s => ({ SlowCat: s.asCat })) },
     };
   }
-  function peg$f42(elems) {    return { asCat: applyElongation(elems) };  }
-  function peg$f43() {    return { kind: 'elongation' };  }
-  function peg$f44(e) {    return { kind: 'element', entry: e };  }
-  function peg$f45(base, parts) {
+  function peg$f44(elems) {    return { asCat: applyElongation(elems) };  }
+  function peg$f45() {    return { kind: 'elongation' };  }
+  function peg$f46(e) {    return { kind: 'element', entry: e };  }
+  function peg$f47(base, parts) {
     let ast = base;
     let weight = null;
     for (const part of parts) {
@@ -437,17 +438,17 @@ function peg$parse(input, options) {
     }
     return [ast, weight];
   }
-  function peg$f46(first, rest) {
+  function peg$f48(first, rest) {
     const seed = ctx.nextSeed();
     return { RandomChoice: [[first, ...rest], seed] };
   }
-  function peg$f47() {    return { Rest: spanOf(location()) };  }
-  function peg$f48(n) {    return { Pure: located(n, location()) };  }
   function peg$f49() {    return { Rest: spanOf(location()) };  }
   function peg$f50(n) {    return { Pure: located(n, location()) };  }
-  function peg$f51(s) {    return s.fast;  }
-  function peg$f52(s) {    return s.slow;  }
-  function peg$f53(first, tail) {
+  function peg$f51() {    return { Rest: spanOf(location()) };  }
+  function peg$f52(n) {    return { Pure: located(n, location()) };  }
+  function peg$f53(s) {    return s.fast;  }
+  function peg$f54(s) {    return s.slow;  }
+  function peg$f55(first, tail) {
     if (tail.length === 0) {
       return { fast: { FastCat: first.asCat }, slow: { SlowCat: first.asCat } };
     }
@@ -457,10 +458,10 @@ function peg$parse(input, options) {
       slow: { Stack: all.map(s => ({ SlowCat: s.asCat })) },
     };
   }
-  function peg$f54(elems) {    return { asCat: applyElongation(elems) };  }
-  function peg$f55() {    return { kind: 'elongation' };  }
-  function peg$f56(e) {    return { kind: 'element', entry: e };  }
-  function peg$f57(base, parts) {
+  function peg$f56(elems) {    return { asCat: applyElongation(elems) };  }
+  function peg$f57() {    return { kind: 'elongation' };  }
+  function peg$f58(e) {    return { kind: 'element', entry: e };  }
+  function peg$f59(base, parts) {
     let ast = base;
     let weight = null;
     for (const part of parts) {
@@ -472,23 +473,23 @@ function peg$parse(input, options) {
     }
     return [ast, weight];
   }
-  function peg$f58(first, rest) {
+  function peg$f60(first, rest) {
     const seed = ctx.nextSeed();
     return { RandomChoice: [[first, ...rest], seed] };
-  }
-  function peg$f59() {    return { Rest: spanOf(location()) };  }
-  function peg$f60(n) {
-    if (n < 0) error("Expected non-negative integer");
-    return { Pure: located(n, location()) };
   }
   function peg$f61() {    return { Rest: spanOf(location()) };  }
   function peg$f62(n) {
     if (n < 0) error("Expected non-negative integer");
     return { Pure: located(n, location()) };
   }
-  function peg$f63(s) {    return s.fast;  }
-  function peg$f64(s) {    return s.slow;  }
-  function peg$f65(first, tail) {
+  function peg$f63() {    return { Rest: spanOf(location()) };  }
+  function peg$f64(n) {
+    if (n < 0) error("Expected non-negative integer");
+    return { Pure: located(n, location()) };
+  }
+  function peg$f65(s) {    return s.fast;  }
+  function peg$f66(s) {    return s.slow;  }
+  function peg$f67(first, tail) {
     if (tail.length === 0) {
       return { fast: { FastCat: first.asCat }, slow: { SlowCat: first.asCat } };
     }
@@ -498,10 +499,10 @@ function peg$parse(input, options) {
       slow: { Stack: all.map(s => ({ SlowCat: s.asCat })) },
     };
   }
-  function peg$f66(elems) {    return { asCat: applyElongation(elems) };  }
-  function peg$f67() {    return { kind: 'elongation' };  }
-  function peg$f68(e) {    return { kind: 'element', entry: e };  }
-  function peg$f69(base, parts) {
+  function peg$f68(elems) {    return { asCat: applyElongation(elems) };  }
+  function peg$f69() {    return { kind: 'elongation' };  }
+  function peg$f70(e) {    return { kind: 'element', entry: e };  }
+  function peg$f71(base, parts) {
     let ast = base;
     let weight = null;
     for (const part of parts) {
@@ -513,18 +514,18 @@ function peg$parse(input, options) {
     }
     return [ast, weight];
   }
-  function peg$f70(first, rest) {
+  function peg$f72(first, rest) {
     const seed = ctx.nextSeed();
     return { RandomChoice: [[first, ...rest], seed] };
   }
-  function peg$f71() {    return { Rest: spanOf(location()) };  }
-  function peg$f72(n) {    return { Pure: located(n, location()) };  }
   function peg$f73() {    return { Rest: spanOf(location()) };  }
   function peg$f74(n) {    return { Pure: located(n, location()) };  }
-  function peg$f75(s) {    return s.fast;  }
-  function peg$f76(s) {    return s.slow;  }
-  function peg$f77(s) {    return parseFloat(s);  }
-  function peg$f78(s) {    return parseInt(s, 10);  }
+  function peg$f75() {    return { Rest: spanOf(location()) };  }
+  function peg$f76(n) {    return { Pure: located(n, location()) };  }
+  function peg$f77(s) {    return s.fast;  }
+  function peg$f78(s) {    return s.slow;  }
+  function peg$f79(s) {    return parseFloat(s);  }
+  function peg$f80(s) {    return parseInt(s, 10);  }
   let peg$currPos = options.peg$currPos | 0;
   let peg$savedPos = peg$currPos;
   const peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -700,7 +701,7 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$parse_();
-    s2 = peg$parseStackExpr();
+    s2 = peg$parseGroup();
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
       peg$savedPos = s0;
@@ -713,59 +714,18 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseStackExpr() {
-    let s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseGroup() {
+    let s0, s1, s2;
 
     s0 = peg$currPos;
-    s1 = peg$parseFeetExpr();
+    s1 = peg$parseFeetSeq();
     if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse_();
-      if (input.charCodeAt(peg$currPos) === 44) {
-        s5 = peg$c0;
-        peg$currPos++;
-      } else {
-        s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e0); }
+      s2 = peg$parseCommaTail();
+      if (s2 === peg$FAILED) {
+        s2 = peg$parsePipeTail();
       }
-      if (s5 !== peg$FAILED) {
-        s6 = peg$parse_();
-        s7 = peg$parseFeetExpr();
-        if (s7 !== peg$FAILED) {
-          s3 = s7;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse_();
-        if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c0;
-          peg$currPos++;
-        } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e0); }
-        }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse_();
-          s7 = peg$parseFeetExpr();
-          if (s7 !== peg$FAILED) {
-            s3 = s7;
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
+      if (s2 === peg$FAILED) {
+        s2 = null;
       }
       peg$savedPos = s0;
       s0 = peg$f1(s1, s2);
@@ -777,71 +737,137 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFeetExpr() {
-    let s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseCommaTail() {
+    let s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
-    s1 = peg$parseChoiceExpr();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse_();
-      if (input.charCodeAt(peg$currPos) === 46) {
-        s5 = peg$c1;
-        peg$currPos++;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parse_();
+    if (input.charCodeAt(peg$currPos) === 44) {
+      s4 = peg$c0;
+      peg$currPos++;
+    } else {
+      s4 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e0); }
+    }
+    if (s4 !== peg$FAILED) {
+      s5 = peg$parse_();
+      s6 = peg$parseFeetSeq();
+      if (s6 !== peg$FAILED) {
+        s2 = s6;
       } else {
-        s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e1); }
+        peg$currPos = s2;
+        s2 = peg$FAILED;
       }
-      if (s5 !== peg$FAILED) {
-        s6 = peg$parse_();
-        s7 = peg$parseChoiceExpr();
-        if (s7 !== peg$FAILED) {
-          s3 = s7;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      while (s3 !== peg$FAILED) {
-        s2.push(s3);
-        s3 = peg$currPos;
-        s4 = peg$parse_();
-        if (input.charCodeAt(peg$currPos) === 46) {
-          s5 = peg$c1;
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$currPos;
+        s3 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s4 = peg$c0;
           peg$currPos++;
         } else {
-          s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e1); }
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e0); }
         }
-        if (s5 !== peg$FAILED) {
-          s6 = peg$parse_();
-          s7 = peg$parseChoiceExpr();
-          if (s7 !== peg$FAILED) {
-            s3 = s7;
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parse_();
+          s6 = peg$parseFeetSeq();
+          if (s6 !== peg$FAILED) {
+            s2 = s6;
           } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
+            peg$currPos = s2;
+            s2 = peg$FAILED;
           }
         } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
+          peg$currPos = s2;
+          s2 = peg$FAILED;
         }
       }
-      peg$savedPos = s0;
-      s0 = peg$f2(s1, s2);
     } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      s1 = peg$FAILED;
     }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$f2(s1);
+    }
+    s0 = s1;
 
     return s0;
   }
 
-  function peg$parseChoiceExpr() {
+  function peg$parsePipeTail() {
+    let s0, s1, s2, s3, s4, s5, s6;
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parse_();
+    if (input.charCodeAt(peg$currPos) === 124) {
+      s4 = peg$c1;
+      peg$currPos++;
+    } else {
+      s4 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e1); }
+    }
+    if (s4 !== peg$FAILED) {
+      s5 = peg$parse_();
+      s6 = peg$parseFeetSeq();
+      if (s6 !== peg$FAILED) {
+        s2 = s6;
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$currPos;
+        s3 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 124) {
+          s4 = peg$c1;
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e1); }
+        }
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parse_();
+          s6 = peg$parseFeetSeq();
+          if (s6 !== peg$FAILED) {
+            s2 = s6;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$f3(s1);
+    }
+    s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseFeetSeq() {
     let s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
@@ -850,7 +876,7 @@ function peg$parse(input, options) {
       s2 = [];
       s3 = peg$currPos;
       s4 = peg$parse_();
-      if (input.charCodeAt(peg$currPos) === 124) {
+      if (input.charCodeAt(peg$currPos) === 46) {
         s5 = peg$c2;
         peg$currPos++;
       } else {
@@ -874,7 +900,7 @@ function peg$parse(input, options) {
         s2.push(s3);
         s3 = peg$currPos;
         s4 = peg$parse_();
-        if (input.charCodeAt(peg$currPos) === 124) {
+        if (input.charCodeAt(peg$currPos) === 46) {
           s5 = peg$c2;
           peg$currPos++;
         } else {
@@ -896,7 +922,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f3(s1, s2);
+      s0 = peg$f4(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -937,7 +963,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f4(s1);
+      s1 = peg$f5(s1);
     }
     s0 = s1;
 
@@ -968,7 +994,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f5();
+        s0 = peg$f6();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -982,7 +1008,7 @@ function peg$parse(input, options) {
       s1 = peg$parseElementWithWeight();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f6(s1);
+        s1 = peg$f7(s1);
       }
       s0 = s1;
     }
@@ -1003,7 +1029,7 @@ function peg$parse(input, options) {
         s3 = peg$parseElementPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f7(s1, s2);
+      s0 = peg$f8(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1020,7 +1046,7 @@ function peg$parse(input, options) {
     s2 = peg$parseWeight();
     if (s2 !== peg$FAILED) {
       peg$savedPos = s0;
-      s0 = peg$f8(s2);
+      s0 = peg$f9(s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1031,7 +1057,7 @@ function peg$parse(input, options) {
       s2 = peg$parseModifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f9(s2);
+        s0 = peg$f10(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1071,7 +1097,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
-      s3 = peg$parseFeetExpr();
+      s3 = peg$parseFeetSeq();
       if (s3 !== peg$FAILED) {
         s4 = [];
         s5 = peg$currPos;
@@ -1085,7 +1111,7 @@ function peg$parse(input, options) {
         }
         if (s7 !== peg$FAILED) {
           s8 = peg$parse_();
-          s9 = peg$parseFeetExpr();
+          s9 = peg$parseFeetSeq();
           if (s9 !== peg$FAILED) {
             s5 = s9;
           } else {
@@ -1109,7 +1135,7 @@ function peg$parse(input, options) {
           }
           if (s7 !== peg$FAILED) {
             s8 = peg$parse_();
-            s9 = peg$parseFeetExpr();
+            s9 = peg$parseFeetSeq();
             if (s9 !== peg$FAILED) {
               s5 = s9;
             } else {
@@ -1135,7 +1161,7 @@ function peg$parse(input, options) {
             s7 = null;
           }
           peg$savedPos = s0;
-          s0 = peg$f10(s3, s4, s7);
+          s0 = peg$f11(s3, s4, s7);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1167,7 +1193,7 @@ function peg$parse(input, options) {
       s2 = peg$parseModOperandF64();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f11(s2);
+        s0 = peg$f12(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1193,7 +1219,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
-      s3 = peg$parseStackExpr();
+      s3 = peg$parseGroup();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (input.charCodeAt(peg$currPos) === 93) {
@@ -1205,7 +1231,7 @@ function peg$parse(input, options) {
         }
         if (s5 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f12(s3);
+          s0 = peg$f13(s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1223,7 +1249,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseSlowSub() {
-    let s0, s1, s2, s3, s4, s5;
+    let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 60) {
@@ -1235,19 +1261,67 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
-      s3 = peg$parseStackExpr();
+      s3 = peg$parseFeetSeq();
       if (s3 !== peg$FAILED) {
-        s4 = peg$parse_();
-        if (input.charCodeAt(peg$currPos) === 62) {
-          s5 = peg$c10;
+        s4 = [];
+        s5 = peg$currPos;
+        s6 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s7 = peg$c0;
           peg$currPos++;
         } else {
+          s7 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e0); }
+        }
+        if (s7 !== peg$FAILED) {
+          s8 = peg$parse_();
+          s9 = peg$parseFeetSeq();
+          if (s9 !== peg$FAILED) {
+            s5 = s9;
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s5;
           s5 = peg$FAILED;
+        }
+        while (s5 !== peg$FAILED) {
+          s4.push(s5);
+          s5 = peg$currPos;
+          s6 = peg$parse_();
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s7 = peg$c0;
+            peg$currPos++;
+          } else {
+            s7 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e0); }
+          }
+          if (s7 !== peg$FAILED) {
+            s8 = peg$parse_();
+            s9 = peg$parseFeetSeq();
+            if (s9 !== peg$FAILED) {
+              s5 = s9;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        }
+        s5 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 62) {
+          s6 = peg$c10;
+          peg$currPos++;
+        } else {
+          s6 = peg$FAILED;
           if (peg$silentFails === 0) { peg$fail(peg$e10); }
         }
-        if (s5 !== peg$FAILED) {
+        if (s6 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f13(s3);
+          s0 = peg$f14(s3, s4);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1326,7 +1400,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f14();
+      s1 = peg$f15();
     }
     s0 = s1;
 
@@ -1362,7 +1436,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f15(s1);
+        s0 = peg$f16(s1);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1382,7 +1456,7 @@ function peg$parse(input, options) {
     s1 = peg$parseNumber();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f16(s1);
+      s1 = peg$f17(s1);
     }
     s0 = s1;
 
@@ -1421,7 +1495,7 @@ function peg$parse(input, options) {
       }
       if (s4 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f17(s1, s2, s3);
+        s0 = peg$f18(s1, s2, s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1447,7 +1521,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f18();
+      s1 = peg$f19();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1461,7 +1535,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f19();
+        s1 = peg$f20();
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1475,7 +1549,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$f20();
+          s1 = peg$f21();
         }
         s0 = s1;
         if (s0 === peg$FAILED) {
@@ -1489,7 +1563,7 @@ function peg$parse(input, options) {
           }
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$f21();
+            s1 = peg$f22();
           }
           s0 = s1;
         }
@@ -1543,7 +1617,7 @@ function peg$parse(input, options) {
     }
     if (s2 !== peg$FAILED) {
       peg$savedPos = s0;
-      s0 = peg$f22(s1, s2);
+      s0 = peg$f23(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1604,7 +1678,7 @@ function peg$parse(input, options) {
         s3 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f23(s3);
+      s0 = peg$f24(s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1629,7 +1703,7 @@ function peg$parse(input, options) {
       s3 = peg$parseModOperandF64();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f24(s3);
+        s0 = peg$f25(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1658,7 +1732,7 @@ function peg$parse(input, options) {
       s3 = peg$parseModOperandF64();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f25(s3);
+        s0 = peg$f26(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1672,28 +1746,64 @@ function peg$parse(input, options) {
   }
 
   function peg$parseReplicate() {
-    let s0, s1, s2, s3;
+    let s0, s1, s2, s3, s4, s5, s6;
 
     s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parse_();
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c21;
+      s4 = peg$c21;
       peg$currPos++;
     } else {
-      s1 = peg$FAILED;
+      s4 = peg$FAILED;
       if (peg$silentFails === 0) { peg$fail(peg$e24); }
     }
-    if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      s3 = peg$parseInteger();
-      if (s3 === peg$FAILED) {
-        s3 = null;
+    if (s4 !== peg$FAILED) {
+      s5 = peg$parse_();
+      s6 = peg$parseInteger();
+      if (s6 === peg$FAILED) {
+        s6 = null;
       }
-      peg$savedPos = s0;
-      s0 = peg$f26(s3);
+      peg$savedPos = s2;
+      s2 = peg$f27(s6);
     } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
+      peg$currPos = s2;
+      s2 = peg$FAILED;
     }
+    if (s2 !== peg$FAILED) {
+      while (s2 !== peg$FAILED) {
+        s1.push(s2);
+        s2 = peg$currPos;
+        s3 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 33) {
+          s4 = peg$c21;
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e24); }
+        }
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parse_();
+          s6 = peg$parseInteger();
+          if (s6 === peg$FAILED) {
+            s6 = null;
+          }
+          peg$savedPos = s2;
+          s2 = peg$f27(s6);
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      }
+    } else {
+      s1 = peg$FAILED;
+    }
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$f28(s1);
+    }
+    s0 = s1;
 
     return s0;
   }
@@ -1716,7 +1826,7 @@ function peg$parse(input, options) {
         s3 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f27(s3);
+      s0 = peg$f29(s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1787,7 +1897,7 @@ function peg$parse(input, options) {
             }
             if (s11 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f28(s3, s7, s9);
+              s0 = peg$f30(s3, s7, s9);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -1819,7 +1929,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOperandRandomChoiceF64();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f29(s1);
+      s1 = peg$f31(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1827,7 +1937,7 @@ function peg$parse(input, options) {
       s1 = peg$parseNumber();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f30(s1);
+        s1 = peg$f32(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1853,7 +1963,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f31(s3);
+              s0 = peg$f33(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -1889,7 +1999,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f32(s3);
+                s0 = peg$f34(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -1916,7 +2026,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOperandRandomChoiceU32();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f33(s1);
+      s1 = peg$f35(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -1924,7 +2034,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f34(s1);
+        s1 = peg$f36(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -1950,7 +2060,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f35(s3);
+              s0 = peg$f37(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -1986,7 +2096,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f36(s3);
+                s0 = peg$f38(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2013,7 +2123,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOperandRandomChoiceI32();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f37(s1);
+      s1 = peg$f39(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2021,7 +2131,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f38(s1);
+        s1 = peg$f40(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -2047,7 +2157,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f39(s3);
+              s0 = peg$f41(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -2083,7 +2193,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f40(s3);
+                s0 = peg$f42(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2158,7 +2268,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f41(s1, s2);
+      s0 = peg$f43(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2199,7 +2309,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f42(s1);
+      s1 = peg$f44(s1);
     }
     s0 = s1;
 
@@ -2230,7 +2340,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f43();
+        s0 = peg$f45();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2244,7 +2354,7 @@ function peg$parse(input, options) {
       s1 = peg$parseOperandElementF64();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f44(s1);
+        s1 = peg$f46(s1);
       }
       s0 = s1;
     }
@@ -2268,7 +2378,7 @@ function peg$parse(input, options) {
         s3 = peg$parseElementPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f45(s1, s2);
+      s0 = peg$f47(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2287,11 +2397,11 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$parse_();
       if (input.charCodeAt(peg$currPos) === 124) {
-        s5 = peg$c2;
+        s5 = peg$c1;
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e2); }
+        if (peg$silentFails === 0) { peg$fail(peg$e1); }
       }
       if (s5 !== peg$FAILED) {
         s6 = peg$parse_();
@@ -2312,11 +2422,11 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$parse_();
           if (input.charCodeAt(peg$currPos) === 124) {
-            s5 = peg$c2;
+            s5 = peg$c1;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e2); }
+            if (peg$silentFails === 0) { peg$fail(peg$e1); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2337,7 +2447,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f46(s1, s2);
+        s0 = peg$f48(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2401,7 +2511,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f47();
+      s1 = peg$f49();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2409,7 +2519,7 @@ function peg$parse(input, options) {
       s1 = peg$parseNumber();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f48(s1);
+        s1 = peg$f50(s1);
       }
       s0 = s1;
     }
@@ -2468,7 +2578,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f49();
+      s1 = peg$f51();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2476,7 +2586,7 @@ function peg$parse(input, options) {
       s1 = peg$parseNumber();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f50(s1);
+        s1 = peg$f52(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -2502,7 +2612,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f51(s3);
+              s0 = peg$f53(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -2538,7 +2648,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f52(s3);
+                s0 = peg$f54(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2613,7 +2723,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f53(s1, s2);
+      s0 = peg$f55(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2654,7 +2764,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f54(s1);
+      s1 = peg$f56(s1);
     }
     s0 = s1;
 
@@ -2685,7 +2795,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f55();
+        s0 = peg$f57();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2699,7 +2809,7 @@ function peg$parse(input, options) {
       s1 = peg$parseOperandElementU32();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f56(s1);
+        s1 = peg$f58(s1);
       }
       s0 = s1;
     }
@@ -2723,7 +2833,7 @@ function peg$parse(input, options) {
         s3 = peg$parseElementPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f57(s1, s2);
+      s0 = peg$f59(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2742,11 +2852,11 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$parse_();
       if (input.charCodeAt(peg$currPos) === 124) {
-        s5 = peg$c2;
+        s5 = peg$c1;
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e2); }
+        if (peg$silentFails === 0) { peg$fail(peg$e1); }
       }
       if (s5 !== peg$FAILED) {
         s6 = peg$parse_();
@@ -2767,11 +2877,11 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$parse_();
           if (input.charCodeAt(peg$currPos) === 124) {
-            s5 = peg$c2;
+            s5 = peg$c1;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e2); }
+            if (peg$silentFails === 0) { peg$fail(peg$e1); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2792,7 +2902,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f58(s1, s2);
+        s0 = peg$f60(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2856,7 +2966,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f59();
+      s1 = peg$f61();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2864,7 +2974,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f60(s1);
+        s1 = peg$f62(s1);
       }
       s0 = s1;
     }
@@ -2923,7 +3033,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f61();
+      s1 = peg$f63();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2931,7 +3041,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f62(s1);
+        s1 = peg$f64(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -2957,7 +3067,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f63(s3);
+              s0 = peg$f65(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -2993,7 +3103,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f64(s3);
+                s0 = peg$f66(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -3068,7 +3178,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f65(s1, s2);
+      s0 = peg$f67(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -3109,7 +3219,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f66(s1);
+      s1 = peg$f68(s1);
     }
     s0 = s1;
 
@@ -3140,7 +3250,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f67();
+        s0 = peg$f69();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3154,7 +3264,7 @@ function peg$parse(input, options) {
       s1 = peg$parseOperandElementI32();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f68(s1);
+        s1 = peg$f70(s1);
       }
       s0 = s1;
     }
@@ -3178,7 +3288,7 @@ function peg$parse(input, options) {
         s3 = peg$parseElementPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f69(s1, s2);
+      s0 = peg$f71(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -3197,11 +3307,11 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$parse_();
       if (input.charCodeAt(peg$currPos) === 124) {
-        s5 = peg$c2;
+        s5 = peg$c1;
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e2); }
+        if (peg$silentFails === 0) { peg$fail(peg$e1); }
       }
       if (s5 !== peg$FAILED) {
         s6 = peg$parse_();
@@ -3222,11 +3332,11 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$parse_();
           if (input.charCodeAt(peg$currPos) === 124) {
-            s5 = peg$c2;
+            s5 = peg$c1;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e2); }
+            if (peg$silentFails === 0) { peg$fail(peg$e1); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -3247,7 +3357,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f70(s1, s2);
+        s0 = peg$f72(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3311,7 +3421,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f71();
+      s1 = peg$f73();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3319,7 +3429,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f72(s1);
+        s1 = peg$f74(s1);
       }
       s0 = s1;
     }
@@ -3378,7 +3488,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f73();
+      s1 = peg$f75();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3386,7 +3496,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f74(s1);
+        s1 = peg$f76(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3412,7 +3522,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f75(s3);
+              s0 = peg$f77(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -3448,7 +3558,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f76(s3);
+                s0 = peg$f78(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -3510,11 +3620,11 @@ function peg$parse(input, options) {
     if (s4 !== peg$FAILED) {
       s5 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 46) {
-        s6 = peg$c1;
+        s6 = peg$c2;
         peg$currPos++;
       } else {
         s6 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e1); }
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
       }
       if (s6 !== peg$FAILED) {
         s7 = [];
@@ -3566,7 +3676,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f77(s1);
+      s1 = peg$f79(s1);
     }
     s0 = s1;
     peg$silentFails--;
@@ -3631,7 +3741,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f78(s1);
+      s1 = peg$f80(s1);
     }
     s0 = s1;
     peg$silentFails--;

--- a/src/main/dsl/miniNotation/grammar.generated.ts
+++ b/src/main/dsl/miniNotation/grammar.generated.ts
@@ -214,15 +214,15 @@ function peg$parse(input, options) {
 
   const peg$c0 = ",";
   const peg$c1 = ".";
-  const peg$c2 = "_";
-  const peg$c3 = "{";
-  const peg$c4 = "}";
-  const peg$c5 = "%";
-  const peg$c6 = "[";
-  const peg$c7 = "]";
-  const peg$c8 = "<";
-  const peg$c9 = ">";
-  const peg$c10 = "|";
+  const peg$c2 = "|";
+  const peg$c3 = "_";
+  const peg$c4 = "{";
+  const peg$c5 = "}";
+  const peg$c6 = "%";
+  const peg$c7 = "[";
+  const peg$c8 = "]";
+  const peg$c9 = "<";
+  const peg$c10 = ">";
   const peg$c11 = "~";
   const peg$c12 = "-";
   const peg$c13 = "hz";
@@ -245,15 +245,15 @@ function peg$parse(input, options) {
 
   const peg$e0 = peg$literalExpectation(",", false);
   const peg$e1 = peg$literalExpectation(".", false);
-  const peg$e2 = peg$literalExpectation("_", false);
-  const peg$e3 = peg$literalExpectation("{", false);
-  const peg$e4 = peg$literalExpectation("}", false);
-  const peg$e5 = peg$literalExpectation("%", false);
-  const peg$e6 = peg$literalExpectation("[", false);
-  const peg$e7 = peg$literalExpectation("]", false);
-  const peg$e8 = peg$literalExpectation("<", false);
-  const peg$e9 = peg$literalExpectation(">", false);
-  const peg$e10 = peg$literalExpectation("|", false);
+  const peg$e2 = peg$literalExpectation("|", false);
+  const peg$e3 = peg$literalExpectation("_", false);
+  const peg$e4 = peg$literalExpectation("{", false);
+  const peg$e5 = peg$literalExpectation("}", false);
+  const peg$e6 = peg$literalExpectation("%", false);
+  const peg$e7 = peg$literalExpectation("[", false);
+  const peg$e8 = peg$literalExpectation("]", false);
+  const peg$e9 = peg$literalExpectation("<", false);
+  const peg$e10 = peg$literalExpectation(">", false);
   const peg$e11 = peg$literalExpectation("~", false);
   const peg$e12 = peg$literalExpectation("-", false);
   const peg$e13 = peg$classExpectation([["0", "9"]], false, false, false);
@@ -284,16 +284,21 @@ function peg$parse(input, options) {
     if (tail.length === 0) return head;
     return { Sequence: [head, ...tail].map(s => [s, null]) };
   }
-  function peg$f3(elems) {
+  function peg$f3(head, tail) {
+    if (tail.length === 0) return head;
+    const seed = ctx.nextSeed();
+    return { RandomChoice: [[head, ...tail], seed] };
+  }
+  function peg$f4(elems) {
     const out = applyElongation(elems);
     if (out.length === 1 && out[0][1] === null) {
       return out[0][0];
     }
     return { Sequence: out };
   }
-  function peg$f4() {    return { kind: 'elongation' };  }
-  function peg$f5(e) {    return { kind: 'element', entry: e };  }
-  function peg$f6(base, parts) {
+  function peg$f5() {    return { kind: 'elongation' };  }
+  function peg$f6(e) {    return { kind: 'element', entry: e };  }
+  function peg$f7(base, parts) {
     let ast = base;
     let weight = null;
     for (const part of parts) {
@@ -306,14 +311,14 @@ function peg$parse(input, options) {
     }
     return [ast, weight];
   }
-  function peg$f7(w) {    return { kind: 'weight', value: w };  }
-  function peg$f8(m) {    return { kind: 'mod', apply: m };  }
-  function peg$f9(head, tail, steps) {
+  function peg$f8(w) {    return { kind: 'weight', value: w };  }
+  function peg$f9(m) {    return { kind: 'mod', apply: m };  }
+  function peg$f10(head, tail, steps) {
     const children = [head, ...tail];
     return { Polymeter: { children, steps_per_cycle: steps } };
   }
-  function peg$f10(op) {    return op;  }
-  function peg$f11(s) {
+  function peg$f11(op) {    return op;  }
+  function peg$f12(s) {
     // Keep `[...]` as FastCat (explicit fast subsequence) rather than
     // letting StackExpr flatten. When `s` is a Stack, wrap it as a
     // single-element FastCat so nesting semantics match the Rust parser.
@@ -326,7 +331,7 @@ function peg$parse(input, options) {
     // Single element: wrap in FastCat with one entry.
     return { FastCat: [[s, null]] };
   }
-  function peg$f12(s) {
+  function peg$f13(s) {
     if (s && s.Stack) {
       return { SlowCat: [[s, null]] };
     }
@@ -334,10 +339,6 @@ function peg$parse(input, options) {
       return { SlowCat: s.Sequence };
     }
     return { SlowCat: [[s, null]] };
-  }
-  function peg$f13(first, rest) {
-    const seed = ctx.nextSeed();
-    return { RandomChoice: [[first, ...rest], seed] };
   }
   function peg$f14() {    return { Rest: spanOf(location()) };  }
   function peg$f15(n) {
@@ -780,7 +781,7 @@ function peg$parse(input, options) {
     let s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
-    s1 = peg$parseSequenceExpr();
+    s1 = peg$parseChoiceExpr();
     if (s1 !== peg$FAILED) {
       s2 = [];
       s3 = peg$currPos;
@@ -794,7 +795,7 @@ function peg$parse(input, options) {
       }
       if (s5 !== peg$FAILED) {
         s6 = peg$parse_();
-        s7 = peg$parseSequenceExpr();
+        s7 = peg$parseChoiceExpr();
         if (s7 !== peg$FAILED) {
           s3 = s7;
         } else {
@@ -818,7 +819,7 @@ function peg$parse(input, options) {
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
-          s7 = peg$parseSequenceExpr();
+          s7 = peg$parseChoiceExpr();
           if (s7 !== peg$FAILED) {
             s3 = s7;
           } else {
@@ -832,6 +833,70 @@ function peg$parse(input, options) {
       }
       peg$savedPos = s0;
       s0 = peg$f2(s1, s2);
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    return s0;
+  }
+
+  function peg$parseChoiceExpr() {
+    let s0, s1, s2, s3, s4, s5, s6, s7;
+
+    s0 = peg$currPos;
+    s1 = peg$parseSequenceExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse_();
+      if (input.charCodeAt(peg$currPos) === 124) {
+        s5 = peg$c2;
+        peg$currPos++;
+      } else {
+        s5 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
+      }
+      if (s5 !== peg$FAILED) {
+        s6 = peg$parse_();
+        s7 = peg$parseSequenceExpr();
+        if (s7 !== peg$FAILED) {
+          s3 = s7;
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 124) {
+          s5 = peg$c2;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e2); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          s7 = peg$parseSequenceExpr();
+          if (s7 !== peg$FAILED) {
+            s3 = s7;
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      peg$savedPos = s0;
+      s0 = peg$f3(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -872,7 +937,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f3(s1);
+      s1 = peg$f4(s1);
     }
     s0 = s1;
 
@@ -884,11 +949,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 95) {
-      s1 = peg$c2;
+      s1 = peg$c3;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e2); }
+      if (peg$silentFails === 0) { peg$fail(peg$e3); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -903,7 +968,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f4();
+        s0 = peg$f5();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -917,7 +982,7 @@ function peg$parse(input, options) {
       s1 = peg$parseElementWithWeight();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f5(s1);
+        s1 = peg$f6(s1);
       }
       s0 = s1;
     }
@@ -938,7 +1003,7 @@ function peg$parse(input, options) {
         s3 = peg$parseElementPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f6(s1, s2);
+      s0 = peg$f7(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -955,7 +1020,7 @@ function peg$parse(input, options) {
     s2 = peg$parseWeight();
     if (s2 !== peg$FAILED) {
       peg$savedPos = s0;
-      s0 = peg$f7(s2);
+      s0 = peg$f8(s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -966,7 +1031,7 @@ function peg$parse(input, options) {
       s2 = peg$parseModifier();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f8(s2);
+        s0 = peg$f9(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -998,11 +1063,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c3;
+      s1 = peg$c4;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e3); }
+      if (peg$silentFails === 0) { peg$fail(peg$e4); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1058,11 +1123,11 @@ function peg$parse(input, options) {
         }
         s5 = peg$parse_();
         if (input.charCodeAt(peg$currPos) === 125) {
-          s6 = peg$c4;
+          s6 = peg$c5;
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e4); }
+          if (peg$silentFails === 0) { peg$fail(peg$e5); }
         }
         if (s6 !== peg$FAILED) {
           s7 = peg$parsePolymeterSteps();
@@ -1070,7 +1135,7 @@ function peg$parse(input, options) {
             s7 = null;
           }
           peg$savedPos = s0;
-          s0 = peg$f9(s3, s4, s7);
+          s0 = peg$f10(s3, s4, s7);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1092,17 +1157,17 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 37) {
-      s1 = peg$c5;
+      s1 = peg$c6;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e5); }
+      if (peg$silentFails === 0) { peg$fail(peg$e6); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseModOperandF64();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f10(s2);
+        s0 = peg$f11(s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1120,11 +1185,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c6;
+      s1 = peg$c7;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e6); }
+      if (peg$silentFails === 0) { peg$fail(peg$e7); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1132,15 +1197,15 @@ function peg$parse(input, options) {
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (input.charCodeAt(peg$currPos) === 93) {
-          s5 = peg$c7;
+          s5 = peg$c8;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e7); }
+          if (peg$silentFails === 0) { peg$fail(peg$e8); }
         }
         if (s5 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f11(s3);
+          s0 = peg$f12(s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1162,11 +1227,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 60) {
-      s1 = peg$c8;
+      s1 = peg$c9;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e8); }
+      if (peg$silentFails === 0) { peg$fail(peg$e9); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -1174,15 +1239,15 @@ function peg$parse(input, options) {
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (input.charCodeAt(peg$currPos) === 62) {
-          s5 = peg$c9;
+          s5 = peg$c10;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e9); }
+          if (peg$silentFails === 0) { peg$fail(peg$e10); }
         }
         if (s5 !== peg$FAILED) {
           peg$savedPos = s0;
-          s0 = peg$f12(s3);
+          s0 = peg$f13(s3);
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -1200,93 +1265,6 @@ function peg$parse(input, options) {
   }
 
   function peg$parseAtom() {
-    let s0;
-
-    s0 = peg$parseRandomChoice();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parseRest();
-      if (s0 === peg$FAILED) {
-        s0 = peg$parseValue();
-      }
-    }
-
-    return s0;
-  }
-
-  function peg$parseRandomChoice() {
-    let s0, s1, s2, s3, s4, s5, s6, s7;
-
-    s0 = peg$currPos;
-    s1 = peg$parseChoiceElement();
-    if (s1 !== peg$FAILED) {
-      s2 = [];
-      s3 = peg$currPos;
-      s4 = peg$parse_();
-      if (input.charCodeAt(peg$currPos) === 124) {
-        s5 = peg$c10;
-        peg$currPos++;
-      } else {
-        s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e10); }
-      }
-      if (s5 !== peg$FAILED) {
-        s6 = peg$parse_();
-        s7 = peg$parseChoiceElement();
-        if (s7 !== peg$FAILED) {
-          s3 = s7;
-        } else {
-          peg$currPos = s3;
-          s3 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s3;
-        s3 = peg$FAILED;
-      }
-      if (s3 !== peg$FAILED) {
-        while (s3 !== peg$FAILED) {
-          s2.push(s3);
-          s3 = peg$currPos;
-          s4 = peg$parse_();
-          if (input.charCodeAt(peg$currPos) === 124) {
-            s5 = peg$c10;
-            peg$currPos++;
-          } else {
-            s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e10); }
-          }
-          if (s5 !== peg$FAILED) {
-            s6 = peg$parse_();
-            s7 = peg$parseChoiceElement();
-            if (s7 !== peg$FAILED) {
-              s3 = s7;
-            } else {
-              peg$currPos = s3;
-              s3 = peg$FAILED;
-            }
-          } else {
-            peg$currPos = s3;
-            s3 = peg$FAILED;
-          }
-        }
-      } else {
-        s2 = peg$FAILED;
-      }
-      if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s0 = peg$f13(s1, s2);
-      } else {
-        peg$currPos = s0;
-        s0 = peg$FAILED;
-      }
-    } else {
-      peg$currPos = s0;
-      s0 = peg$FAILED;
-    }
-
-    return s0;
-  }
-
-  function peg$parseChoiceElement() {
     let s0;
 
     s0 = peg$parseRest();
@@ -1855,11 +1833,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c6;
+          s1 = peg$c7;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e6); }
+          if (peg$silentFails === 0) { peg$fail(peg$e7); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
@@ -1867,11 +1845,11 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c7;
+              s5 = peg$c8;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e7); }
+              if (peg$silentFails === 0) { peg$fail(peg$e8); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -1891,11 +1869,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 60) {
-            s1 = peg$c8;
+            s1 = peg$c9;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e8); }
+            if (peg$silentFails === 0) { peg$fail(peg$e9); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -1903,11 +1881,11 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
               if (input.charCodeAt(peg$currPos) === 62) {
-                s5 = peg$c9;
+                s5 = peg$c10;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e9); }
+                if (peg$silentFails === 0) { peg$fail(peg$e10); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
@@ -1952,11 +1930,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c6;
+          s1 = peg$c7;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e6); }
+          if (peg$silentFails === 0) { peg$fail(peg$e7); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
@@ -1964,11 +1942,11 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c7;
+              s5 = peg$c8;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e7); }
+              if (peg$silentFails === 0) { peg$fail(peg$e8); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -1988,11 +1966,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 60) {
-            s1 = peg$c8;
+            s1 = peg$c9;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e8); }
+            if (peg$silentFails === 0) { peg$fail(peg$e9); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -2000,11 +1978,11 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
               if (input.charCodeAt(peg$currPos) === 62) {
-                s5 = peg$c9;
+                s5 = peg$c10;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e9); }
+                if (peg$silentFails === 0) { peg$fail(peg$e10); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
@@ -2049,11 +2027,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c6;
+          s1 = peg$c7;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e6); }
+          if (peg$silentFails === 0) { peg$fail(peg$e7); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
@@ -2061,11 +2039,11 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c7;
+              s5 = peg$c8;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e7); }
+              if (peg$silentFails === 0) { peg$fail(peg$e8); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -2085,11 +2063,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 60) {
-            s1 = peg$c8;
+            s1 = peg$c9;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e8); }
+            if (peg$silentFails === 0) { peg$fail(peg$e9); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -2097,11 +2075,11 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
               if (input.charCodeAt(peg$currPos) === 62) {
-                s5 = peg$c9;
+                s5 = peg$c10;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e9); }
+                if (peg$silentFails === 0) { peg$fail(peg$e10); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
@@ -2233,11 +2211,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 95) {
-      s1 = peg$c2;
+      s1 = peg$c3;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e2); }
+      if (peg$silentFails === 0) { peg$fail(peg$e3); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2309,11 +2287,11 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$parse_();
       if (input.charCodeAt(peg$currPos) === 124) {
-        s5 = peg$c10;
+        s5 = peg$c2;
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e10); }
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
       }
       if (s5 !== peg$FAILED) {
         s6 = peg$parse_();
@@ -2334,11 +2312,11 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$parse_();
           if (input.charCodeAt(peg$currPos) === 124) {
-            s5 = peg$c10;
+            s5 = peg$c2;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e10); }
+            if (peg$silentFails === 0) { peg$fail(peg$e2); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2504,11 +2482,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c6;
+          s1 = peg$c7;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e6); }
+          if (peg$silentFails === 0) { peg$fail(peg$e7); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
@@ -2516,11 +2494,11 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c7;
+              s5 = peg$c8;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e7); }
+              if (peg$silentFails === 0) { peg$fail(peg$e8); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -2540,11 +2518,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 60) {
-            s1 = peg$c8;
+            s1 = peg$c9;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e8); }
+            if (peg$silentFails === 0) { peg$fail(peg$e9); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -2552,11 +2530,11 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
               if (input.charCodeAt(peg$currPos) === 62) {
-                s5 = peg$c9;
+                s5 = peg$c10;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e9); }
+                if (peg$silentFails === 0) { peg$fail(peg$e10); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
@@ -2688,11 +2666,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 95) {
-      s1 = peg$c2;
+      s1 = peg$c3;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e2); }
+      if (peg$silentFails === 0) { peg$fail(peg$e3); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -2764,11 +2742,11 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$parse_();
       if (input.charCodeAt(peg$currPos) === 124) {
-        s5 = peg$c10;
+        s5 = peg$c2;
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e10); }
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
       }
       if (s5 !== peg$FAILED) {
         s6 = peg$parse_();
@@ -2789,11 +2767,11 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$parse_();
           if (input.charCodeAt(peg$currPos) === 124) {
-            s5 = peg$c10;
+            s5 = peg$c2;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e10); }
+            if (peg$silentFails === 0) { peg$fail(peg$e2); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -2959,11 +2937,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c6;
+          s1 = peg$c7;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e6); }
+          if (peg$silentFails === 0) { peg$fail(peg$e7); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
@@ -2971,11 +2949,11 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c7;
+              s5 = peg$c8;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e7); }
+              if (peg$silentFails === 0) { peg$fail(peg$e8); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -2995,11 +2973,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 60) {
-            s1 = peg$c8;
+            s1 = peg$c9;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e8); }
+            if (peg$silentFails === 0) { peg$fail(peg$e9); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -3007,11 +2985,11 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
               if (input.charCodeAt(peg$currPos) === 62) {
-                s5 = peg$c9;
+                s5 = peg$c10;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e9); }
+                if (peg$silentFails === 0) { peg$fail(peg$e10); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
@@ -3143,11 +3121,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 95) {
-      s1 = peg$c2;
+      s1 = peg$c3;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$e2); }
+      if (peg$silentFails === 0) { peg$fail(peg$e3); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$currPos;
@@ -3219,11 +3197,11 @@ function peg$parse(input, options) {
       s3 = peg$currPos;
       s4 = peg$parse_();
       if (input.charCodeAt(peg$currPos) === 124) {
-        s5 = peg$c10;
+        s5 = peg$c2;
         peg$currPos++;
       } else {
         s5 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$e10); }
+        if (peg$silentFails === 0) { peg$fail(peg$e2); }
       }
       if (s5 !== peg$FAILED) {
         s6 = peg$parse_();
@@ -3244,11 +3222,11 @@ function peg$parse(input, options) {
           s3 = peg$currPos;
           s4 = peg$parse_();
           if (input.charCodeAt(peg$currPos) === 124) {
-            s5 = peg$c10;
+            s5 = peg$c2;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e10); }
+            if (peg$silentFails === 0) { peg$fail(peg$e2); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -3414,11 +3392,11 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 91) {
-          s1 = peg$c6;
+          s1 = peg$c7;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$e6); }
+          if (peg$silentFails === 0) { peg$fail(peg$e7); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
@@ -3426,11 +3404,11 @@ function peg$parse(input, options) {
           if (s3 !== peg$FAILED) {
             s4 = peg$parse_();
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c7;
+              s5 = peg$c8;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$e7); }
+              if (peg$silentFails === 0) { peg$fail(peg$e8); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -3450,11 +3428,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 60) {
-            s1 = peg$c8;
+            s1 = peg$c9;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$e8); }
+            if (peg$silentFails === 0) { peg$fail(peg$e9); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -3462,11 +3440,11 @@ function peg$parse(input, options) {
             if (s3 !== peg$FAILED) {
               s4 = peg$parse_();
               if (input.charCodeAt(peg$currPos) === 62) {
-                s5 = peg$c9;
+                s5 = peg$c10;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$e9); }
+                if (peg$silentFails === 0) { peg$fail(peg$e10); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;

--- a/src/main/dsl/miniNotation/grammar.peggy
+++ b/src/main/dsl/miniNotation/grammar.peggy
@@ -98,9 +98,22 @@ StackExpr
 // fastcat), each taking an equal slice of the cycle. Mirrors strudel's
 // `dot_tail` → `feet` alignment.
 FeetExpr
-  = head:SequenceExpr tail:(_ "." _ @SequenceExpr)* {
+  = head:ChoiceExpr tail:(_ "." _ @ChoiceExpr)* {
       if (tail.length === 0) return head;
       return { Sequence: [head, ...tail].map(s => [s, null]) };
+    }
+
+// Random choice: `a b | c d` picks one whole sequence at random each
+// cycle. Mirrors strudel krill's `choose_tail`, whose operands are full
+// `sequence`s — so `|` binds looser than a space-separated sequence but
+// tighter than feet (`.`) and stack (`,`). Handling it here (rather than at
+// the atom level) is what lets `[0,0,0] | [0,-7,0]` and `0 1 | 2 3` choose
+// between whole subsequences instead of mis-binding to a single atom.
+ChoiceExpr
+  = head:SequenceExpr tail:(_ "|" _ @SequenceExpr)* {
+      if (tail.length === 0) return head;
+      const seed = ctx.nextSeed();
+      return { RandomChoice: [[head, ...tail], seed] };
     }
 
 // Sequence: space-separated elements. Bare `_` tokens after an element act
@@ -191,20 +204,9 @@ SlowSub
       return { SlowCat: [[s, null]] };
     }
 
-// Atoms: random-choice group, a rest, or a concrete value.
+// Atoms: a rest or a concrete value. Random choice (`|`) is handled higher
+// up at the ChoiceExpr level so it can alternate whole sequences.
 Atom
-  = RandomChoice
-  / Rest
-  / Value
-
-// Random choice: a|b|c (at least one `|` present).
-RandomChoice
-  = first:ChoiceElement rest:(_ "|" _ @ChoiceElement)+ {
-      const seed = ctx.nextSeed();
-      return { RandomChoice: [[first, ...rest], seed] };
-    }
-
-ChoiceElement
   = Rest
   / Value
 

--- a/src/main/dsl/miniNotation/grammar.peggy
+++ b/src/main/dsl/miniNotation/grammar.peggy
@@ -17,8 +17,14 @@
  *   - Modifier operands reuse the same AST typing as the Rust parser
  *     (MiniASTF64 for fast/slow factors and degrade probabilities,
  *     MiniASTU32 for euclidean pulses/steps, MiniASTI32 for rotation).
- *   - No polymeter, $-operator chain, struct/target/scale/etc. high-level
- *     statements, no `cat(...)` / `slow(...)` / `fast(...)` commands.
+ *   - No $-operator chain, struct/target/scale/etc. high-level statements,
+ *     no `cat(...)` / `slow(...)` / `fast(...)` commands.
+ *   - Replicate (`!`) accumulates: `x!!` / `x!2!3` sum into a single
+ *     Replicate count (1 + Σ(value - 1)), and bare `@` weight defaults to 2 —
+ *     both matching Tidal/krill (and `@` is then consistent with `_`).
+ *   - Separator model matches Tidal/krill: top-level `,` and `|` are mutually
+ *     exclusive (commit to one, never mix), feet (`.`) live inside each
+ *     operand, and `<...>` / `{...}` are comma-only voices (no `|`).
  *
  * Seed assignment for RandomChoice / Degrade nodes is left-to-right,
  * depth-first: matches Rust's `assign_seeds` pass so equivalent pattern
@@ -82,38 +88,40 @@
 // ---------------------------------------------------------------------------
 
 Start
-  = _ s:StackExpr _ { return s; }
+  = _ s:Group _ { return s; }
 
-// Stack: comma-separated patterns play simultaneously.
-// Each element may itself be a feet-separated chain (`a b . c d`), wrapped
-// in a Sequence node whose entries each take an equal slice of the cycle.
-StackExpr
-  = head:FeetExpr tail:(_ "," _ @FeetExpr)* {
-      if (tail.length === 0) return head;
-      return { Stack: [head, ...tail] };
+// Top-level separators `,` (stack) and `|` (random choice) are mutually
+// exclusive: a group commits to one tail and never mixes them, so `a , b , c`
+// stacks, `a | b | c` chooses, and `a , b | c` is a parse error. Matches
+// Tidal's stackTail/chooseTail and krill's single stack_or_choose tail. Feet
+// (`.`) live one level down, inside each `,`/`|` operand.
+Group
+  = head:FeetSeq tail:(CommaTail / PipeTail)? {
+      if (!tail) return head;
+      if (tail.kind === 'stack') return { Stack: [head, ...tail.items] };
+      return { RandomChoice: [[head, ...tail.items], ctx.nextSeed()] };
     }
+
+// Stack tail: `, b , c` — comma-separated voices that play simultaneously.
+CommaTail
+  = items:(_ "," _ @FeetSeq)+ { return { kind: 'stack', items }; }
+
+// Choice tail: `| b | c` — picks one whole operand at random each cycle.
+// Mirrors strudel krill's `choose_tail`; the seed is taken in the Group
+// action (after the operands) so seeding stays left-to-right depth-first,
+// matching Rust's assign_seeds.
+PipeTail
+  = items:(_ "|" _ @FeetSeq)+ { return { kind: 'rand', items }; }
 
 // Feet separator: `a b . c d` wraps the dot-separated sub-sequences [a b]
 // and [c d] in a Sequence node (which convert.rs lowers identically to a
-// fastcat), each taking an equal slice of the cycle. Mirrors strudel's
-// `dot_tail` → `feet` alignment.
-FeetExpr
-  = head:ChoiceExpr tail:(_ "." _ @ChoiceExpr)* {
+// fastcat), each taking an equal slice of the cycle. Feet bind tighter than
+// the `,`/`|` tails but looser than a space-separated sequence. Mirrors
+// strudel's `dot_tail` → `feet` alignment.
+FeetSeq
+  = head:SequenceExpr tail:(_ "." _ @SequenceExpr)* {
       if (tail.length === 0) return head;
       return { Sequence: [head, ...tail].map(s => [s, null]) };
-    }
-
-// Random choice: `a b | c d` picks one whole sequence at random each
-// cycle. Mirrors strudel krill's `choose_tail`, whose operands are full
-// `sequence`s — so `|` binds looser than a space-separated sequence but
-// tighter than feet (`.`) and stack (`,`). Handling it here (rather than at
-// the atom level) is what lets `[0,0,0] | [0,-7,0]` and `0 1 | 2 3` choose
-// between whole subsequences instead of mis-binding to a single atom.
-ChoiceExpr
-  = head:SequenceExpr tail:(_ "|" _ @SequenceExpr)* {
-      if (tail.length === 0) return head;
-      const seed = ctx.nextSeed();
-      return { RandomChoice: [[head, ...tail], seed] };
     }
 
 // Sequence: space-separated elements. Bare `_` tokens after an element act
@@ -170,7 +178,7 @@ ElementBase
 // Each comma-separated child sequence gets stacked, scaled so its step
 // count maps to `steps_per_cycle`. Matches strudel's `polymeter`.
 Polymeter
-  = "{" _ head:FeetExpr tail:(_ "," _ @FeetExpr)* _ "}" steps:PolymeterSteps? {
+  = "{" _ head:FeetSeq tail:(_ "," _ @FeetSeq)* _ "}" steps:PolymeterSteps? {
       const children = [head, ...tail];
       return { Polymeter: { children, steps_per_cycle: steps } };
     }
@@ -179,22 +187,27 @@ PolymeterSteps
   = "%" op:ModOperandF64 { return op; }
 
 FastSub
-  = "[" _ s:StackExpr _ "]" {
+  = "[" _ s:Group _ "]" {
       // Keep `[...]` as FastCat (explicit fast subsequence) rather than
-      // letting StackExpr flatten. When `s` is a Stack, wrap it as a
-      // single-element FastCat so nesting semantics match the Rust parser.
+      // letting the inner Group flatten. The Group body allows `,` XOR `|`
+      // with feet inside; a Stack/RandomChoice is wrapped as a single-element
+      // FastCat so nesting semantics match the Rust parser.
       if (s && s.Stack) {
         return { FastCat: [[s, null]] };
       }
       if (s && s.Sequence) {
         return { FastCat: s.Sequence };
       }
-      // Single element: wrap in FastCat with one entry.
+      // Single element (atom, or a `|` choice voice): wrap in one entry.
       return { FastCat: [[s, null]] };
     }
 
+// `<...>` is comma-only (voices), feet allowed, no `|` — matches Tidal/krill
+// (`<0|1>` is a parse error). Build the same Stack/Sequence intermediate a
+// comma group would, then wrap as SlowCat exactly as before.
 SlowSub
-  = "<" _ s:StackExpr _ ">" {
+  = "<" _ head:FeetSeq tail:(_ "," _ @FeetSeq)* _ ">" {
+      const s = tail.length === 0 ? head : { Stack: [head, ...tail] };
       if (s && s.Stack) {
         return { SlowCat: [[s, null]] };
       }
@@ -283,8 +296,10 @@ Modifier
 // The `_` after each sigil mirrors pest's implicit WHITESPACE between a
 // modifier operator and its operand (`/ 4`, `* 2`, `@ 3` all parsed in the
 // Rust grammar). Euclidean already spells its inner whitespace explicitly.
+// Bare `@` (no number) is weight 2 — matching Tidal's `pElongate = 1 + sum`
+// and krill, and consistent with `_` elongation.
 Weight
-  = "@" _ n:Number? { return n === null ? 1 : n; }
+  = "@" _ n:Number? { return n === null ? 2 : n; }
 
 FastMod
   = "*" _ op:ModOperandF64 {
@@ -296,11 +311,14 @@ SlowMod
       return (ast, _c) => ({ Slow: [ast, op] });
     }
 
+// Replicate accumulates: consecutive `!`/`!n` sum into a single Replicate, so
+// `x!` = 2 copies, `x!3` = 3, `x!!` = 3, `x!2!3` = 4 — matching Tidal's
+// `pRepeat = 1 + sum es` and krill. Total copies = 1 + Σ(value - 1).
 Replicate
-  = "!" _ n:Integer? {
-      const count = n === null ? 2 : n;
-      if (count < 0) error("Replicate count must be a non-negative integer");
-      return (ast, _c) => ({ Replicate: [ast, count] });
+  = parts:(_ "!" _ n:Integer? { return n === null ? 2 : n; })+ {
+      const total = parts.reduce((acc, v) => acc + (v - 1), 1);
+      if (total < 0) error("Replicate count must be a non-negative integer");
+      return (ast, _c) => ({ Replicate: [ast, total] });
     }
 
 Degrade


### PR DESCRIPTION
## Summary

Aligns the mini-notation parser with both TidalCycles (`ParseBP.hs`) and strudel (`krill.pegjs`) across three divergent behaviours, on top of a precursor `|`-precedence fix.

- **`|` chooses whole sequences** (`7e1b1e8`): random choice binds across whole sequences, not a single neighbouring atom — `0 1 | 2 3` picks between `0 1` and `2 3`, `[0,0,0] | [0,-7,0]` between the two chords.
- **Replicate `!` accumulates** (`e50c9e0`): `x!!` / `x!2!3` sum into one `Replicate` (1 + Σ(value−1)); `0!!` is 3 copies (was 4). Matches Tidal `pRepeat = 1 + sum es`.
- **Bare `@` → weight 2** (was 1): matches Tidal `pElongate = 1 + sum`, consistent with `_` elongation.
- **Mutually-exclusive `,` / `|`**: top-level `,` and `|` no longer mix (`a , b | c` is a parse error); feet (`.`) live inside each operand, so `a | b . c` is `choose(a, feet(b,c))`. `<...>` is comma-only (`<0|1>` errors); `{...}` was already comma-only.

The Rust descent parity twin, generated peggy parser, and parity fixtures are updated in lockstep. `0!!`→3 is validated against **real @strudel/core** via the sp_combine parity fixture. Stale "No polymeter" header claim dropped.

## Test Plan
- [x] `yarn test:unit` — 427 pass (parser.test.ts +7 new cases)
- [x] `cargo test -p modular_core` — lib 534, peggy parity gate, strudel runtime parity all green
- [x] `yarn gen:sp-fixtures` regenerates with `0!!` (0 errors)
- [x] `tsc --noEmit` clean
- [x] Spot-checked all four divergent inputs + unchanged upstream cases against the regenerated parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)