### PR TITLE
feat(dsp): dynamic per-channel allocation; raise max channels to 64

### DIFF
--- a/crates/modular/index.d.ts
+++ b/crates/modular/index.d.ts
@@ -425,7 +425,7 @@ export interface ModuleSchema {
   channelsParamDefault?: number
 }
 
-export interface ModuleState {
+export interface ModuleSpec {
   id: string
   moduleType: string
   idIsExplicit?: boolean
@@ -446,7 +446,7 @@ export interface OutputSchema {
 }
 
 export interface PatchGraph {
-  modules: Array<ModuleState>
+  modules: Array<ModuleSpec>
   moduleIdRemaps?: Array<ModuleIdRemap>
   scopes: Array<Scope>
   scopeXy?: ScopeXy

--- a/crates/modular/schemas.json
+++ b/crates/modular/schemas.json
@@ -244,14 +244,14 @@
   },
   {
     "name": "$mixDown",
-    "documentation": "Folds a polyphonic input down to an arbitrary target channel count.\n\nUnlike `$mix` (which mixes channel `n` of every input into output channel\n`n`), `$mixDown` takes a single poly signal and distributes its `N` channels\nacross `M` output channels by panning them evenly over the output field with\nan equal-power crossfade. With the default `channels = 1` it is a plain mono\nsum; `channels = 2` produces an equal-power stereo fold-down. When the target\nexceeds the input channel count, the input is instead spread to fill every\noutput channel (equal-power interpolation) so no channel is left silent.\n\n- **channels** — target output channel count (1–16, default 1)\n- **mode** — how channels landing on the same output combine (sum / average /\n  max / min); applies only when folding down (target ≤ input channels)\n\n## Example\n\n```js\n// Fold a 3-voice spread down to stereo\n$saw($spread(0, 5, 3)).mix(2).out()\n```",
+    "documentation": "Folds a polyphonic input down to an arbitrary target channel count.\n\nUnlike `$mix` (which mixes channel `n` of every input into output channel\n`n`), `$mixDown` takes a single poly signal and distributes its `N` channels\nacross `M` output channels by panning them evenly over the output field with\nan equal-power crossfade. With the default `channels = 1` it is a plain mono\nsum; `channels = 2` produces an equal-power stereo fold-down. When the target\nexceeds the input channel count, the input is instead spread to fill every\noutput channel (equal-power interpolation) so no channel is left silent.\n\n- **channels** — target output channel count (1–64, default 1)\n- **mode** — how channels landing on the same output combine (sum / average /\n  max / min); applies only when folding down (target ≤ input channels)\n\n## Example\n\n```js\n// Fold a 3-voice spread down to stereo\n$saw($spread(0, 5, 3)).mix(2).out()\n```",
     "paramsSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "MixDownParams",
       "type": "object",
       "properties": {
         "channels": {
-          "description": "Target output channel count (1–16). Defaults to 1 (mono).",
+          "description": "Target output channel count (1–64). Defaults to 1 (mono).",
           "type": "integer",
           "format": "uint",
           "default": 1,
@@ -3477,7 +3477,7 @@
   },
   {
     "name": "$supersaw",
-    "documentation": "Supersaw oscillator with multiple detuned sawtooth voices and PolyBLEP anti-aliasing.\n\nGenerates a classic supersaw sound by stacking multiple sawtooth oscillators\nwith symmetric detuning. Each input channel is processed by all voices,\ncreating a rich, full sound.\n\n- **freq** — pitch in V/Oct (0V = C4)\n- **voices** — number of detuned saw voices (1–16, default 5)\n- **detune** — detune spread in semitones (default 0.18)\n\nOutput range is **±5V** with gain compensation for input channel count.\n\n## Example\n\n```js\n$supersaw('c3').out()\n$supersaw('c3', { voices: 7, detune: 0.3 }).out()\n```",
+    "documentation": "Supersaw oscillator with multiple detuned sawtooth voices and PolyBLEP anti-aliasing.\n\nGenerates a classic supersaw sound by stacking multiple sawtooth oscillators\nwith symmetric detuning. Each input channel is processed by all voices,\ncreating a rich, full sound.\n\n- **freq** — pitch in V/Oct (0V = C4)\n- **voices** — number of detuned saw voices (1–64, default 5)\n- **detune** — detune spread in semitones (default 0.18)\n\nOutput range is **±5V** with gain compensation for input channel count.\n\n## Example\n\n```js\n$supersaw('c3').out()\n$supersaw('c3', { voices: 7, detune: 0.3 }).out()\n```",
     "paramsSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "SupersawParams",
@@ -3515,7 +3515,7 @@
           "$ref": "#/$defs/PolySignal"
         },
         "voices": {
-          "description": "number of supersaw voices (1–16)",
+          "description": "number of supersaw voices (1–64)",
           "type": "integer",
           "format": "uint",
           "default": 5,
@@ -7530,7 +7530,7 @@
           ]
         },
         "count": {
-          "description": "number of output channels (1–16)",
+          "description": "number of output channels (1–64)",
           "type": "integer",
           "format": "uint",
           "minimum": 0
@@ -7658,14 +7658,14 @@
   },
   {
     "name": "$unison",
-    "documentation": "Expands each input channel into multiple detuned copies for unison effects.\n\nTakes a signal (typically V/Oct pitch) and multiplies channels by the\nunison count, applying symmetric detuning controlled by the spread parameter.\n\n- **count** — number of detuned copies per input channel (1–16)\n- **spread** — detune amount with exponential curve (0–10V → 0–1 octave V/Oct)\n\nOutput channels = `input_channels × count`, clamped to 16.\n\n## Example\n\n```js\n// 7-voice unison saw with moderate spread\n$saw($unison('c4', 7, 5)).out()\n\n// With modulated spread\n$saw($unison($midiCV().pitch, 5, $sine('0.2hz'))).out()\n```",
+    "documentation": "Expands each input channel into multiple detuned copies for unison effects.\n\nTakes a signal (typically V/Oct pitch) and multiplies channels by the\nunison count, applying symmetric detuning controlled by the spread parameter.\n\n- **count** — number of detuned copies per input channel (1–64)\n- **spread** — detune amount with exponential curve (0–10V → 0–1 octave V/Oct)\n\nOutput channels = `input_channels × count`, clamped to 64.\n\n## Example\n\n```js\n// 7-voice unison saw with moderate spread\n$saw($unison('c4', 7, 5)).out()\n\n// With modulated spread\n$saw($unison($midiCV().pitch, 5, $sine('0.2hz'))).out()\n```",
     "paramsSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "UnisonParams",
       "type": "object",
       "properties": {
         "count": {
-          "description": "number of unison voices per input channel (1–16)",
+          "description": "number of unison voices per input channel (1–64)",
           "type": "integer",
           "format": "uint",
           "default": 1,
@@ -7934,7 +7934,7 @@
       "type": "object",
       "properties": {
         "channels": {
-          "description": "Number of polyphonic voices (1-16)",
+          "description": "Number of polyphonic voices (1-64)",
           "type": [
             "integer",
             "null"
@@ -10349,7 +10349,7 @@
   },
   {
     "name": "$midiCV",
-    "documentation": "Converts MIDI note input into control voltages for driving synthesizer modules.\nSupports polyphonic voice allocation with up to 16 voices.\n\n## Outputs\n\n| Output | Signal | Range |\n|---|---|---|\n| `pitch` | V/Oct pitch (0V = C4), includes pitch bend | — |\n| `gate` | High while a note is held | 0–5V |\n| `velocity` | Note-on velocity | 0–5V |\n| `aftertouch` | Channel or polyphonic aftertouch | 0–5V |\n| `retrigger` | 5V pulse for 1ms on each new note | 0–5V |\n| `pitchWheel` | Pitch bend wheel position | -5V–+5V |\n| `modWheel` | Mod wheel (CC 1) | 0–5V |\n\n## Polyphonic modes (`polyMode`)\n\n- `\"rotate\"` — cycles through voices round-robin\n- `\"reuse\"` — reuses the voice that last played the same note\n- `\"reset\"` — always starts allocation from voice 1\n- `\"mpe\"` — one voice per MIDI channel (for MPE controllers)\n\n## Monophonic modes (`monoMode`, when `channels: 1`)\n\n- `\"last\"` — most recently pressed note wins\n- `\"first\"` — first pressed note wins\n- `\"lowest\"` — lowest held note wins\n- `\"highest\"` — highest held note wins\n\n## Example\n\n```js\n// 4-voice polyphonic MIDI synth\nconst midi = $midiCV({ channels: 4 });\n$sine(midi.pitch).amplitude($adsr(midi.gate,{attack: 0.01, decay: 0.1, sustain: 0.8, release: 0.5})).out();\n\n// Mono lead with pitch bend\nconst lead = $midiCV({ channels: 1, pitchBendRange: 12 });\n$saw(lead.pitch).amplitude($adsr(lead.gate,{attack: 0.01, decay: 0.1, sustain: 0.8, release: 0.5})).out();\n```",
+    "documentation": "Converts MIDI note input into control voltages for driving synthesizer modules.\nSupports polyphonic voice allocation with up to 64 voices.\n\n## Outputs\n\n| Output | Signal | Range |\n|---|---|---|\n| `pitch` | V/Oct pitch (0V = C4), includes pitch bend | — |\n| `gate` | High while a note is held | 0–5V |\n| `velocity` | Note-on velocity | 0–5V |\n| `aftertouch` | Channel or polyphonic aftertouch | 0–5V |\n| `retrigger` | 5V pulse for 1ms on each new note | 0–5V |\n| `pitchWheel` | Pitch bend wheel position | -5V–+5V |\n| `modWheel` | Mod wheel (CC 1) | 0–5V |\n\n## Polyphonic modes (`polyMode`)\n\n- `\"rotate\"` — cycles through voices round-robin\n- `\"reuse\"` — reuses the voice that last played the same note\n- `\"reset\"` — always starts allocation from voice 1\n- `\"mpe\"` — one voice per MIDI channel (for MPE controllers)\n\n## Monophonic modes (`monoMode`, when `channels: 1`)\n\n- `\"last\"` — most recently pressed note wins\n- `\"first\"` — first pressed note wins\n- `\"lowest\"` — lowest held note wins\n- `\"highest\"` — highest held note wins\n\n## Example\n\n```js\n// 4-voice polyphonic MIDI synth\nconst midi = $midiCV({ channels: 4 });\n$sine(midi.pitch).amplitude($adsr(midi.gate,{attack: 0.01, decay: 0.1, sustain: 0.8, release: 0.5})).out();\n\n// Mono lead with pitch bend\nconst lead = $midiCV({ channels: 1, pitchBendRange: 12 });\n$saw(lead.pitch).amplitude($adsr(lead.gate,{attack: 0.01, decay: 0.1, sustain: 0.8, release: 0.5})).out();\n```",
     "paramsSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "title": "MidiCvParams",
@@ -10366,7 +10366,7 @@
           "minimum": 0
         },
         "channels": {
-          "description": "Number of polyphonic voices (1-16)",
+          "description": "Number of polyphonic voices (1-64)",
           "type": "integer",
           "format": "uint",
           "default": 1,

--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -27,6 +27,7 @@ use ringbuf::{
   traits::{Consumer, Producer, Split},
 };
 use rtrb::{Consumer as RtrbConsumer, Producer as RtrbProducer, RingBuffer};
+use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs::File;
@@ -35,7 +36,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::OnceLock;
-use std::cell::UnsafeCell;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -1369,8 +1369,7 @@ impl AudioState {
     // are sample-rate ring buffers that would smear if reused).
     {
       let scope_xy_collection = self.scope_xy_collection.lock();
-      let current_keys: HashSet<ScopeXyBufferKey> =
-        scope_xy_collection.keys().cloned().collect();
+      let current_keys: HashSet<ScopeXyBufferKey> = scope_xy_collection.keys().cloned().collect();
 
       let desired_keys: HashSet<ScopeXyBufferKey> = match scope_xy.as_ref() {
         Some(sx) => sx
@@ -1878,12 +1877,12 @@ impl AudioProcessor {
           {
             let garbage_tx = &mut self.garbage_tx;
             let scope_xy_audio = &mut self.scope_xy_audio;
-            scope_xy_audio.retain(
-              |(_k, buf)| match garbage_tx.push(GarbageItem::ScopeXy(buf.clone())) {
+            scope_xy_audio.retain(|(_k, buf)| {
+              match garbage_tx.push(GarbageItem::ScopeXy(buf.clone())) {
                 Ok(()) => false,
                 Err(_) => true,
-              },
-            );
+              }
+            });
           }
           self.patch.insert_audio_in();
           self.patch.rebuild_message_listeners();
@@ -2156,7 +2155,11 @@ impl AudioProcessor {
         slot[ch] = frame[ch] * AUDIO_INPUT_GAIN;
       }
     }
-    if let Some(audio_in) = self.patch.sampleables.get(WellKnownModule::HiddenAudioIn.id()) {
+    if let Some(audio_in) = self
+      .patch
+      .sampleables
+      .get(WellKnownModule::HiddenAudioIn.id())
+    {
       audio_in.inject_audio_in_block(&self.input_block_scratch);
     }
   }
@@ -2396,11 +2399,7 @@ where
 
           {
             let eager_end = block_size.min(audio_processor.block_pos + num_frames);
-            audio_processor.eager_fill_clock(
-              audio_processor.block_pos,
-              eager_end,
-              written,
-            );
+            audio_processor.eager_fill_clock(audio_processor.block_pos, eager_end, written);
           }
 
           {
@@ -2417,28 +2416,20 @@ where
                 audio_processor.eager_fill_clock(0, eager_end, written);
               }
 
-              let scan_end =
-                block_size.min(audio_processor.block_pos + (num_frames - written));
+              let scan_end = block_size.min(audio_processor.block_pos + (num_frames - written));
 
               // Resolve trigger sample for queued patch swap.
-              let trigger_sample: Option<usize> = match audio_processor
-                .queued_update
-                .as_ref()
-                .map(|(_, t)| t)
-              {
-                Some(QueuedTrigger::Immediate) => Some(audio_processor.block_pos),
-                Some(QueuedTrigger::NextBar) => audio_processor.scan_trigger(
-                  "barTrigger",
-                  audio_processor.block_pos,
-                  scan_end,
-                ),
-                Some(QueuedTrigger::NextBeat) => audio_processor.scan_trigger(
-                  "beatTrigger",
-                  audio_processor.block_pos,
-                  scan_end,
-                ),
-                None => None,
-              };
+              let trigger_sample: Option<usize> =
+                match audio_processor.queued_update.as_ref().map(|(_, t)| t) {
+                  Some(QueuedTrigger::Immediate) => Some(audio_processor.block_pos),
+                  Some(QueuedTrigger::NextBar) => {
+                    audio_processor.scan_trigger("barTrigger", audio_processor.block_pos, scan_end)
+                  }
+                  Some(QueuedTrigger::NextBeat) => {
+                    audio_processor.scan_trigger("beatTrigger", audio_processor.block_pos, scan_end)
+                  }
+                  None => None,
+                };
 
               let end = trigger_sample.map(|n| n.min(scan_end)).unwrap_or(scan_end);
 
@@ -2489,16 +2480,13 @@ where
                     continue;
                   }
 
-                  if let Some(root) =
-                    audio_processor.patch.sampleables.get(&*ROOT_ID)
-                  {
+                  if let Some(root) = audio_processor.patch.sampleables.get(&*ROOT_ID) {
                     let mut any_audible = false;
                     let mut samples = [0.0f32; PORT_MAX_CHANNELS];
                     for ch in 0..num_channels.min(PORT_MAX_CHANNELS) {
-                      let raw = root.get_value_at(&ROOT_OUTPUT_PORT, ch, i)
-                        * AUDIO_OUTPUT_ATTENUATION;
-                      let sample =
-                        safety_soft_clip(raw * final_state_processor.attenuation_factor);
+                      let raw =
+                        root.get_value_at(&ROOT_OUTPUT_PORT, ch, i) * AUDIO_OUTPUT_ATTENUATION;
+                      let sample = safety_soft_clip(raw * final_state_processor.attenuation_factor);
                       samples[ch] = sample;
                       if sample.abs() >= 0.0005 {
                         any_audible = true;
@@ -2512,7 +2500,11 @@ where
                       }
                     } else {
                       for ch in 0..num_channels {
-                        let v = if ch < PORT_MAX_CHANNELS { samples[ch] } else { 0.0 };
+                        let v = if ch < PORT_MAX_CHANNELS {
+                          samples[ch]
+                        } else {
+                          0.0
+                        };
                         output[frame_start + ch] = T::from_sample(v);
                       }
                     }
@@ -2526,41 +2518,24 @@ where
                     }
                     if let Some(scope_lock) = scope_guard.as_mut() {
                       for (key, scope_buffer) in scope_lock.iter_mut() {
-                        if let Some(module) =
-                          audio_processor.patch.sampleables.get(&key.module_id)
+                        if let Some(module) = audio_processor.patch.sampleables.get(&key.module_id)
                         {
-                          let s = module.get_value_at(
-                            &key.port_name,
-                            key.channel as usize,
-                            i,
-                          );
+                          let s = module.get_value_at(&key.port_name, key.channel as usize, i);
                           scope_buffer.push(s);
                         }
                       }
                     }
                     for (key, xy_buffer) in &audio_processor.scope_xy_audio {
                       let (Some(x_mod), Some(y_mod)) = (
-                        audio_processor
-                          .patch
-                          .sampleables
-                          .get(&key.pair.x.module_id),
-                        audio_processor
-                          .patch
-                          .sampleables
-                          .get(&key.pair.y.module_id),
+                        audio_processor.patch.sampleables.get(&key.pair.x.module_id),
+                        audio_processor.patch.sampleables.get(&key.pair.y.module_id),
                       ) else {
                         continue;
                       };
-                      let xv = x_mod.get_value_at(
-                        &key.pair.x.port_name,
-                        key.pair.x.channel as usize,
-                        i,
-                      );
-                      let yv = y_mod.get_value_at(
-                        &key.pair.y.port_name,
-                        key.pair.y.channel as usize,
-                        i,
-                      );
+                      let xv =
+                        x_mod.get_value_at(&key.pair.x.port_name, key.pair.x.channel as usize, i);
+                      let yv =
+                        y_mod.get_value_at(&key.pair.y.port_name, key.pair.y.channel as usize, i);
                       xy_buffer.push(xv, yv);
                     }
                   } else {
@@ -2595,13 +2570,10 @@ where
                 // `[swap_pos, block_size)` was filled under the OLD params;
                 // refill the remainder of this callback's range from
                 // `swap_pos` forward under the NEW patch.
-                if let Some(root_clock) =
-                  audio_processor.patch.sampleables.get(&*ROOT_CLOCK_ID)
-                {
+                if let Some(root_clock) = audio_processor.patch.sampleables.get(&*ROOT_CLOCK_ID) {
                   root_clock.set_initial_index(swap_pos);
                 }
-                let eager_end =
-                  block_size.min(audio_processor.block_pos + (num_frames - written));
+                let eager_end = block_size.min(audio_processor.block_pos + (num_frames - written));
                 audio_processor.eager_fill_clock(swap_pos, eager_end, written);
               }
             }

--- a/crates/modular/src/lib.rs
+++ b/crates/modular/src/lib.rs
@@ -1061,9 +1061,7 @@ impl Synthesizer {
   /// - Windows: `%APPDATA%\Operator\logs\`
   #[napi]
   pub fn panic_log_dir(&self) -> String {
-    panic_log::panic_log_dir()
-      .to_string_lossy()
-      .into_owned()
+    panic_log::panic_log_dir().to_string_lossy().into_owned()
   }
 
   #[napi]
@@ -1118,9 +1116,7 @@ impl Synthesizer {
   /// window, the last element the newest — and `ranges` is the per-axis volt
   /// window the renderer maps into clip space.
   #[napi]
-  pub fn get_scope_xy(
-    &self,
-  ) -> Vec<(ScopeXyBufferKey, Float32Array, Float32Array, ScopeXyRanges)> {
+  pub fn get_scope_xy(&self) -> Vec<(ScopeXyBufferKey, Float32Array, Float32Array, ScopeXyRanges)> {
     self.state.get_scope_xy_buffers()
   }
 

--- a/crates/modular/src/panic_log.rs
+++ b/crates/modular/src/panic_log.rs
@@ -77,10 +77,7 @@ fn write_panic_log(info: &panic::PanicHookInfo<'_>) -> std::io::Result<()> {
   let pid = std::process::id();
   let path = dir.join(format!("panic-{epoch}-{pid}.log"));
 
-  let mut f: File = OpenOptions::new()
-    .create(true)
-    .append(true)
-    .open(&path)?;
+  let mut f: File = OpenOptions::new().create(true).append(true).open(&path)?;
 
   let payload: &str = if let Some(s) = info.payload().downcast_ref::<&'static str>() {
     s

--- a/crates/modular/src/validation.rs
+++ b/crates/modular/src/validation.rs
@@ -1,5 +1,5 @@
 use modular_core::params::ARGUMENT_SPANS_KEY;
-use modular_core::types::{ModuleSchema, ModuleState, PatchGraph, Signal, WellKnownModule};
+use modular_core::types::{ModuleSchema, ModuleSpec, PatchGraph, Signal, WellKnownModule};
 use napi_derive::napi;
 use schemars::Schema;
 use serde::{Deserialize, Serialize};
@@ -22,7 +22,7 @@ pub struct ValidationError {
 ///
 /// For explicitly named modules, returns the user's ID (e.g., "myOscillator").
 /// For auto-generated IDs, returns None so the error can be tied to source line instead.
-fn format_module_location(module: &ModuleState) -> String {
+fn format_module_location(module: &ModuleSpec) -> String {
   if module.id_is_explicit == Some(true) {
     // User explicitly set this ID, show it
     format!("'{}'", module.id)
@@ -162,7 +162,7 @@ fn validate_signal_reference(
   signal: &Signal,
   field: &str,
   location: &str,
-  module_by_id: &HashMap<&str, &ModuleState>,
+  module_by_id: &HashMap<&str, &ModuleSpec>,
   schema_map: &HashMap<&str, &ModuleSchema>,
   errors: &mut Vec<ValidationError>,
 ) {
@@ -224,7 +224,7 @@ fn validate_signals_in_json_value(
   value: &serde_json::Value,
   field: &str,
   location: &str,
-  module_by_id: &HashMap<&str, &ModuleState>,
+  module_by_id: &HashMap<&str, &ModuleSpec>,
   schema_map: &HashMap<&str, &ModuleSchema>,
   errors: &mut Vec<ValidationError>,
 ) {
@@ -312,11 +312,11 @@ pub fn validate_patch(
     schemas.iter().map(|s| (s.name.as_str(), s)).collect();
 
   // Build a map from module id -> module instance (state) from the patch.
-  let module_by_id: HashMap<&str, &ModuleState> =
+  let module_by_id: HashMap<&str, &ModuleSpec> =
     patch.modules.iter().map(|m| (m.id.as_str(), m)).collect();
 
   // === Schema helpers ===
-  // The runtime patch stores parameter values as JSON (`ModuleState.params`), but
+  // The runtime patch stores parameter values as JSON (`ModuleSpec.params`), but
   // the authoritative set of valid parameter names/types lives in the module schema.
 
   // === Module validation ===
@@ -507,7 +507,7 @@ pub fn validate_patch(
 #[cfg(test)]
 mod tests {
   use super::*;
-  use modular_core::types::ModuleState;
+  use modular_core::types::ModuleSpec;
   use serde_json::json;
 
   fn schemas() -> Vec<ModuleSchema> {
@@ -518,7 +518,7 @@ mod tests {
   fn test_valid_patch() {
     let schemas = schemas();
     let patch = PatchGraph {
-      modules: vec![ModuleState {
+      modules: vec![ModuleSpec {
         id: "sine-1".to_string(),
         module_type: "$sine".to_string(),
         id_is_explicit: None,
@@ -538,7 +538,7 @@ mod tests {
   fn patch_with_scope_xy(x_port: &str, x_module: &str) -> PatchGraph {
     use modular_core::types::{ScopeChannel, ScopeXy, ScopeXyPair};
     PatchGraph {
-      modules: vec![ModuleState {
+      modules: vec![ModuleSpec {
         id: "sine-1".to_string(),
         module_type: "$sine".to_string(),
         id_is_explicit: None,
@@ -602,7 +602,7 @@ mod tests {
   fn test_unknown_module_type() {
     let schemas = schemas();
     let patch = PatchGraph {
-      modules: vec![ModuleState {
+      modules: vec![ModuleSpec {
         id: "foo-1".to_string(),
         module_type: "unknown-module".to_string(),
         id_is_explicit: None,
@@ -641,7 +641,7 @@ mod tests {
   fn test_cable_to_nonexistent_module() {
     let schemas = schemas();
     let patch = PatchGraph {
-      modules: vec![ModuleState {
+      modules: vec![ModuleSpec {
         id: "root".to_string(),
         module_type: "$signal".to_string(),
         id_is_explicit: None,
@@ -667,7 +667,7 @@ mod tests {
     let schemas = schemas();
     let patch = PatchGraph {
       modules: vec![
-        ModuleState {
+        ModuleSpec {
           id: "sine-1".to_string(),
           module_type: "$sine".to_string(),
           id_is_explicit: None,
@@ -675,7 +675,7 @@ mod tests {
               "freq": 4.0
           }),
         },
-        ModuleState {
+        ModuleSpec {
           id: "root".to_string(),
           module_type: "$signal".to_string(),
           id_is_explicit: None,
@@ -705,7 +705,7 @@ mod tests {
   fn test_nested_signal_cable_to_nonexistent_module() {
     let schemas = schemas();
     let patch = PatchGraph {
-      modules: vec![ModuleState {
+      modules: vec![ModuleSpec {
         id: "nested-1".to_string(),
         module_type: "$mix".to_string(),
         id_is_explicit: None,
@@ -737,7 +737,7 @@ mod tests {
     let schemas = schemas();
     let patch = PatchGraph {
       modules: vec![
-        ModuleState {
+        ModuleSpec {
           id: "sine-1".to_string(),
           module_type: "$sine".to_string(),
           id_is_explicit: None,
@@ -745,7 +745,7 @@ mod tests {
               "freq": 4.0
           }),
         },
-        ModuleState {
+        ModuleSpec {
           id: "nested-1".to_string(),
           module_type: "$mix".to_string(),
           id_is_explicit: None,
@@ -770,7 +770,7 @@ mod tests {
     let schemas = schemas();
     let patch = PatchGraph {
       modules: vec![
-        ModuleState {
+        ModuleSpec {
           id: "sine-1".to_string(),
           module_type: "$sine".to_string(),
           id_is_explicit: None,
@@ -778,7 +778,7 @@ mod tests {
               "freq": 4.0
           }),
         },
-        ModuleState {
+        ModuleSpec {
           id: "signal-1".to_string(),
           module_type: "$signal".to_string(),
           id_is_explicit: None,
@@ -833,7 +833,7 @@ mod tests {
     let schemas = modular_core::dsp::schema();
 
     let patch = PatchGraph {
-      modules: vec![ModuleState {
+      modules: vec![ModuleSpec {
         id: "noise-1".to_string(),
         module_type: "$noise".to_string(),
         id_is_explicit: None,

--- a/crates/modular/src/wav_bpm.rs
+++ b/crates/modular/src/wav_bpm.rs
@@ -103,7 +103,10 @@ mod tests {
   #[test]
   fn filename_trailing_digits() {
     assert_eq!(parse_bpm_from_filename(&p("breaks125.wav")), Some(125.0));
-    assert_eq!(parse_bpm_from_filename(&p("cw_amen01_175.wav")), Some(175.0));
+    assert_eq!(
+      parse_bpm_from_filename(&p("cw_amen01_175.wav")),
+      Some(175.0)
+    );
   }
 
   #[test]

--- a/crates/modular_core/src/block_port.rs
+++ b/crates/modular_core/src/block_port.rs
@@ -1,47 +1,65 @@
 //! Block-sized port buffer.
 //!
-//! Layout: `data[sample_index][channel_index]`
-//!
+//! Layout: a flat `block_size * channels` slice, indexed `data[index * channels + ch]`.
 //! All channel values at the same sample index are contiguous in memory,
 //! enabling future SIMD optimization. Heap-allocated once at construction;
 //! never resized on the audio thread.
 
-use crate::poly::PORT_MAX_CHANNELS;
-
-/// A pre-allocated buffer holding `block_size` samples, each with `PORT_MAX_CHANNELS` channels.
+/// A pre-allocated buffer holding `block_size` samples, each with `channels`
+/// channels. The channel count is the producing port's width: 1 for a mono
+/// (f32) output, the module's channel count for a polyphonic output.
 ///
-/// `data[i][ch]` is the value for sample index `i`, channel `ch`.
+/// Reads cycle (`ch % channels`) so a consumer with more channels than the
+/// producer still sees the producer's value broadcast/wrapped across its
+/// channels — preserving the mono→poly broadcast semantics.
 pub struct BlockPort {
-    /// `data.len() == block_size` (set at construction, never changed).
-    pub data: Box<[[f32; PORT_MAX_CHANNELS]]>,
+    /// Flat `block_size * channels` voltages. Length never changes after
+    /// construction.
+    data: Box<[f32]>,
+    /// Per-port channel width (`>= 1` for live ports, `0` only when the
+    /// module is zero-channel).
+    channels: usize,
+    /// Number of sample slots (the internal block size).
+    block_size: usize,
 }
 
 impl BlockPort {
-    /// Allocate a new zeroed port buffer for the given block size.
+    /// Allocate a new zeroed port buffer for the given block size and channel
+    /// width.
     ///
     /// **Must not be called on the audio thread** (allocates heap memory).
-    pub fn new(block_size: usize) -> Self {
+    pub fn new(block_size: usize, channels: usize) -> Self {
         Self {
-            data: vec![[0.0f32; PORT_MAX_CHANNELS]; block_size].into_boxed_slice(),
+            data: vec![0.0f32; block_size * channels].into_boxed_slice(),
+            channels,
+            block_size,
         }
     }
 
-    /// Read value at `(index, ch)`, returning `0.0` for out-of-range accesses.
+    /// This port's channel width.
     #[inline]
-    pub fn get(&self, index: usize, ch: usize) -> f32 {
-        self.data
-            .get(index)
-            .and_then(|slot| slot.get(ch).copied())
-            .unwrap_or(0.0)
+    pub fn channels(&self) -> usize {
+        self.channels
     }
 
-    /// Write value at `(index, ch)`. Silently ignored if out of range.
+    /// Read value at `(index, ch)`, returning `0.0` for out-of-range sample
+    /// indices or a zero-channel port. The channel index cycles modulo the
+    /// port width, so a consumer reading a higher channel than the producer
+    /// has wraps around — preserving mono-broadcast / poly-cycling semantics.
+    #[inline]
+    pub fn get(&self, index: usize, ch: usize) -> f32 {
+        if self.channels == 0 || index >= self.block_size {
+            return 0.0;
+        }
+        self.data[index * self.channels + ch % self.channels]
+    }
+
+    /// Write value at `(index, ch)`. Silently ignored if out of range. The
+    /// channel index is raw (no cycling): callers write `0..channels`.
     #[inline]
     pub fn set(&mut self, index: usize, ch: usize, value: f32) {
-        if let Some(slot) = self.data.get_mut(index) {
-            if let Some(cell) = slot.get_mut(ch) {
-                *cell = value;
-            }
+        if index < self.block_size && ch < self.channels {
+            self.data[index * self.channels + ch] = value;
         }
     }
 }
@@ -49,34 +67,50 @@ impl BlockPort {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::poly::PORT_MAX_CHANNELS;
 
     #[test]
     fn block_port_new_zeroed() {
-        let bp = BlockPort::new(4);
-        assert_eq!(bp.data.len(), 4);
-        for slot in bp.data.iter() {
-            assert_eq!(*slot, [0.0f32; PORT_MAX_CHANNELS]);
+        let bp = BlockPort::new(4, 16);
+        assert_eq!(bp.channels(), 16);
+        for index in 0..4 {
+            for ch in 0..16 {
+                assert_eq!(bp.get(index, ch), 0.0);
+            }
         }
     }
 
     #[test]
     fn block_port_get_in_range() {
-        let mut bp = BlockPort::new(4);
-        bp.data[2][3] = 1.5;
+        let mut bp = BlockPort::new(4, 16);
+        bp.set(2, 3, 1.5);
         assert_eq!(bp.get(2, 3), 1.5);
     }
 
     #[test]
     fn block_port_get_out_of_range() {
-        let bp = BlockPort::new(4);
+        let bp = BlockPort::new(4, 16);
+        // Sample index out of range → 0.0.
         assert_eq!(bp.get(99, 0), 0.0);
-        assert_eq!(bp.get(0, 99), 0.0);
+    }
+
+    #[test]
+    fn block_port_channel_cycles() {
+        // A mono (width-1) port broadcasts to every consumer channel.
+        let mut bp = BlockPort::new(4, 1);
+        bp.set(1, 0, 2.5);
+        assert_eq!(bp.get(1, 0), 2.5);
+        assert_eq!(bp.get(1, 5), 2.5); // 5 % 1 == 0
+        // A width-2 port wraps higher channels.
+        let mut poly = BlockPort::new(4, 2);
+        poly.set(0, 0, 1.0);
+        poly.set(0, 1, 2.0);
+        assert_eq!(poly.get(0, 2), 1.0); // 2 % 2 == 0
+        assert_eq!(poly.get(0, 3), 2.0); // 3 % 2 == 1
     }
 
     #[test]
     fn block_port_set() {
-        let mut bp = BlockPort::new(4);
+        let mut bp = BlockPort::new(4, 16);
         bp.set(1, 2, 3.14);
         assert!((bp.get(1, 2) - 3.14).abs() < 1e-6);
     }

--- a/crates/modular_core/src/dsp/core/mix.rs
+++ b/crates/modular_core/src/dsp/core/mix.rs
@@ -172,8 +172,7 @@ impl Mix {
                         sum += input.get_value(channel);
                         count += 1;
                     }
-                    pre_gain_values[channel] =
-                        if count > 0 { sum / count as f32 } else { 0.0 };
+                    pre_gain_values[channel] = if count > 0 { sum / count as f32 } else { 0.0 };
                 }
             }
             MixMode::Max => {
@@ -215,8 +214,7 @@ impl Mix {
                             best_val = v;
                         }
                     }
-                    pre_gain_values[channel] =
-                        if best_abs.is_finite() { best_val } else { 0.0 };
+                    pre_gain_values[channel] = if best_abs.is_finite() { best_val } else { 0.0 };
                 }
             }
         }

--- a/crates/modular_core/src/dsp/core/mix.rs
+++ b/crates/modular_core/src/dsp/core/mix.rs
@@ -87,13 +87,7 @@ pub fn mix_derive_channel_count(params: &MixParams) -> usize {
 pub struct Mix {
     outputs: MixOutputs,
     params: MixParams,
-    state: MixState,
-}
-
-/// State for the Mix module.
-#[derive(Default)]
-struct MixState {
-    gain_buffer: [Clickless; PORT_MAX_CHANNELS],
+    channel_state: Box<[Clickless]>,
 }
 
 message_handlers!(impl Mix {});
@@ -109,7 +103,7 @@ pub fn __bench_make_mix(params: MixParams) -> Mix {
         outputs,
         _channel_count: channels,
         _block_index: Default::default(),
-        state: MixState::default(),
+        channel_state: vec![Clickless::default(); channels].into_boxed_slice(),
     }
 }
 
@@ -230,8 +224,8 @@ impl Mix {
             let amp_val = gain.value_or(i, 5.0);
             let normalized = (amp_val.abs() * (1.0 / 5.0)).max(0.0);
             let curved = amp_val.signum() * (normalized * normalized * normalized);
-            self.state.gain_buffer[i].update(curved);
-            let gain_value = *self.state.gain_buffer[i];
+            self.channel_state[i].update(curved);
+            let gain_value = *self.channel_state[i];
             self.outputs.sample.set(i, pre_gain_value * gain_value);
         }
     }
@@ -248,13 +242,14 @@ mod tests {
         let channels = mix_derive_channel_count(&params);
         let mut outputs = MixOutputs::default();
         outputs.set_all_channels(channels);
-        Mix {
+        let mixer = Mix {
             params,
             outputs,
             _channel_count: channels,
             _block_index: Default::default(),
-            state: MixState::default(),
-        }
+            channel_state: vec![Clickless::default(); channels].into_boxed_slice(),
+        };
+        mixer
     }
 
     #[test]

--- a/crates/modular_core/src/dsp/core/mix_down.rs
+++ b/crates/modular_core/src/dsp/core/mix_down.rs
@@ -110,17 +110,17 @@ impl MixDown {
     ///   silent gaps. There are no collisions, so `mode` does not apply.
     fn build_gains(gains: &mut [f32], in_ch: usize, out_ch: usize) {
         // Clear any stale entries from a previous topology.
-        for g in gains.iter_mut() {
-            *g = 0.0;
-        }
+        gains.fill(0.0);
 
         if in_ch == 0 || out_ch == 0 {
             return;
         }
 
+        // Mono and fold-down are row-keyed: each input owns one row of the
+        // flat `in_ch * out_ch` matrix, so iterate rows via `chunks_mut`.
         if out_ch == 1 {
-            for i in 0..in_ch {
-                gains[i * out_ch] = 1.0;
+            for row in gains.chunks_mut(out_ch).take(in_ch) {
+                row[0] = 1.0;
             }
             return;
         }
@@ -128,7 +128,7 @@ impl MixDown {
         if out_ch <= in_ch {
             // Fold-down: scatter each input across the output field so every
             // input contributes.
-            for i in 0..in_ch {
+            for (i, row) in gains.chunks_mut(out_ch).enumerate().take(in_ch) {
                 let t = if in_ch == 1 {
                     0.5
                 } else {
@@ -137,15 +137,18 @@ impl MixDown {
                 let pos = t * (out_ch - 1) as f32;
                 let lo = pos.floor() as usize;
                 let frac = pos - lo as f32;
-                gains[i * out_ch + lo] = (1.0 - frac).sqrt();
+                row[lo] = (1.0 - frac).sqrt();
                 if lo + 1 < out_ch {
-                    gains[i * out_ch + lo + 1] = frac.sqrt();
+                    row[lo + 1] = frac.sqrt();
                 }
             }
         } else {
             // Fold-up: gather an equal-power interpolation of adjacent inputs
             // into each output so no output channel is left silent. With a
-            // single input (N == 1) every output samples it at unity.
+            // single input (N == 1) every output samples it at unity. This
+            // branch writes one output column `j` across two adjacent input
+            // rows (`lo`, `lo + 1`), so it indexes the flat matrix directly
+            // rather than iterating rows.
             for j in 0..out_ch {
                 let s = if in_ch == 1 {
                     0.0

--- a/crates/modular_core/src/dsp/core/mix_down.rs
+++ b/crates/modular_core/src/dsp/core/mix_down.rs
@@ -14,7 +14,7 @@ fn default_channels() -> usize {
 pub struct MixDownParams {
     /// Polyphonic input whose channels are folded down.
     pub input: PolySignal,
-    /// Target output channel count (1–16). Defaults to 1 (mono).
+    /// Target output channel count (1–64). Defaults to 1 (mono).
     #[serde(default = "default_channels")]
     #[deserr(default = default_channels())]
     pub channels: usize,
@@ -47,7 +47,7 @@ struct MixDownOutputs {
 /// exceeds the input channel count, the input is instead spread to fill every
 /// output channel (equal-power interpolation) so no channel is left silent.
 ///
-/// - **channels** — target output channel count (1–16, default 1)
+/// - **channels** — target output channel count (1–64, default 1)
 /// - **mode** — how channels landing on the same output combine (sum / average /
 ///   max / min); applies only when folding down (target ≤ input channels)
 ///
@@ -61,29 +61,39 @@ struct MixDownOutputs {
     name = "$mixDown",
     channels_param = "channels",
     args(input, channels),
-    patch_update,
+    has_init,
+    patch_update
 )]
 pub struct MixDown {
     outputs: MixDownOutputs,
     params: MixDownParams,
-    state: MixDownState,
-}
-
-/// State for the MixDown module.
-///
-/// `gains[i][j]` is the equal-power pan gain from input channel `i` to output
-/// channel `j`. It depends only on the input/output channel counts, both fixed
-/// for the patch's lifetime, so it is built once per patch-apply in
-/// `on_patch_update` (loop-invariant — keeps the per-sample `sqrt` out of
-/// `update`) and read unchanged on the audio thread.
-#[derive(Default)]
-struct MixDownState {
-    gains: [[f32; PORT_MAX_CHANNELS]; PORT_MAX_CHANNELS],
+    /// Equal-power pan gains, stored row-major as a flat `in_ch * out_ch`
+    /// matrix: `gains[i * out_ch + j]` is the gain from input channel `i` to
+    /// output channel `j`. Both counts are fixed for the patch's lifetime, so
+    /// the matrix is sized to them in `init` (no fixed `PORT_MAX²` upfront cost)
+    /// and rebuilt — never reallocated — in `on_patch_update`, then read
+    /// unchanged on the audio thread.
+    ///
+    /// It lives in `channel_state` (not `state`) so the macro's size-aware
+    /// transfer never grows a swapped-in box across a channel-count change: a
+    /// fresh `init` always sizes each new instance, and `on_patch_update` only
+    /// fills within that length.
+    channel_state: Box<[f32]>,
 }
 
 message_handlers!(impl MixDown {});
 
 impl MixDown {
+    /// Size the gain matrix to the patch's input × output channel counts on the
+    /// main thread, so `on_patch_update` (audio thread) only fills it. Both
+    /// counts are resolved by construction time: `out_ch` from `channels`,
+    /// `in_ch` from the input signal's width.
+    fn init(&mut self, _sample_rate: f32) {
+        let in_ch = self.params.input.channels().min(PORT_MAX_CHANNELS);
+        let out_ch = self.channel_count();
+        self.channel_state = vec![0.0; in_ch * out_ch].into_boxed_slice();
+    }
+
     /// Fill `gains` with the equal-power pan matrix mapping `in_ch` (N) input
     /// channels onto `out_ch` (M) output channels. `gains[i][j]` is the gain
     /// from input channel `i` to output channel `j`.
@@ -98,16 +108,10 @@ impl MixDown {
     ///   position `s = j*(N-1)/(M-1)` and gathers an equal-power interpolation
     ///   of the adjacent input channels. This fills every output channel — no
     ///   silent gaps. There are no collisions, so `mode` does not apply.
-    fn build_gains(
-        gains: &mut [[f32; PORT_MAX_CHANNELS]; PORT_MAX_CHANNELS],
-        in_ch: usize,
-        out_ch: usize,
-    ) {
+    fn build_gains(gains: &mut [f32], in_ch: usize, out_ch: usize) {
         // Clear any stale entries from a previous topology.
-        for row in gains.iter_mut() {
-            for g in row.iter_mut() {
-                *g = 0.0;
-            }
+        for g in gains.iter_mut() {
+            *g = 0.0;
         }
 
         if in_ch == 0 || out_ch == 0 {
@@ -115,8 +119,8 @@ impl MixDown {
         }
 
         if out_ch == 1 {
-            for row in gains.iter_mut().take(in_ch) {
-                row[0] = 1.0;
+            for i in 0..in_ch {
+                gains[i * out_ch] = 1.0;
             }
             return;
         }
@@ -124,7 +128,7 @@ impl MixDown {
         if out_ch <= in_ch {
             // Fold-down: scatter each input across the output field so every
             // input contributes.
-            for (i, row) in gains.iter_mut().enumerate().take(in_ch) {
+            for i in 0..in_ch {
                 let t = if in_ch == 1 {
                     0.5
                 } else {
@@ -133,9 +137,9 @@ impl MixDown {
                 let pos = t * (out_ch - 1) as f32;
                 let lo = pos.floor() as usize;
                 let frac = pos - lo as f32;
-                row[lo] = (1.0 - frac).sqrt();
+                gains[i * out_ch + lo] = (1.0 - frac).sqrt();
                 if lo + 1 < out_ch {
-                    row[lo + 1] = frac.sqrt();
+                    gains[i * out_ch + lo + 1] = frac.sqrt();
                 }
             }
         } else {
@@ -150,9 +154,9 @@ impl MixDown {
                 };
                 let lo = s.floor() as usize;
                 let frac = s - lo as f32;
-                gains[lo][j] = (1.0 - frac).sqrt();
+                gains[lo * out_ch + j] = (1.0 - frac).sqrt();
                 if lo + 1 < in_ch {
-                    gains[lo + 1][j] = frac.sqrt();
+                    gains[(lo + 1) * out_ch + j] = frac.sqrt();
                 }
             }
         }
@@ -168,7 +172,7 @@ impl MixDown {
             *v = self.params.input.get_value(i);
         }
 
-        let gains = &self.state.gains;
+        let gains = &self.channel_state;
 
         // Folding up gathers an equal-power crossfade per output (no inputs
         // collide on one output), so the combine mode is irrelevant — sum the
@@ -186,7 +190,7 @@ impl MixDown {
                 for j in 0..out_ch {
                     let mut acc = 0.0f32;
                     for i in 0..in_ch {
-                        acc += in_vals[i] * gains[i][j];
+                        acc += in_vals[i] * gains[i * out_ch + j];
                     }
                     self.outputs.sample.set(j, acc);
                 }
@@ -196,7 +200,7 @@ impl MixDown {
                     let mut acc = 0.0f32;
                     let mut count: u32 = 0;
                     for i in 0..in_ch {
-                        let g = gains[i][j];
+                        let g = gains[i * out_ch + j];
                         if g == 0.0 {
                             continue;
                         }
@@ -213,7 +217,7 @@ impl MixDown {
                     let mut best_abs = -1.0f32;
                     let mut best_val = 0.0f32;
                     for i in 0..in_ch {
-                        let g = gains[i][j];
+                        let g = gains[i * out_ch + j];
                         if g == 0.0 {
                             continue;
                         }
@@ -236,7 +240,7 @@ impl MixDown {
                     let mut best_abs = f32::INFINITY;
                     let mut best_val = 0.0f32;
                     for i in 0..in_ch {
-                        let g = gains[i][j];
+                        let g = gains[i * out_ch + j];
                         if g == 0.0 {
                             continue;
                         }
@@ -264,11 +268,12 @@ impl crate::types::PatchUpdateHandler for MixDown {
     /// counts are fixed for the patch's lifetime, and this runs after the
     /// connect pass (so `input.channels()` is resolved) and after any
     /// `transfer_state_from`, so the unconditional rebuild overwrites a stale
-    /// swapped-in matrix. Allocation-free — safe on the audio thread.
+    /// swapped-in matrix. The matrix was sized in `init`, so this only fills it
+    /// — allocation-free, safe on the audio thread.
     fn on_patch_update(&mut self) {
         let in_ch = self.params.input.channels().min(PORT_MAX_CHANNELS);
         let out_ch = self.channel_count();
-        Self::build_gains(&mut self.state.gains, in_ch, out_ch);
+        Self::build_gains(&mut self.channel_state, in_ch, out_ch);
     }
 }
 
@@ -279,8 +284,8 @@ mod tests {
     use crate::types::{OutputStruct, Signal};
 
     /// Build a MixDown directly, initializing `_channel_count` and the output
-    /// channels the way the module macro would. `channels` is clamped to 1–16
-    /// (matching the macro's `channels_param` codegen).
+    /// channels the way the module macro would. `channels` is clamped to
+    /// 1–PORT_MAX_CHANNELS (matching the macro's `channels_param` codegen).
     fn make_mix_down(params: MixDownParams) -> MixDown {
         let channels = params.channels.clamp(1, PORT_MAX_CHANNELS);
         let mut outputs = MixDownOutputs::default();
@@ -290,10 +295,12 @@ mod tests {
             outputs,
             _channel_count: channels,
             _block_index: Default::default(),
-            state: MixDownState::default(),
+            channel_state: Box::default(),
         };
-        // Production constructs → connects → on_patch_update → process; mirror
-        // that order here so the gain matrix is built before update() reads it.
+        // Production constructs → init → connects → on_patch_update → process;
+        // mirror that order so the gain matrix is sized (init) and built
+        // (on_patch_update) before update() reads it.
+        m.init(48000.0);
         crate::types::PatchUpdateHandler::on_patch_update(&mut m);
         m
     }
@@ -308,11 +315,7 @@ mod tests {
     fn test_three_to_two_equal_power_pan() {
         // 3 input channels folded to 2: inputs land at -1, 0, +1.
         let mut m = make_mix_down(MixDownParams {
-            input: PolySignal::poly(&[
-                Signal::Volts(1.0),
-                Signal::Volts(1.0),
-                Signal::Volts(1.0),
-            ]),
+            input: PolySignal::poly(&[Signal::Volts(1.0), Signal::Volts(1.0), Signal::Volts(1.0)]),
             channels: 2,
             mode: MixMode::Sum,
         });
@@ -327,11 +330,7 @@ mod tests {
     fn test_center_input_equal_power() {
         // Only the center input is active: it pans equally to both outputs.
         let mut m = make_mix_down(MixDownParams {
-            input: PolySignal::poly(&[
-                Signal::Volts(0.0),
-                Signal::Volts(4.0),
-                Signal::Volts(0.0),
-            ]),
+            input: PolySignal::poly(&[Signal::Volts(0.0), Signal::Volts(4.0), Signal::Volts(0.0)]),
             channels: 2,
             mode: MixMode::Sum,
         });
@@ -344,11 +343,7 @@ mod tests {
     fn test_mono_fold_down_default_channels() {
         // channels defaults to 1 in the DSL; here we exercise a plain mono sum.
         let mut m = make_mix_down(MixDownParams {
-            input: PolySignal::poly(&[
-                Signal::Volts(1.0),
-                Signal::Volts(2.0),
-                Signal::Volts(3.0),
-            ]),
+            input: PolySignal::poly(&[Signal::Volts(1.0), Signal::Volts(2.0), Signal::Volts(3.0)]),
             channels: 1,
             mode: MixMode::Sum,
         });
@@ -387,11 +382,7 @@ mod tests {
     fn test_average_mode() {
         // 3→2, average of the contributing (non-zero-gain) inputs per output.
         let mut m = make_mix_down(MixDownParams {
-            input: PolySignal::poly(&[
-                Signal::Volts(1.0),
-                Signal::Volts(2.0),
-                Signal::Volts(3.0),
-            ]),
+            input: PolySignal::poly(&[Signal::Volts(1.0), Signal::Volts(2.0), Signal::Volts(3.0)]),
             channels: 2,
             mode: MixMode::Average,
         });
@@ -404,10 +395,10 @@ mod tests {
 
     #[test]
     fn test_channel_count_clamped() {
-        // Over-large channel counts clamp to PORT_MAX_CHANNELS (16).
+        // Over-large channel counts clamp to PORT_MAX_CHANNELS.
         let mut m = make_mix_down(MixDownParams {
             input: PolySignal::poly(&[Signal::Volts(1.0), Signal::Volts(2.0)]),
-            channels: 20,
+            channels: PORT_MAX_CHANNELS + 50,
             mode: MixMode::Sum,
         });
         m.update(48000.0);

--- a/crates/modular_core/src/dsp/core/stereo_mixer.rs
+++ b/crates/modular_core/src/dsp/core/stereo_mixer.rs
@@ -1,5 +1,4 @@
 use crate::{
-    PORT_MAX_CHANNELS,
     poly::{MonoSignal, MonoSignalExt, PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
 };
@@ -37,40 +36,42 @@ struct ChannelState {
 }
 
 /// Pan and spread a signal into stereo.
-#[module(name = "$stereoMix", channels = 2, args(input))]
+#[module(name = "$stereoMix", channels = 2, args(input), has_init)]
 pub struct StereoMixer {
     outputs: StereoMixerOutputs,
     params: StereoMixerParams,
     state: StereoMixerState,
+    /// Per-input-channel pan state. Sized to the *input* signal's channel
+    /// count (not the module's fixed 2 output channels) in `init`, so its
+    /// length is decoupled from the derived channel count. State transfer
+    /// carries over the overlapping channels; a width change keeps the surplus
+    /// freshly initialised.
+    channel_state: Box<[ChannelState]>,
 }
 
-/// State for the StereoMixer module.
+/// Module-level state for the StereoMixer.
+#[derive(Default)]
 struct StereoMixerState {
-    /// Per-channel pan state
-    channel_state: [ChannelState; PORT_MAX_CHANNELS],
     /// Width buffer for stereo spread
     width_buffer: Clickless,
 }
 
-impl Default for StereoMixerState {
-    fn default() -> Self {
-        Self {
-            channel_state: [ChannelState::default(); PORT_MAX_CHANNELS],
-            width_buffer: Clickless::default(),
-        }
-    }
-}
-
 impl StereoMixer {
+    fn init(&mut self, _sample_rate: f32) {
+        // One pan smoother per input channel.
+        let input_channels = self.params.input.channels().max(1);
+        self.channel_state = vec![ChannelState::default(); input_channels].into_boxed_slice();
+    }
+
     pub fn update(&mut self, _sample_rate: f32) {
         let input_channels = self.params.input.channels();
-        let state = &mut self.state;
 
         // Width: 0 = no spread, 5 = full ±5V spread across voices. Defaults to
         // 0 (no spread) when no width signal is connected.
-        state
+        self.state
             .width_buffer
             .update(self.params.width.value_or(0.0).clamp(0.0, 5.0));
+        let width = *self.state.width_buffer;
 
         let mut left_sum = 0.0f32;
         let mut right_sum = 0.0f32;
@@ -86,7 +87,7 @@ impl StereoMixer {
             // Voice 0 -> -width, last voice -> +width
             let spread_offset = if input_channels > 1 {
                 let voice_pos = ch as f32 / (input_channels - 1) as f32; // 0.0 to 1.0
-                (voice_pos - 0.5) * 2.0 * *state.width_buffer // -width to +width
+                (voice_pos - 0.5) * 2.0 * width // -width to +width
             } else {
                 0.0 // Single voice stays at base pan
             };
@@ -95,8 +96,8 @@ impl StereoMixer {
             let final_pan = (base_pan + spread_offset).clamp(-5.0, 5.0);
 
             // Smooth pan changes to avoid clicks
-            state.channel_state[ch].pan.update(final_pan);
-            let pan = *state.channel_state[ch].pan;
+            self.channel_state[ch].pan.update(final_pan);
+            let pan = *self.channel_state[ch].pan;
 
             // Convert -5..+5 to 0..1 (0 = full left, 1 = full right)
             let pan_norm = (pan + 5.0) / 10.0;
@@ -119,26 +120,50 @@ message_handlers!(impl StereoMixer {});
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::poly::PolySignal;
-    use crate::types::{OutputStruct, Signal};
+    use crate::types::{OutputStruct as _, Signal};
 
-    /// Build a StereoMixer directly, initializing the output channels the way the
-    /// module macro would (fixed 2-channel stereo). `Clickless` snaps to its
-    /// target on the first `update`, so a single call shows the full pan/width.
-    fn make_stereo(params: StereoMixerParams) -> StereoMixer {
+    /// Build a StereoMixer the way the module macro would: fixed 2-channel
+    /// stereo output, per-input-channel pan state sized by `init`. `Clickless`
+    /// snaps to its target on the first `update`, so a single call shows the
+    /// full pan/width.
+    fn make_stereo(input: PolySignal) -> StereoMixer {
         let mut outputs = StereoMixerOutputs::default();
         outputs.set_all_channels(2);
-        StereoMixer {
-            params,
+        let mut m = StereoMixer {
             outputs,
+            params: StereoMixerParams {
+                input,
+                pan: None,
+                width: None,
+            },
+            state: StereoMixerState::default(),
+            channel_state: Box::default(),
             _channel_count: 2,
             _block_index: Default::default(),
-            state: StereoMixerState::default(),
-        }
+        };
+        m.init(48000.0);
+        m
+    }
+
+    fn poly(n: usize) -> PolySignal {
+        PolySignal::poly(&(0..n).map(|_| Signal::Volts(0.0)).collect::<Vec<_>>())
     }
 
     fn approx(a: f32, b: f32) {
         assert!((a - b).abs() < 1e-5, "expected {b}, got {a}");
+    }
+
+    #[test]
+    fn pan_state_sized_to_input_channels() {
+        assert_eq!(make_stereo(poly(5)).channel_state.len(), 5);
+        assert_eq!(make_stereo(poly(1)).channel_state.len(), 1);
+    }
+
+    #[test]
+    fn wide_input_does_not_panic_and_outputs_stereo() {
+        let mut m = make_stereo(poly(40));
+        m.update(48000.0);
+        assert_eq!(m.outputs.sample.channels(), 2);
     }
 
     #[test]
@@ -147,11 +172,7 @@ mod tests {
         // every voice stays centered, so a 2-voice input sums equally to both
         // channels at the equal-power center gain sqrt(0.5). (A width of 5
         // would instead hard-pan voice 0 left and voice 1 right.)
-        let mut m = make_stereo(StereoMixerParams {
-            input: PolySignal::poly(&[Signal::Volts(1.0), Signal::Volts(0.0)]),
-            pan: None,
-            width: None,
-        });
+        let mut m = make_stereo(PolySignal::poly(&[Signal::Volts(1.0), Signal::Volts(0.0)]));
         m.update(48000.0);
         let center = 0.5f32.sqrt();
         approx(m.outputs.sample.get(0), center); // left  = voice 0 centered

--- a/crates/modular_core/src/dsp/dynamics/compressor.rs
+++ b/crates/modular_core/src/dsp/dynamics/compressor.rs
@@ -7,7 +7,7 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::dsp::utils::sanitize;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 
 // Gain voltage scaling: maps [-5, 5] volts to [-24, 24] dB (4.8 dB per volt)
 const DB_PER_VOLT: f32 = 4.8;
@@ -107,12 +107,6 @@ fn compress(
 #[derive(Clone, Copy, Default)]
 struct ChannelState {
     envelope: f32,
-}
-
-/// State for the Compressor module.
-#[derive(Default)]
-struct CompressorState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
 }
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -244,7 +238,7 @@ struct CompressorOutputs {
 #[module(name = "$comp", args(input))]
 pub struct Compressor {
     outputs: CompressorOutputs,
-    state: CompressorState,
+    channel_state: Box<[ChannelState]>,
     params: CompressorParams,
 }
 
@@ -253,7 +247,7 @@ impl Compressor {
         let channels = self.channel_count();
 
         for ch in 0..channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
 

--- a/crates/modular_core/src/dsp/dynamics/crossover.rs
+++ b/crates/modular_core/src/dsp/dynamics/crossover.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 
 use crate::{
     dsp::utils::{changed, sanitize, voct_to_hz},
-    poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
+    poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
 };
 
@@ -169,12 +169,6 @@ struct ChannelState {
     smooth_mid_high: Clickless,
 }
 
-/// State for the Crossover module.
-#[derive(Default)]
-struct CrossoverState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 // ── Module ───────────────────────────────────────────────────────────────────
 
 /// EXPERIMENTAL
@@ -201,7 +195,7 @@ struct CrossoverState {
 #[module(name = "$xover", args(input))]
 pub struct Crossover {
     outputs: CrossoverOutputs,
-    state: CrossoverState,
+    channel_state: Box<[ChannelState]>,
     params: CrossoverParams,
 }
 
@@ -210,7 +204,7 @@ impl Crossover {
         let channels = self.channel_count();
 
         for ch in 0..channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
 

--- a/crates/modular_core/src/dsp/filters/bandpass.rs
+++ b/crates/modular_core/src/dsp/filters/bandpass.rs
@@ -2,7 +2,6 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::{
-    PORT_MAX_CHANNELS,
     dsp::utils::{changed, sanitize, voct_to_hz},
     poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
@@ -94,13 +93,12 @@ fn compute_bpf_biquad(center: f32, resonance: f32, sample_rate: f32) -> BiquadCo
 pub struct BandpassFilter {
     outputs: BandpassFilterOutputs,
     state: BandpassFilterState,
+    channel_state: Box<[BpfChannelState]>,
     params: BandpassFilterParams,
 }
 
 /// State for the BandpassFilter module.
 struct BandpassFilterState {
-    /// Per-channel state
-    channels: [BpfChannelState; PORT_MAX_CHANNELS],
     /// Mono optimization
     coeffs_mono: BiquadCoeffs,
     last_center_mono: f32,
@@ -112,7 +110,6 @@ struct BandpassFilterState {
 impl Default for BandpassFilterState {
     fn default() -> Self {
         Self {
-            channels: [BpfChannelState::default(); PORT_MAX_CHANNELS],
             coeffs_mono: BiquadCoeffs::default(),
             last_center_mono: f32::NAN,
             last_q_mono: f32::NAN,
@@ -125,7 +122,6 @@ impl Default for BandpassFilterState {
 impl BandpassFilter {
     fn update(&mut self, sample_rate: f32) {
         let num_channels = self.channel_count();
-        let state = &mut self.state;
 
         let center_mono = self.params.center.is_monophonic();
         let resonance_mono = self
@@ -136,36 +132,37 @@ impl BandpassFilter {
 
         // Update coefficients with smoothed params to prevent clicks
         if center_mono && resonance_mono {
-            state
+            self.state
                 .smooth_center_mono
                 .update(self.params.center.get_value(0));
-            state
+            self.state
                 .smooth_resonance_mono
                 .update(self.params.resonance.value_or(0, 1.0));
-            let c = *state.smooth_center_mono;
-            let r = *state.smooth_resonance_mono;
+            let c = *self.state.smooth_center_mono;
+            let r = *self.state.smooth_resonance_mono;
 
-            if changed(c, state.last_center_mono) || changed(r, state.last_q_mono) {
-                state.coeffs_mono = compute_bpf_biquad(c, r, sample_rate);
-                state.last_center_mono = c;
-                state.last_q_mono = r;
+            if changed(c, self.state.last_center_mono) || changed(r, self.state.last_q_mono) {
+                self.state.coeffs_mono = compute_bpf_biquad(c, r, sample_rate);
+                self.state.last_center_mono = c;
+                self.state.last_q_mono = r;
             }
         } else {
             for i in 0..num_channels {
-                state.channels[i]
+                self.channel_state[i]
                     .smooth_center
                     .update(self.params.center.get_value(i));
-                state.channels[i]
+                self.channel_state[i]
                     .smooth_resonance
                     .update(self.params.resonance.value_or(i, 1.0));
-                let c = *state.channels[i].smooth_center;
-                let r = *state.channels[i].smooth_resonance;
+                let c = *self.channel_state[i].smooth_center;
+                let r = *self.channel_state[i].smooth_resonance;
 
-                if changed(c, state.channels[i].last_center) || changed(r, state.channels[i].last_q)
+                if changed(c, self.channel_state[i].last_center)
+                    || changed(r, self.channel_state[i].last_q)
                 {
-                    state.channels[i].coeffs = compute_bpf_biquad(c, r, sample_rate);
-                    state.channels[i].last_center = c;
-                    state.channels[i].last_q = r;
+                    self.channel_state[i].coeffs = compute_bpf_biquad(c, r, sample_rate);
+                    self.channel_state[i].last_center = c;
+                    self.channel_state[i].last_q = r;
                 }
             }
         }
@@ -174,12 +171,12 @@ impl BandpassFilter {
             let input = self.params.input.get_value(i);
 
             let c = if center_mono && resonance_mono {
-                state.coeffs_mono
+                self.state.coeffs_mono
             } else {
-                state.channels[i].coeffs
+                self.channel_state[i].coeffs
             };
 
-            let ch_state = &mut state.channels[i];
+            let ch_state = &mut self.channel_state[i];
             let w = input - c.a1 * ch_state.z1 - c.a2 * ch_state.z2;
             let w = sanitize(w);
             let y = c.b0 * w + c.b1 * ch_state.z1 + c.b2 * ch_state.z2;

--- a/crates/modular_core/src/dsp/filters/highpass.rs
+++ b/crates/modular_core/src/dsp/filters/highpass.rs
@@ -2,7 +2,6 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::{
-    PORT_MAX_CHANNELS,
     dsp::utils::{changed, sanitize, voct_to_hz},
     poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
@@ -94,13 +93,12 @@ fn compute_hpf_biquad(cutoff: f32, resonance: f32, sample_rate: f32) -> BiquadCo
 pub struct HighpassFilter {
     outputs: HighpassFilterOutputs,
     state: HighpassFilterState,
+    channel_state: Box<[HpfChannelState]>,
     params: HighpassFilterParams,
 }
 
 /// State for the HighpassFilter module.
 struct HighpassFilterState {
-    /// Per-channel state
-    channels: [HpfChannelState; PORT_MAX_CHANNELS],
     /// Mono optimization
     coeffs_mono: BiquadCoeffs,
     last_cutoff_mono: f32,
@@ -112,7 +110,6 @@ struct HighpassFilterState {
 impl Default for HighpassFilterState {
     fn default() -> Self {
         Self {
-            channels: [HpfChannelState::default(); PORT_MAX_CHANNELS],
             coeffs_mono: BiquadCoeffs::default(),
             last_cutoff_mono: f32::NAN,
             last_resonance_mono: f32::NAN,
@@ -152,21 +149,21 @@ impl HighpassFilter {
             }
         } else {
             for i in 0..num_channels {
-                state.channels[i]
+                self.channel_state[i]
                     .smooth_cutoff
                     .update(self.params.cutoff.get_value(i));
-                state.channels[i]
+                self.channel_state[i]
                     .smooth_resonance
                     .update(self.params.resonance.value_or(i, 0.0));
-                let c = *state.channels[i].smooth_cutoff;
-                let r = *state.channels[i].smooth_resonance;
+                let c = *self.channel_state[i].smooth_cutoff;
+                let r = *self.channel_state[i].smooth_resonance;
 
-                if changed(c, state.channels[i].last_cutoff)
-                    || changed(r, state.channels[i].last_resonance)
+                if changed(c, self.channel_state[i].last_cutoff)
+                    || changed(r, self.channel_state[i].last_resonance)
                 {
-                    state.channels[i].coeffs = compute_hpf_biquad(c, r, sample_rate);
-                    state.channels[i].last_cutoff = c;
-                    state.channels[i].last_resonance = r;
+                    self.channel_state[i].coeffs = compute_hpf_biquad(c, r, sample_rate);
+                    self.channel_state[i].last_cutoff = c;
+                    self.channel_state[i].last_resonance = r;
                 }
             }
         }
@@ -177,10 +174,10 @@ impl HighpassFilter {
             let c = if cutoff_mono && resonance_mono {
                 state.coeffs_mono
             } else {
-                state.channels[i].coeffs
+                self.channel_state[i].coeffs
             };
 
-            let ch_state = &mut state.channels[i];
+            let ch_state = &mut self.channel_state[i];
             let w = input - c.a1 * ch_state.z1 - c.a2 * ch_state.z2;
             let w = sanitize(w);
             let y = c.b0 * w + c.b1 * ch_state.z1 + c.b2 * ch_state.z2;

--- a/crates/modular_core/src/dsp/filters/jup6f.rs
+++ b/crates/modular_core/src/dsp/filters/jup6f.rs
@@ -2,7 +2,6 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::{
-    PORT_MAX_CHANNELS,
     dsp::utils::{changed, sanitize, voct_to_hz},
     poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
@@ -79,13 +78,12 @@ struct LadderState {
 pub struct Jup6f {
     outputs: Jup6fOutputs,
     state: Jup6fState,
+    channel_state: Box<[LadderState]>,
     params: Jup6fParams,
 }
 
 /// State for the Jup6f module.
 struct Jup6fState {
-    /// Per-channel ladder state
-    channels: [LadderState; PORT_MAX_CHANNELS],
     /// Mono optimization
     mono_g: f32,
     mono_k: f32,
@@ -98,7 +96,6 @@ struct Jup6fState {
 impl Default for Jup6fState {
     fn default() -> Self {
         Self {
-            channels: [LadderState::default(); PORT_MAX_CHANNELS],
             mono_g: 0.0,
             mono_k: 0.0,
             last_cutoff_mono: f32::NAN, // Indicate that coefficients have never been calculated
@@ -197,6 +194,7 @@ impl Jup6f {
     fn update(&mut self, sample_rate: f32) {
         let num_channels = self.channel_count();
         let state = &mut self.state;
+        let channel_state = &mut self.channel_state;
         let cutoff_mono = self.params.cutoff.is_monophonic();
         let resonance_mono = self
             .params
@@ -225,23 +223,23 @@ impl Jup6f {
             }
         } else {
             for i in 0..num_channels {
-                state.channels[i]
+                channel_state[i]
                     .smooth_cutoff
                     .update(self.params.cutoff.get_value(i));
-                state.channels[i]
+                channel_state[i]
                     .smooth_resonance
                     .update(self.params.resonance.value_or(i, 0.0));
-                let c = *state.channels[i].smooth_cutoff;
-                let r = *state.channels[i].smooth_resonance;
+                let c = *channel_state[i].smooth_cutoff;
+                let r = *channel_state[i].smooth_resonance;
 
-                if changed(c, state.channels[i].last_cutoff)
-                    || changed(r, state.channels[i].last_resonance)
+                if changed(c, channel_state[i].last_cutoff)
+                    || changed(r, channel_state[i].last_resonance)
                 {
                     let (g, k) = compute_coeffs(c, r, sample_rate);
-                    state.channels[i].g = g;
-                    state.channels[i].k = k;
-                    state.channels[i].last_cutoff = c;
-                    state.channels[i].last_resonance = r;
+                    channel_state[i].g = g;
+                    channel_state[i].k = k;
+                    channel_state[i].last_cutoff = c;
+                    channel_state[i].last_resonance = r;
                 }
             }
         }
@@ -252,10 +250,10 @@ impl Jup6f {
             let (g, k) = if is_mono {
                 (state.mono_g, state.mono_k)
             } else {
-                (state.channels[i].g, state.channels[i].k)
+                (channel_state[i].g, channel_state[i].k)
             };
 
-            let (lp24, lp12, bp, hp) = process_ladder(input, &mut state.channels[i].s, g, k);
+            let (lp24, lp12, bp, hp) = process_ladder(input, &mut channel_state[i].s, g, k);
 
             self.outputs.lp24.set(i, lp24 * 5.0);
             self.outputs.lp12.set(i, lp12 * 5.0);

--- a/crates/modular_core/src/dsp/filters/lowpass.rs
+++ b/crates/modular_core/src/dsp/filters/lowpass.rs
@@ -2,7 +2,6 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::{
-    PORT_MAX_CHANNELS,
     dsp::utils::{changed, sanitize, voct_to_hz},
     poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
@@ -49,23 +48,42 @@ struct LowpassFilterOutputs {
 pub struct LowpassFilter {
     outputs: LowpassFilterOutputs,
     state: LowpassFilterState,
+    channel_state: Box<[LowpassChannel]>,
     params: LowpassFilterParams,
 }
 
-/// State for the LowpassFilter module.
+/// Per-channel filter state.
+#[derive(Clone, Copy)]
+struct LowpassChannel {
+    /// Audio-rate biquad state.
+    z1: f32,
+    z2: f32,
+    /// Cached coefficients (control-rate).
+    coeffs: BiquadCoeffs,
+    /// Last seen params (for change detection); `NaN` = never computed.
+    last_cutoff: f32,
+    last_resonance: f32,
+    /// Parameter smoothing to prevent clicks on sudden changes.
+    smooth_cutoff: Clickless,
+    smooth_resonance: Clickless,
+}
+
+impl Default for LowpassChannel {
+    fn default() -> Self {
+        Self {
+            z1: 0.0,
+            z2: 0.0,
+            coeffs: BiquadCoeffs::default(),
+            last_cutoff: f32::NAN,
+            last_resonance: f32::NAN,
+            smooth_cutoff: Clickless::default(),
+            smooth_resonance: Clickless::default(),
+        }
+    }
+}
+
+/// Module-level state for the LowpassFilter (mono-input fast path).
 struct LowpassFilterState {
-    /// Per-channel state (audio-rate)
-    z1: [f32; PORT_MAX_CHANNELS],
-    z2: [f32; PORT_MAX_CHANNELS],
-    /// Cached coefficients (control-rate)
-    coeffs: [BiquadCoeffs; PORT_MAX_CHANNELS],
-    /// Last seen params (for change detection)
-    last_cutoff: [f32; PORT_MAX_CHANNELS],
-    last_resonance: [f32; PORT_MAX_CHANNELS],
-    /// Parameter smoothing to prevent clicks on sudden changes
-    smooth_cutoff: [Clickless; PORT_MAX_CHANNELS],
-    smooth_resonance: [Clickless; PORT_MAX_CHANNELS],
-    /// Mono optimization
     coeffs_mono: BiquadCoeffs,
     last_cutoff_mono: f32,
     last_resonance_mono: f32,
@@ -76,13 +94,6 @@ struct LowpassFilterState {
 impl Default for LowpassFilterState {
     fn default() -> Self {
         Self {
-            z1: [0.0; PORT_MAX_CHANNELS],
-            z2: [0.0; PORT_MAX_CHANNELS],
-            coeffs: [BiquadCoeffs::default(); PORT_MAX_CHANNELS],
-            last_cutoff: [f32::NAN; PORT_MAX_CHANNELS],
-            last_resonance: [f32::NAN; PORT_MAX_CHANNELS],
-            smooth_cutoff: [Clickless::default(); PORT_MAX_CHANNELS],
-            smooth_resonance: [Clickless::default(); PORT_MAX_CHANNELS],
             coeffs_mono: BiquadCoeffs::default(),
             last_cutoff_mono: f32::NAN,
             last_resonance_mono: f32::NAN,
@@ -130,7 +141,6 @@ fn compute_biquad(cutoff: f32, resonance: f32, sample_rate: f32) -> BiquadCoeffs
 impl LowpassFilter {
     fn update(&mut self, sample_rate: f32) {
         let channels = self.channel_count();
-        let state = &mut self.state;
 
         let cutoff_mono = self.params.cutoff.is_monophonic();
         let resonance_mono = self
@@ -141,6 +151,7 @@ impl LowpassFilter {
 
         // Update coefficients with smoothed params to prevent clicks
         if cutoff_mono && resonance_mono {
+            let state = &mut self.state;
             state
                 .smooth_cutoff_mono
                 .update(self.params.cutoff.get_value(0));
@@ -157,15 +168,17 @@ impl LowpassFilter {
             }
         } else {
             for i in 0..channels as usize {
-                state.smooth_cutoff[i].update(self.params.cutoff.get_value(i));
-                state.smooth_resonance[i].update(self.params.resonance.value_or(i, 0.0));
-                let c = *state.smooth_cutoff[i];
-                let r = *state.smooth_resonance[i];
+                let cs = &mut self.channel_state[i];
+                cs.smooth_cutoff.update(self.params.cutoff.get_value(i));
+                cs.smooth_resonance
+                    .update(self.params.resonance.value_or(i, 0.0));
+                let c = *cs.smooth_cutoff;
+                let r = *cs.smooth_resonance;
 
-                if changed(c, state.last_cutoff[i]) || changed(r, state.last_resonance[i]) {
-                    state.coeffs[i] = compute_biquad(c, r, sample_rate);
-                    state.last_cutoff[i] = c;
-                    state.last_resonance[i] = r;
+                if changed(c, cs.last_cutoff) || changed(r, cs.last_resonance) {
+                    cs.coeffs = compute_biquad(c, r, sample_rate);
+                    cs.last_cutoff = c;
+                    cs.last_resonance = r;
                 }
             }
         }
@@ -174,17 +187,17 @@ impl LowpassFilter {
             let input = self.params.input.get_value(i);
 
             let c = if cutoff_mono && resonance_mono {
-                state.coeffs_mono
+                self.state.coeffs_mono
             } else {
-                state.coeffs[i]
+                self.channel_state[i].coeffs
             };
 
-            let w = input - c.a1 * state.z1[i] - c.a2 * state.z2[i];
-            let w = sanitize(w);
-            let y = c.b0 * w + c.b1 * state.z1[i] + c.b2 * state.z2[i];
+            let cs = &mut self.channel_state[i];
+            let w = sanitize(input - c.a1 * cs.z1 - c.a2 * cs.z2);
+            let y = c.b0 * w + c.b1 * cs.z1 + c.b2 * cs.z2;
 
-            state.z2[i] = state.z1[i];
-            state.z1[i] = w;
+            cs.z2 = cs.z1;
+            cs.z1 = w;
             self.outputs.sample.set(i, y);
         }
     }

--- a/crates/modular_core/src/dsp/fx/cheby.rs
+++ b/crates/modular_core/src/dsp/fx/cheby.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 
 use crate::dsp::fx::enosc_tables::{aa_cheby, interpolate_cheby};
 use crate::dsp::utils::voct_to_hz;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::Clickless;
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -38,12 +38,6 @@ struct ChannelState {
     amount: Clickless,
 }
 
-/// State for the Cheby module.
-#[derive(Default)]
-struct ChebyState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Harmonic waveshaping effect that adds controlled overtone content.
 ///
 /// At low amounts the signal passes through cleanly; turning it up
@@ -52,7 +46,7 @@ struct ChebyState {
 #[module(name = "$cheby", args(input, amount))]
 pub struct Cheby {
     outputs: ChebyOutputs,
-    state: ChebyState,
+    channel_state: Box<[ChannelState]>,
     params: ChebyParams,
 }
 
@@ -62,7 +56,7 @@ impl Cheby {
         let freq_connected = !self.params.freq.is_disconnected();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
             let amount_raw = self.params.amount.get_value(ch);

--- a/crates/modular_core/src/dsp/fx/fold.rs
+++ b/crates/modular_core/src/dsp/fx/fold.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 
 use crate::dsp::fx::enosc_tables::{aa_fold, lookup_fold};
 use crate::dsp::utils::voct_to_hz;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::Clickless;
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -38,19 +38,13 @@ struct ChannelState {
     amount: Clickless,
 }
 
-/// State for the Fold module.
-#[derive(Default)]
-struct FoldState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Wavefolder that reflects the signal back when it exceeds a threshold,
 /// producing dense, harmonically rich tones. Higher amounts create more
 /// complex, metallic timbres.
 #[module(name = "$fold", args(input, amount))]
 pub struct Fold {
     outputs: FoldOutputs,
-    state: FoldState,
+    channel_state: Box<[ChannelState]>,
     params: FoldParams,
 }
 
@@ -60,7 +54,7 @@ impl Fold {
         let freq_connected = !self.params.freq.is_disconnected();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
             let amount_raw = self.params.amount.get_value(ch);

--- a/crates/modular_core/src/dsp/fx/overdrive.rs
+++ b/crates/modular_core/src/dsp/fx/overdrive.rs
@@ -11,7 +11,7 @@ use std::f32::consts::PI;
 
 use crate::dsp::utils::halfband::{Halfband2xDown, Halfband2xUp};
 use crate::dsp::utils::one_pole::OnePole;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::Clickless;
 
 /// Saturation algorithm.
@@ -70,7 +70,6 @@ struct ChannelState {
 
 #[derive(Default)]
 struct OverdriveState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
     tilt_coeff: f32,
     dc_block_coeff: f32,
 }
@@ -96,6 +95,7 @@ const TONE_RANGE: f32 = 3.0;
 pub struct Overdrive {
     outputs: OverdriveOutputs,
     state: OverdriveState,
+    channel_state: Box<[ChannelState]>,
     params: OverdriveParams,
 }
 
@@ -113,8 +113,11 @@ impl Overdrive {
         self.state.dc_block_coeff = (1.0 - (2.0 * PI * DC_BLOCK_FC_HZ / base_rate)).clamp(0.0, 1.0);
 
         // Tilt-EQ coefficient is constant for the module's lifetime, so seed
-        // every channel's filters once here instead of per sample.
-        for channel in self.state.channels.iter_mut() {
+        // every channel's filters once here instead of per sample. `init` runs
+        // after the macro sizes `channel_state` to the channel count and before
+        // the audio thread carries over runtime state, so a later channel-count
+        // grow keeps the freshly seeded surplus channels.
+        for channel in self.channel_state.iter_mut() {
             channel.tilt_pre.set_coeff(self.state.tilt_coeff);
             channel.tilt_post.set_coeff(self.state.tilt_coeff);
         }
@@ -126,7 +129,7 @@ impl Overdrive {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
             let drive_raw = self.params.drive.get_value(ch);
@@ -222,6 +225,7 @@ pub fn __bench_make_overdrive(params: OverdriveParams) -> Overdrive {
         _channel_count: 1,
         _block_index: Default::default(),
         state: OverdriveState::default(),
+        channel_state: vec![ChannelState::default(); 1].into_boxed_slice(),
     };
     od.init(48000.0);
     od
@@ -249,6 +253,7 @@ mod tests {
             _channel_count: 1,
             _block_index: Default::default(),
             state: OverdriveState::default(),
+            channel_state: vec![ChannelState::default(); 1].into_boxed_slice(),
         };
         od.init(48000.0);
         od

--- a/crates/modular_core/src/dsp/fx/segment.rs
+++ b/crates/modular_core/src/dsp/fx/segment.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 
 use crate::dsp::fx::enosc_tables::{aa_segment, interpolate_segment};
 use crate::dsp::utils::voct_to_hz;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::Clickless;
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -38,12 +38,6 @@ struct ChannelState {
     amount: Clickless,
 }
 
-/// State for the Segment module.
-#[derive(Default)]
-struct SegmentState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Waveshaper that morphs through 8 distinct tonal shapes as you sweep the
 /// amount control. Low settings pass the signal cleanly; mid settings compress
 /// and square it off; high settings introduce stepped, ripple-like overtone
@@ -51,7 +45,7 @@ struct SegmentState {
 #[module(name = "$segment", args(input, amount))]
 pub struct Segment {
     outputs: SegmentOutputs,
-    state: SegmentState,
+    channel_state: Box<[ChannelState]>,
     params: SegmentParams,
 }
 
@@ -61,7 +55,7 @@ impl Segment {
         let freq_connected = !self.params.freq.is_disconnected();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
             let amount_raw = self.params.amount.get_value(ch);

--- a/crates/modular_core/src/dsp/midi/midi_cv.rs
+++ b/crates/modular_core/src/dsp/midi/midi_cv.rs
@@ -11,10 +11,9 @@ use serde::Serialize;
 use crate::dsp::utils::{
     GATE_HIGH_VOLTAGE, GATE_LOW_VOLTAGE, TempGate, TempGateState, min_gate_samples,
 };
-use crate::patch::Patch;
 use crate::poly::{PORT_MAX_CHANNELS, PolyOutput};
 use crate::types::{
-    Connect, MidiChannelPressure, MidiControlChange, MidiNoteOff, MidiNoteOn, MidiPitchBend,
+    MidiChannelPressure, MidiControlChange, MidiNoteOff, MidiNoteOn, MidiPitchBend,
     MidiPolyPressure,
 };
 
@@ -75,7 +74,7 @@ struct MidiCvParams {
     #[deserr(default)]
     device: Option<String>,
 
-    /// Number of polyphonic voices (1-16)
+    /// Number of polyphonic voices (1-64)
     #[serde(default = "default_channels")]
     #[deserr(default = default_channels())]
     channels: usize,
@@ -132,7 +131,7 @@ struct MidiCvOutputs {
 }
 
 /// Converts MIDI note input into control voltages for driving synthesizer modules.
-/// Supports polyphonic voice allocation with up to 16 voices.
+/// Supports polyphonic voice allocation with up to 64 voices.
 ///
 /// ## Outputs
 ///
@@ -176,14 +175,21 @@ pub struct MidiCv {
     outputs: MidiCvOutputs,
     params: MidiCvParams,
     state: MidiCvState,
+    /// Per-voice state, one element per polyphonic channel.
+    channel_state: Box<[MidiCvChannel]>,
 }
 
-/// State for the MidiCv module.
+/// Per-voice state (one element per polyphonic channel).
+#[derive(Clone, Copy, Default)]
+struct MidiCvChannel {
+    voice: VoiceState,
+    /// Retrigger pulse gate (multi-sample duration via TempGate).
+    retrigger_gate: TempGate,
+}
+
+/// Module-level state for the MidiCv module.
 struct MidiCvState {
     sample_rate: f32,
-
-    /// Per-voice state
-    voices: [VoiceState; PORT_MAX_CHANNELS],
 
     /// Held notes (order preserved for priority modes)
     held_notes: Vec<(u8, u8, u8)>, // (note, velocity, midi_channel)
@@ -205,16 +211,12 @@ struct MidiCvState {
 
     /// Global aftertouch (for non-MPE mode)
     global_aftertouch: u8,
-
-    /// Retrigger pulse gates (multi-sample duration via TempGate)
-    retrigger_gates: [TempGate; PORT_MAX_CHANNELS],
 }
 
 impl Default for MidiCvState {
     fn default() -> Self {
         Self {
             sample_rate: 48000.0,
-            voices: [VoiceState::default(); PORT_MAX_CHANNELS],
             held_notes: Vec::with_capacity(128),
             rotate_index: 0,
             sustain: [false; 16],
@@ -222,7 +224,6 @@ impl Default for MidiCvState {
             global_pitch_wheel: 0,
             global_mod_wheel: 0,
             global_aftertouch: 0,
-            retrigger_gates: [TempGate::default(); PORT_MAX_CHANNELS],
         }
     }
 }
@@ -283,7 +284,8 @@ impl MidiCv {
             PolyMode::Reuse => {
                 // First, try to find a voice already playing this note
                 for i in 0..num_voices {
-                    if self.state.voices[i].gate && self.state.voices[i].note == note {
+                    if self.channel_state[i].voice.gate && self.channel_state[i].voice.note == note
+                    {
                         return i;
                     }
                 }
@@ -293,7 +295,7 @@ impl MidiCv {
             PolyMode::Reset => {
                 // Always scan from 0, use first free voice
                 for i in 0..num_voices {
-                    if !self.state.voices[i].gate {
+                    if !self.channel_state[i].voice.gate {
                         return i;
                     }
                 }
@@ -308,7 +310,7 @@ impl MidiCv {
         // Find next free voice starting from rotate_index
         for i in 0..num_voices {
             let idx = (self.state.rotate_index + i) % num_voices;
-            if !self.state.voices[idx].gate {
+            if !self.channel_state[idx].voice.gate {
                 self.state.rotate_index = (idx + 1) % num_voices;
                 return idx;
             }
@@ -323,7 +325,7 @@ impl MidiCv {
     fn find_voice_for_note(&self, note: u8) -> Option<usize> {
         let num_voices = self.params.channels.clamp(1, PORT_MAX_CHANNELS) as usize;
         for i in 0..num_voices {
-            if self.state.voices[i].gate && self.state.voices[i].note == note {
+            if self.channel_state[i].voice.gate && self.channel_state[i].voice.note == note {
                 return Some(i);
             }
         }
@@ -375,13 +377,13 @@ impl MidiCv {
         if num_voices == 1 {
             // Monophonic mode
             if let Some((mono_note, mono_vel)) = self.get_mono_note() {
-                let voice = &mut self.state.voices[0];
+                let voice = &mut self.channel_state[0].voice;
                 let should_retrigger = !voice.gate || voice.note != mono_note;
                 voice.note = mono_note;
                 voice.velocity = mono_vel;
                 voice.gate = true;
                 if should_retrigger {
-                    self.state.retrigger_gates[0].set_state(
+                    self.channel_state[0].retrigger_gate.set_state(
                         TempGateState::High,
                         TempGateState::Low,
                         min_gate_samples(self.state.sample_rate),
@@ -391,11 +393,11 @@ impl MidiCv {
         } else {
             // Polyphonic mode
             let voice_idx = self.allocate_voice(note, midi_channel);
-            let voice = &mut self.state.voices[voice_idx];
+            let voice = &mut self.channel_state[voice_idx].voice;
             voice.note = note;
             voice.velocity = velocity;
             voice.gate = true;
-            self.state.retrigger_gates[voice_idx].set_state(
+            self.channel_state[voice_idx].retrigger_gate.set_state(
                 TempGateState::High,
                 TempGateState::Low,
                 min_gate_samples(self.state.sample_rate),
@@ -441,23 +443,23 @@ impl MidiCv {
         if num_voices == 1 {
             // Monophonic: check if a different note should take over
             if let Some((mono_note, mono_vel)) = self.get_mono_note() {
-                let voice = &mut self.state.voices[0];
+                let voice = &mut self.channel_state[0].voice;
                 if voice.note != mono_note {
                     voice.note = mono_note;
                     voice.velocity = mono_vel;
-                    self.state.retrigger_gates[0].set_state(
+                    self.channel_state[0].retrigger_gate.set_state(
                         TempGateState::High,
                         TempGateState::Low,
                         min_gate_samples(self.state.sample_rate),
                     );
                 }
             } else {
-                self.state.voices[0].gate = false;
+                self.channel_state[0].voice.gate = false;
             }
         } else {
             // Polyphonic: release the specific voice
             if let Some(voice_idx) = self.find_voice_for_note(note) {
-                self.state.voices[voice_idx].gate = false;
+                self.channel_state[voice_idx].voice.gate = false;
             }
         }
 
@@ -478,7 +480,7 @@ impl MidiCv {
                 if self.params.poly_mode == PolyMode::Mpe && msg.channel > 0 {
                     let voice_idx = ((msg.channel - 1) as usize)
                         .min(self.params.channels.saturating_sub(1) as usize);
-                    self.state.voices[voice_idx].mod_wheel = msg.value;
+                    self.channel_state[voice_idx].voice.mod_wheel = msg.value;
                 } else {
                     self.state.global_mod_wheel = msg.value;
                 }
@@ -508,7 +510,7 @@ impl MidiCv {
                         // Release voices for these notes
                         for note in notes_to_release {
                             if let Some(voice_idx) = self.find_voice_for_note(note) {
-                                self.state.voices[voice_idx].gate = false;
+                                self.channel_state[voice_idx].voice.gate = false;
                             }
                         }
                     }
@@ -532,7 +534,7 @@ impl MidiCv {
             // MPE: per-voice pitch bend
             let voice_idx =
                 ((msg.channel - 1) as usize).min(self.params.channels.saturating_sub(1) as usize);
-            self.state.voices[voice_idx].pitch_wheel = msg.value;
+            self.channel_state[voice_idx].voice.pitch_wheel = msg.value;
         } else {
             // Standard: global pitch bend
             self.state.global_pitch_wheel = msg.value;
@@ -552,7 +554,7 @@ impl MidiCv {
         if self.params.poly_mode == PolyMode::Mpe && msg.channel > 0 {
             let voice_idx =
                 ((msg.channel - 1) as usize).min(self.params.channels.saturating_sub(1) as usize);
-            self.state.voices[voice_idx].aftertouch = msg.pressure;
+            self.channel_state[voice_idx].voice.aftertouch = msg.pressure;
         } else {
             self.state.global_aftertouch = msg.pressure;
         }
@@ -570,7 +572,7 @@ impl MidiCv {
 
         // Find voice playing this note and update its aftertouch
         if let Some(voice_idx) = self.find_voice_for_note(msg.note) {
-            self.state.voices[voice_idx].aftertouch = msg.pressure;
+            self.channel_state[voice_idx].voice.aftertouch = msg.pressure;
         }
 
         Ok(())
@@ -585,9 +587,13 @@ impl MidiCv {
         self.state.global_mod_wheel = 0;
         self.state.global_aftertouch = 0;
 
-        for i in 0..PORT_MAX_CHANNELS {
-            self.state.voices[i] = VoiceState::default();
-            self.state.retrigger_gates[i].set_state(TempGateState::Low, TempGateState::Low, 0);
+        for i in 0..self.channel_state.len() {
+            self.channel_state[i].voice = VoiceState::default();
+            self.channel_state[i].retrigger_gate.set_state(
+                TempGateState::Low,
+                TempGateState::Low,
+                0,
+            );
         }
 
         for i in 0..16 {
@@ -604,7 +610,7 @@ impl MidiCv {
 
         // Update outputs for each voice
         for i in 0..num_voices as usize {
-            let voice = &self.state.voices[i];
+            let voice = &self.channel_state[i].voice;
 
             // Pitch CV
             let pitch_cv = Self::note_to_cv(voice.note);
@@ -643,7 +649,7 @@ impl MidiCv {
             // Retrigger pulse
             self.outputs
                 .retrigger
-                .set(i, self.state.retrigger_gates[i].process());
+                .set(i, self.channel_state[i].retrigger_gate.process());
 
             // Pitch wheel (raw, unscaled, -5V to +5V)
             let pw = if self.params.poly_mode == PolyMode::Mpe {

--- a/crates/modular_core/src/dsp/oscillators/mod.rs
+++ b/crates/modular_core/src/dsp/oscillators/mod.rs
@@ -6,8 +6,7 @@ use serde::Serialize;
 
 use crate::dsp::utils::voct_to_hz;
 use crate::params::ParamsDeserializer;
-use crate::patch::Patch;
-use crate::types::{Connect, Module, ModuleSchema, SampleableConstructor};
+use crate::types::{Module, ModuleSchema, SampleableConstructor};
 
 /// FM synthesis mode for oscillators.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserr, Serialize, JsonSchema, Connect)]

--- a/crates/modular_core/src/dsp/oscillators/p_pulse.rs
+++ b/crates/modular_core/src/dsp/oscillators/p_pulse.rs
@@ -1,6 +1,6 @@
 use crate::{
     dsp::utils::wrap,
-    poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
+    poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
 };
 use deserr::Deserr;
@@ -37,12 +37,6 @@ struct ChannelState {
     prev_phase: f32,
 }
 
-/// State for the PPulseOscillator module.
-#[derive(Default)]
-struct PPulseOscillatorState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Phase-driven pulse/square oscillator with pulse width modulation.
 ///
 /// Instead of a frequency input, this oscillator is driven by an external
@@ -57,7 +51,7 @@ struct PPulseOscillatorState {
 #[module(name = "$pPulse", args(phase))]
 pub struct PPulseOscillator {
     outputs: PPulseOscillatorOutputs,
-    state: PPulseOscillatorState,
+    channel_state: Box<[ChannelState]>,
     params: PPulseOscillatorParams,
 }
 
@@ -66,7 +60,7 @@ impl PPulseOscillator {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let base_width = self.params.width.value_or(ch, 2.5);
             let pwm = self.params.pwm.value_or(ch, 0.0);

--- a/crates/modular_core/src/dsp/oscillators/p_saw.rs
+++ b/crates/modular_core/src/dsp/oscillators/p_saw.rs
@@ -1,6 +1,6 @@
 use crate::{
     dsp::utils::wrap,
-    poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
+    poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
 };
 use deserr::Deserr;
@@ -34,12 +34,6 @@ struct ChannelState {
     prev_phase: f32,
 }
 
-/// State for the PSawOscillator module.
-#[derive(Default)]
-struct PSawOscillatorState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Phase-driven variable-symmetry triangle oscillator.
 ///
 /// Instead of a frequency input, this oscillator is driven by an external
@@ -56,7 +50,7 @@ struct PSawOscillatorState {
 #[module(name = "$pSaw", args(phase))]
 pub struct PSawOscillator {
     outputs: PSawOscillatorOutputs,
-    state: PSawOscillatorState,
+    channel_state: Box<[ChannelState]>,
     params: PSawOscillatorParams,
 }
 
@@ -65,7 +59,7 @@ impl PSawOscillator {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             // Update shape with smoothing - clamp to valid range
             let shape_val = self.params.shape.value_or(ch, 0.0).clamp(0.0, 5.0);

--- a/crates/modular_core/src/dsp/oscillators/plaits.rs
+++ b/crates/modular_core/src/dsp/oscillators/plaits.rs
@@ -15,9 +15,8 @@ use schemars::JsonSchema;
 
 use crate::{
     dsp::utils::{SchmittTrigger, voct_to_midi},
-    patch::Patch as ModularPatch,
-    poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
-    types::{Clickless, Connect},
+    poly::{PolyOutput, PolySignal, PolySignalExt},
+    types::Clickless,
 };
 
 /// Block size for rendering - matches VCV Rack's implementation
@@ -266,11 +265,12 @@ pub struct Plaits {
     outputs: PlaitsOutputs,
     params: PlaitsParams,
     state: PlaitsState,
+    /// One heavy Plaits voice per active channel; built in `init`.
+    channel_state: Box<[PlaitsChannelState]>,
 }
 
-/// State for the Plaits module.
+/// Module-level state for the Plaits module.
 struct PlaitsState {
-    channels: Vec<PlaitsChannelState>,
     buffer_pos: usize,
     sample_rate: f32,
 }
@@ -278,7 +278,6 @@ struct PlaitsState {
 impl Default for PlaitsState {
     fn default() -> Self {
         Self {
-            channels: Vec::new(),   // Will be initialized in init()
             buffer_pos: BLOCK_SIZE, // Start exhausted to trigger initial render
             sample_rate: 0.0,
         }
@@ -290,15 +289,18 @@ impl Plaits {
     /// Called once at construction time by the macro-generated constructor.
     fn init(&mut self, sample_rate: f32) {
         self.state.sample_rate = sample_rate;
-        self.state.channels = Vec::with_capacity(PORT_MAX_CHANNELS);
-        for _ in 0..PORT_MAX_CHANNELS {
-            let mut voice = Voice::new(BLOCK_SIZE, sample_rate);
-            voice.init();
-            self.state.channels.push(PlaitsChannelState {
-                voice,
-                ..PlaitsChannelState::default()
-            });
-        }
+        let num_channels = self.channel_count().max(1);
+        self.channel_state = (0..num_channels)
+            .map(|_| {
+                let mut voice = Voice::new(BLOCK_SIZE, sample_rate);
+                voice.init();
+                PlaitsChannelState {
+                    voice,
+                    ..PlaitsChannelState::default()
+                }
+            })
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
     }
 
     fn update(&mut self, _sample_rate: f32) {
@@ -310,7 +312,7 @@ impl Plaits {
         // Triggers can be as short as 1 sample, so we need to detect rising edges
         // and latch them until the next block render.
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
             let trigger_val = self.params.trigger.value_or(ch, 0.0);
 
             // Detect rising edge using Schmitt trigger for noise immunity
@@ -327,7 +329,7 @@ impl Plaits {
         }
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
             // Output scaling: Plaits outputs ±1.0, scale to ±5V (inverted to match hardware)
             let main = -state.main_buffer[self.state.buffer_pos] * 5.0;
             let aux = -state.aux_buffer[self.state.buffer_pos] * 5.0;
@@ -351,7 +353,7 @@ impl Plaits {
 
     fn render_block(&mut self, num_channels: usize) {
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             // Update smoothed parameters
             state

--- a/crates/modular_core/src/dsp/oscillators/pulse.rs
+++ b/crates/modular_core/src/dsp/oscillators/pulse.rs
@@ -2,7 +2,6 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::{
-    PORT_MAX_CHANNELS,
     dsp::oscillators::{FmMode, apply_fm},
     poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
@@ -45,12 +44,6 @@ struct PulseChannelState {
     width: Clickless,
 }
 
-/// State for the PulseOscillator module.
-#[derive(Default)]
-struct PulseOscillatorState {
-    channels: [PulseChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Pulse/square wave oscillator with pulse width modulation.
 ///
 /// The `freq` input follows the **V/Oct** standard (0V = C4).
@@ -68,7 +61,7 @@ struct PulseOscillatorState {
 #[module(name = "$pulse", args(freq))]
 pub struct PulseOscillator {
     outputs: PulseOscillatorOutputs,
-    state: PulseOscillatorState,
+    channel_state: Box<[PulseChannelState]>,
     params: PulseOscillatorParams,
 }
 
@@ -77,7 +70,7 @@ impl PulseOscillator {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let base_width = self.params.width.value_or(ch, 2.5);
             let pwm = self.params.pwm.value_or(ch, 0.0);

--- a/crates/modular_core/src/dsp/oscillators/saw.rs
+++ b/crates/modular_core/src/dsp/oscillators/saw.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 
 use crate::{
     dsp::oscillators::{FmMode, apply_fm},
-    poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
+    poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
 };
 
@@ -42,12 +42,6 @@ struct ChannelState {
     shape: Clickless,
 }
 
-/// State for the SawOscillator module.
-#[derive(Default)]
-struct SawOscillatorState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// A variable-symmetry triangle oscillator that morphs between saw, triangle, and ramp.
 ///
 /// The `shape` parameter shifts the peak position of a triangle wave,
@@ -67,7 +61,7 @@ struct SawOscillatorState {
 #[module(name = "$saw", args(freq))]
 pub struct SawOscillator {
     outputs: SawOscillatorOutputs,
-    state: SawOscillatorState,
+    channel_state: Box<[ChannelState]>,
     params: SawOscillatorParams,
 }
 
@@ -79,7 +73,7 @@ impl SawOscillator {
         let inv_sample_rate = 1.0 / sample_rate;
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             // Update shape with smoothing - clamp to valid range
             let shape_val = self.params.shape.value_or(ch, 0.0).clamp(0.0, 5.0);

--- a/crates/modular_core/src/dsp/oscillators/sine.rs
+++ b/crates/modular_core/src/dsp/oscillators/sine.rs
@@ -4,7 +4,7 @@ use crate::{
         oscillators::{FmMode, apply_fm},
         utils::interpolate,
     },
-    poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
+    poly::{PolyOutput, PolySignal, PolySignalExt},
 };
 use deserr::Deserr;
 use schemars::JsonSchema;
@@ -39,12 +39,6 @@ struct ChannelState {
     phase: f32,
 }
 
-/// State for the SineOscillator module.
-#[derive(Default)]
-struct SineOscillatorState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// A sine wave oscillator.
 ///
 /// ## Example
@@ -55,7 +49,7 @@ struct SineOscillatorState {
 #[module(name = "$sine", args(freq))]
 pub struct SineOscillator {
     outputs: SineOscillatorOutputs,
-    state: SineOscillatorState,
+    channel_state: Box<[ChannelState]>,
     params: SineOscillatorParams,
 }
 
@@ -64,7 +58,7 @@ impl SineOscillator {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let pitch = self.params.freq.get_value(ch);
             let fm = self.params.fm.value_or(ch, 0.0);

--- a/crates/modular_core/src/dsp/oscillators/supersaw.rs
+++ b/crates/modular_core/src/dsp/oscillators/supersaw.rs
@@ -17,7 +17,7 @@ fn default_voices() -> usize {
 struct SupersawParams {
     /// pitch in V/Oct (0V = C4)
     freq: PolySignal,
-    /// number of supersaw voices (1–16)
+    /// number of supersaw voices (1–64)
     #[serde(default = "default_voices")]
     #[deserr(default = default_voices())]
     voices: usize,
@@ -54,7 +54,7 @@ pub fn supersaw_derive_channel_count(params: &SupersawParams) -> usize {
 /// creating a rich, full sound.
 ///
 /// - **freq** — pitch in V/Oct (0V = C4)
-/// - **voices** — number of detuned saw voices (1–16, default 5)
+/// - **voices** — number of detuned saw voices (1–64, default 5)
 /// - **detune** — detune spread in semitones (default 0.18)
 ///
 /// Output range is **±5V** with gain compensation for input channel count.
@@ -70,12 +70,14 @@ pub struct Supersaw {
     outputs: SupersawOutputs,
     params: SupersawParams,
     state: SupersawState,
+    /// Phase state for matrix mixing: a `PORT_MAX_CHANNELS * voices` matrix
+    /// indexed as `[input_ch * voices + voice]` (row stride = voice count).
+    /// Allocated in `init` to the active voice count rather than the fixed max.
+    channel_state: Box<[f32]>,
 }
 
-/// State for the Supersaw module.
+/// Module-level state for the Supersaw module.
 struct SupersawState {
-    /// Phase state for matrix mixing: indexed as [input_ch * PORT_MAX_CHANNELS + voice]
-    osc_states: [f32; PORT_MAX_CHANNELS * PORT_MAX_CHANNELS],
     rng_state: u32,
     /// Voice count clamped to [1, PORT_MAX_CHANNELS]. Derived from params.
     voices: usize,
@@ -89,10 +91,12 @@ struct SupersawState {
     voice_t: [f32; PORT_MAX_CHANNELS],
 }
 
+// Hand-written `Default`: `voice_t` is `[f32; PORT_MAX_CHANNELS]` and the
+// standard library only derives `Default` for arrays up to length 32, so a
+// 64-wide array needs an explicit array-repeat initializer.
 impl Default for SupersawState {
     fn default() -> Self {
         Self {
-            osc_states: [0.0; PORT_MAX_CHANNELS * PORT_MAX_CHANNELS],
             rng_state: 0,
             voices: 1,
             input_channels: 1,
@@ -147,8 +151,13 @@ impl Supersaw {
         // patch updates by transfer_state_from, so it must not be re-seeded in
         // configure().
         self.state.rng_state = self as *const Self as usize as u32;
-        for i in 0..self.state.osc_states.len() {
-            self.state.osc_states[i] = rand_phase(&mut self.state.rng_state);
+        // `voices` rows of state per input channel. Input channels are bounded
+        // by PORT_MAX_CHANNELS, so allocating that many rows keeps the matrix
+        // valid for any input width while shrinking the voice dimension.
+        let voices = self.channel_count().max(1);
+        self.channel_state = vec![0.0; PORT_MAX_CHANNELS * voices].into_boxed_slice();
+        for i in 0..self.channel_state.len() {
+            self.channel_state[i] = rand_phase(&mut self.state.rng_state);
         }
     }
 
@@ -208,8 +217,8 @@ impl Supersaw {
                 let freq = base_freq * (2.0f32).powf(offset_semitones / 12.0);
                 let dt = freq * inv_sample_rate;
 
-                let state_idx = input_ch * PORT_MAX_CHANNELS + voice;
-                let phase = &mut self.state.osc_states[state_idx];
+                let state_idx = input_ch * voices + voice;
+                let phase = &mut self.channel_state[state_idx];
 
                 // Advance phase (rem_euclid supports negative increments from through-zero FM)
                 *phase += dt;
@@ -257,7 +266,11 @@ mod tests {
             _channel_count: channels,
             _block_index: Default::default(),
             state: SupersawState::default(),
+            channel_state: Box::default(),
         };
+        // Mirror the production lifecycle: init() allocates and seeds the phase
+        // matrix; on_patch_update() computes the param-derived constants that
+        // update() reads from state.
         s.init(48000.0);
         s.on_patch_update();
         s
@@ -315,15 +328,15 @@ mod tests {
     }
 
     #[test]
-    fn test_voices_clamped_to_16() {
+    fn test_voices_clamped_to_max() {
         let params = SupersawParams {
             freq: PolySignal::mono(Signal::Volts(0.0)),
-            voices: 32,
+            voices: 100,
             detune: None,
             fm: None,
             fm_mode: FmMode::default(),
         };
-        assert_eq!(supersaw_derive_channel_count(&params), 16);
+        assert_eq!(supersaw_derive_channel_count(&params), PORT_MAX_CHANNELS);
 
         let params_zero = SupersawParams {
             freq: PolySignal::mono(Signal::Volts(0.0)),
@@ -346,8 +359,8 @@ mod tests {
             fm_mode: FmMode::default(),
         });
         // Force known phases (overwrite whatever init set)
-        for i in 0..PORT_MAX_CHANNELS * PORT_MAX_CHANNELS {
-            s_no_detune.state.osc_states[i] = 0.25;
+        for i in 0..s_no_detune.channel_state.len() {
+            s_no_detune.channel_state[i] = 0.25;
         }
 
         let mut s_detune = make_supersaw(SupersawParams {
@@ -357,8 +370,8 @@ mod tests {
             fm: None,
             fm_mode: FmMode::default(),
         });
-        for i in 0..PORT_MAX_CHANNELS * PORT_MAX_CHANNELS {
-            s_detune.state.osc_states[i] = 0.25;
+        for i in 0..s_detune.channel_state.len() {
+            s_detune.channel_state[i] = 0.25;
         }
 
         // Run both for several samples
@@ -398,7 +411,7 @@ mod tests {
 
         // Check that at least some initial phases differ
         // (statistically extremely unlikely all 4 are identical)
-        let phases: Vec<f32> = (0..4).map(|v| s.state.osc_states[v]).collect();
+        let phases: Vec<f32> = (0..4).map(|v| s.channel_state[v]).collect();
         let all_same = phases.windows(2).all(|w| (w[0] - w[1]).abs() < 1e-10);
         assert!(!all_same, "Random phases should not all be identical");
     }
@@ -414,8 +427,8 @@ mod tests {
             fm_mode: FmMode::default(),
         });
         // Force known phases, zero detune -> all voices should produce identical output
-        for i in 0..PORT_MAX_CHANNELS * PORT_MAX_CHANNELS {
-            s.state.osc_states[i] = 0.5;
+        for i in 0..s.channel_state.len() {
+            s.channel_state[i] = 0.5;
         }
         s.update(48000.0);
 
@@ -446,7 +459,7 @@ mod tests {
             fm_mode: FmMode::default(),
         });
         // Set phase to 0.75 -> naive saw = 2*0.75 - 1 = 0.5
-        s1.state.osc_states[0] = 0.75;
+        s1.channel_state[0] = 0.75;
         s1.update(48000.0);
         let val_mono = s1.outputs.sample.get(0);
 
@@ -463,9 +476,10 @@ mod tests {
             fm: None,
             fm_mode: FmMode::default(),
         });
-        // Set all 4 input channel phases identically
+        // Set all 4 input channel phases identically. Row stride is the voice
+        // count (1 here), so channel `input_ch`'s single voice is at `input_ch`.
         for input_ch in 0..4 {
-            s4.state.osc_states[input_ch * PORT_MAX_CHANNELS] = 0.75;
+            s4.channel_state[input_ch] = 0.75;
         }
         s4.update(48000.0);
         let val_quad = s4.outputs.sample.get(0);

--- a/crates/modular_core/src/dsp/oscillators/wavetable.rs
+++ b/crates/modular_core/src/dsp/oscillators/wavetable.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use crate::{
     dsp::oscillators::{FmMode, apply_fm, wavetable_prep::PreparedWavetable},
     poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
-    types::{Connect, Table, Wav, WavData},
+    types::{Table, Wav, WavData},
 };
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -76,11 +76,6 @@ impl Default for ChannelState {
     }
 }
 
-#[derive(Default)]
-struct WavetableOscState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Derive the channel count from the maximum of `pitch` and (optional)
 /// `position`. Clamped to `[1, PORT_MAX_CHANNELS]`.
 #[allow(private_interfaces)]
@@ -114,12 +109,12 @@ pub fn wavetable_derive_channel_count(params: &WavetableOscParams) -> usize {
     name = "$wavetable",
     channels_derive = wavetable_derive_channel_count,
     args(wav, pitch, position),
-    has_prepare_resources
+    has_prepare_resources,
 )]
 pub struct WavetableOsc {
     params: WavetableOscParams,
     outputs: WavetableOscOutputs,
-    state: WavetableOscState,
+    channel_state: Box<[ChannelState]>,
 }
 
 impl WavetableOsc {
@@ -148,7 +143,7 @@ impl WavetableOsc {
         };
 
         for ch in 0..channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let pitch_v = self.params.pitch.get_value(ch);
             let fm = self.params.fm.value_or(ch, 0.0);
@@ -240,13 +235,14 @@ mod tests {
         let channels = wavetable_derive_channel_count(&params);
         let mut outputs = WavetableOscOutputs::default();
         outputs.set_all_channels(channels);
-        WavetableOsc {
+        let osc = WavetableOsc {
             params,
             outputs,
-            state: WavetableOscState::default(),
+            channel_state: vec![ChannelState::default(); channels].into_boxed_slice(),
             _channel_count: channels,
             _block_index: Default::default(),
-        }
+        };
+        osc
     }
 
     fn base_params() -> WavetableOscParams {

--- a/crates/modular_core/src/dsp/phase/crush.rs
+++ b/crates/modular_core/src/dsp/phase/crush.rs
@@ -6,7 +6,7 @@
 use deserr::Deserr;
 use schemars::JsonSchema;
 
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::Clickless;
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -34,12 +34,6 @@ struct ChannelState {
     amount: Clickless,
 }
 
-/// State for the Crush module.
-#[derive(Default)]
-struct CrushState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Phase effect: digital bit-crush distortion.
 ///
 /// Transforms a 0–1 phase signal by quantizing it into coarse steps,
@@ -57,7 +51,7 @@ struct CrushState {
 #[module(name = "$crush", args(input, amount))]
 pub struct Crush {
     outputs: CrushOutputs,
-    state: CrushState,
+    channel_state: Box<[ChannelState]>,
     params: CrushParams,
 }
 
@@ -66,7 +60,7 @@ impl Crush {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
             let amount_raw = self.params.amount.value_or(ch, 0.0);

--- a/crates/modular_core/src/dsp/phase/feedback.rs
+++ b/crates/modular_core/src/dsp/phase/feedback.rs
@@ -10,7 +10,7 @@ use schemars::JsonSchema;
 
 use crate::dsp::fx::enosc_tables::aa_feedback;
 use crate::dsp::utils::{sanitize, voct_to_hz};
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::Clickless;
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -43,12 +43,6 @@ struct ChannelState {
     lp_state: f32, // One-pole LP filter state (matches IOnePoleLp<s1_15, 2>)
 }
 
-/// State for the Feedback module.
-#[derive(Default)]
-struct FeedbackState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Phase effect: FM feedback distortion.
 ///
 /// Transforms a 0–1 phase signal by feeding the output back into itself,
@@ -66,7 +60,7 @@ struct FeedbackState {
 #[module(name = "$feedback", args(input, amount))]
 pub struct Feedback {
     outputs: FeedbackOutputs,
-    state: FeedbackState,
+    channel_state: Box<[ChannelState]>,
     params: FeedbackParams,
 }
 
@@ -76,7 +70,7 @@ impl Feedback {
         let freq_connected = !self.params.freq.is_disconnected();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
             let amount_raw = self.params.amount.value_or(ch, 0.0);

--- a/crates/modular_core/src/dsp/phase/pulsar.rs
+++ b/crates/modular_core/src/dsp/phase/pulsar.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 
 use crate::dsp::fx::enosc_tables::aa_pulsar;
 use crate::dsp::utils::voct_to_hz;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::Clickless;
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -40,12 +40,6 @@ struct ChannelState {
     amount: Clickless,
 }
 
-/// State for the Pulsar module.
-#[derive(Default)]
-struct PulsarState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Phase effect: pulsar synthesis distortion.
 ///
 /// Transforms a 0–1 phase signal by compressing the active portion of each
@@ -64,7 +58,7 @@ struct PulsarState {
 #[module(name = "$pulsar", args(input, amount))]
 pub struct Pulsar {
     outputs: PulsarOutputs,
-    state: PulsarState,
+    channel_state: Box<[ChannelState]>,
     params: PulsarParams,
 }
 
@@ -74,7 +68,7 @@ impl Pulsar {
         let freq_connected = self.params.freq.is_some();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let input = self.params.input.get_value(ch);
             let amount_raw = self.params.amount.value_or(ch, 0.0);

--- a/crates/modular_core/src/dsp/phase/ramp.rs
+++ b/crates/modular_core/src/dsp/phase/ramp.rs
@@ -6,7 +6,7 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::dsp::utils::voct_to_hz;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal};
+use crate::poly::{PolyOutput, PolySignal};
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
 #[serde(rename_all = "camelCase")]
@@ -30,12 +30,6 @@ struct ChannelState {
     phase: f32,
 }
 
-/// State for the Ramp module.
-#[derive(Default)]
-struct RampState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Phase ramp generator.
 ///
 /// Produces a rising sawtooth phase signal from 0 to 1 at the given frequency.
@@ -45,7 +39,7 @@ struct RampState {
 #[module(name = "$ramp", args(freq))]
 pub struct Ramp {
     outputs: RampOutputs,
-    state: RampState,
+    channel_state: Box<[ChannelState]>,
     params: RampParams,
 }
 
@@ -55,7 +49,7 @@ impl Ramp {
         let inv_sample_rate = 1.0 / sample_rate;
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let frequency = voct_to_hz(self.params.freq.get_value(ch));
             let phase_increment = frequency * inv_sample_rate;

--- a/crates/modular_core/src/dsp/seq/seq.rs
+++ b/crates/modular_core/src/dsp/seq/seq.rs
@@ -121,7 +121,7 @@ pub struct SeqParams {
     #[signal(range = (0.0, 1.0))]
     #[deserr(default)]
     playhead: Option<MonoSignal>,
-    /// Number of polyphonic voices (1-16)
+    /// Number of polyphonic voices (1-64)
     #[deserr(default)]
     pub channels: Option<usize>,
     /// loop window [offset, length] in cycles (fractional allowed)
@@ -351,15 +351,24 @@ pub struct Seq {
     outputs: SeqOutputs,
     params: SeqParams,
     state: SeqState,
+    /// Per-channel voice state, one element per polyphonic channel. Sized to the
+    /// derived channel count by the `#[module]` macro and carried across patch
+    /// updates by the macro's per-element state transfer.
+    channel_state: Box<[SeqChannel]>,
 }
 
-/// State for the Seq module.
+/// Per-channel sequencer state.
+#[derive(Default)]
+struct SeqChannel {
+    /// Per-voice playback state.
+    voice: VoiceState,
+    /// Last CV voltage — holds through rest periods and state transfers. Also
+    /// the "value the voice held before", used for nearest-value allocation.
+    last_cv: f32,
+}
+
+/// Module-level state for the Seq module.
 struct SeqState {
-    /// Per-voice state array
-    voices: [VoiceState; PORT_MAX_CHANNELS],
-    /// Last CV voltage per channel — holds through rest periods and state transfers.
-    /// Also the "value the voice held before", used for nearest-value allocation.
-    last_cv: [f32; PORT_MAX_CHANNELS],
     /// Previous frame's folded playhead position, for window-membership edge
     /// detection: a hap fires only when the playhead *enters* its window (an
     /// outside→inside transition), never because it is merely inside it.
@@ -380,8 +389,6 @@ struct SeqState {
 impl Default for SeqState {
     fn default() -> Self {
         Self {
-            voices: std::array::from_fn(|_| VoiceState::default()),
-            last_cv: [0.0; PORT_MAX_CHANNELS],
             prev_logical: 0.0,
             started: false,
             voices_to_release: ArrayVec::new(),
@@ -471,16 +478,17 @@ impl Seq {
         // frees), because `logical` wraps at the ribbon seam.
         self.state.voices_to_release.clear();
         for i in 0..num_channels {
-            if let Some(cached) = self.state.voices[i].cached_hap {
+            if let Some(cached) = self.channel_state[i].voice.cached_hap {
                 if !cached.contains(raw) {
                     self.state.voices_to_release.push(i);
                 }
             }
         }
         for i in self.state.voices_to_release.iter().copied() {
-            self.state.voices[i].active = false;
-            self.state.voices[i].cached_hap = None;
-            self.state.voices[i]
+            self.channel_state[i].voice.active = false;
+            self.channel_state[i].voice.cached_hap = None;
+            self.channel_state[i]
+                .voice
                 .gate
                 .set_state(TempGateState::Low, TempGateState::Low, 0);
         }
@@ -490,10 +498,10 @@ impl Seq {
                 self.outputs.cv.set(ch, 0.0);
                 self.outputs
                     .gate
-                    .set(ch, self.state.voices[ch].gate.process());
+                    .set(ch, self.channel_state[ch].voice.gate.process());
                 self.outputs
                     .trig
-                    .set(ch, self.state.voices[ch].trigger.process());
+                    .set(ch, self.channel_state[ch].voice.trigger.process());
             }
             return;
         }
@@ -501,11 +509,7 @@ impl Seq {
         // Collect new onsets for this frame, then dispatch to voices in a
         // separate pass so we don't hold a borrow of cycle storage while
         // mutating voice state.
-        let SeqState {
-            voices,
-            events_to_process,
-            ..
-        } = &mut self.state;
+        let events_to_process = &mut self.state.events_to_process;
         events_to_process.clear();
         let storage_opt = self.params.pattern.cached_haps().get(storage_index);
         if let Some(storage) = storage_opt {
@@ -526,7 +530,8 @@ impl Seq {
                 }
                 let hap_index = hap_index as u32;
                 let already_assigned = (0..num_channels).any(|i| {
-                    voices[i]
+                    self.channel_state[i]
+                        .voice
                         .cached_hap
                         .map(|existing| {
                             existing.hap_index == hap_index
@@ -562,18 +567,23 @@ impl Seq {
             // Tier 1: free voices.
             let mut free: ArrayVec<usize, PORT_MAX_CHANNELS> = ArrayVec::new();
             for i in 0..num_channels {
-                if !self.state.voices[i].active {
+                if !self.channel_state[i].voice.active {
                     free.push(i);
                 }
             }
             {
                 let SeqState {
                     events_to_process,
-                    last_cv,
                     assign,
                     ..
                 } = &mut self.state;
-                assign_nearest(events_to_process, &mut assigned, &free, last_cv, assign);
+                assign_nearest(
+                    events_to_process,
+                    &mut assigned,
+                    &free,
+                    &self.channel_state,
+                    assign,
+                );
             }
 
             // Tier 2: steal orphaned voices, computed lazily only when onsets
@@ -581,8 +591,8 @@ impl Seq {
             if (0..n).any(|ei| assigned[ei].is_none()) {
                 let mut orphans: ArrayVec<usize, PORT_MAX_CHANNELS> = ArrayVec::new();
                 for i in 0..num_channels {
-                    if self.state.voices[i].active
-                        && let Some(cached) = self.state.voices[i].cached_hap
+                    if self.channel_state[i].voice.active
+                        && let Some(cached) = self.channel_state[i].voice.cached_hap
                         && self.voice_is_orphan(&cached)
                     {
                         orphans.push(i);
@@ -590,11 +600,16 @@ impl Seq {
                 }
                 let SeqState {
                     events_to_process,
-                    last_cv,
                     assign,
                     ..
                 } = &mut self.state;
-                assign_nearest(events_to_process, &mut assigned, &orphans, last_cv, assign);
+                assign_nearest(
+                    events_to_process,
+                    &mut assigned,
+                    &orphans,
+                    &self.channel_state,
+                    assign,
+                );
             }
 
             // Apply the chosen voice for each placed onset. Map the note's logical
@@ -606,7 +621,7 @@ impl Seq {
                     continue;
                 };
                 let event = self.state.events_to_process[ei];
-                let voice = &mut self.state.voices[voice_idx];
+                let voice = &mut self.channel_state[voice_idx].voice;
                 voice.cached_hap = Some(CachedHap {
                     hap_index: event.hap_index,
                     cached_cycle: current_cycle,
@@ -626,17 +641,16 @@ impl Seq {
             }
         }
 
-        let state = &mut self.state;
         for ch in 0..num_channels {
-            let voice = &mut state.voices[ch];
-            if let Some(cached) = voice.cached_hap
+            let channel = &mut self.channel_state[ch];
+            if let Some(cached) = channel.voice.cached_hap
                 && let Some(cv) = cached.get_cv()
             {
-                state.last_cv[ch] = cv as f32;
+                channel.last_cv = cv as f32;
             }
-            self.outputs.cv.set(ch, state.last_cv[ch]);
-            self.outputs.gate.set(ch, voice.gate.process());
-            self.outputs.trig.set(ch, voice.trigger.process());
+            self.outputs.cv.set(ch, channel.last_cv);
+            self.outputs.gate.set(ch, channel.voice.gate.process());
+            self.outputs.trig.set(ch, channel.voice.trigger.process());
         }
     }
 }
@@ -688,12 +702,13 @@ impl Default for AssignScratch {
 /// Onsets already placed (by an earlier tier) are skipped, so this is called
 /// once per tier (free voices, then orphaned voices). Allocation-free: fixed
 /// `[_; PORT_MAX_CHANNELS]` stacks, an in-place `sort_unstable`, and the boxed
-/// `scratch` decision table.
+/// `scratch` decision table. Each candidate's previously-held value is read
+/// from `channel_state[voice].last_cv`.
 fn assign_nearest(
     events: &[PendingEvent],
     assigned: &mut [Option<usize>; PORT_MAX_CHANNELS],
     candidates: &[usize],
-    last_cv: &[f32; PORT_MAX_CHANNELS],
+    channel_state: &[SeqChannel],
     scratch: &mut AssignScratch,
 ) {
     // Gather the unplaced onsets and the candidate voices as (value, index)
@@ -707,7 +722,7 @@ fn assign_nearest(
     }
     let mut cands: ArrayVec<(f32, u32), PORT_MAX_CHANNELS> = ArrayVec::new();
     for &vidx in candidates {
-        cands.push((last_cv[vidx], vidx as u32));
+        cands.push((channel_state[vidx].last_cv, vidx as u32));
     }
     if evs.is_empty() || cands.is_empty() {
         return;
@@ -833,7 +848,8 @@ impl crate::types::StatefulModule for Seq {
         let mut per_pattern_spans: Vec<Vec<(usize, usize)>> = vec![Vec::new(); num_sources];
         let mut any_non_rest = false;
 
-        for voice in self.state.voices.iter().take(num_channels) {
+        for channel in self.channel_state.iter().take(num_channels) {
+            let voice = &channel.voice;
             if let Some(cached) = voice.cached_hap
                 && !cached.is_rest()
             {
@@ -979,13 +995,14 @@ mod tests {
         cands: &[usize],
         cv: &[(usize, f32)],
     ) -> Vec<Option<usize>> {
-        let mut last_cv = [0.0f32; PORT_MAX_CHANNELS];
+        let mut channels: Vec<SeqChannel> =
+            (0..PORT_MAX_CHANNELS).map(|_| SeqChannel::default()).collect();
         for &(i, v) in cv {
-            last_cv[i] = v;
+            channels[i].last_cv = v;
         }
         let mut assigned = [None; PORT_MAX_CHANNELS];
         let mut scratch = AssignScratch::default();
-        assign_nearest(events, &mut assigned, cands, &last_cv, &mut scratch);
+        assign_nearest(events, &mut assigned, cands, &channels, &mut scratch);
         assigned[..events.len()].to_vec()
     }
 

--- a/crates/modular_core/src/dsp/utilities/adsr.rs
+++ b/crates/modular_core/src/dsp/utilities/adsr.rs
@@ -1,5 +1,5 @@
 use crate::dsp::utils::SchmittTrigger;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use deserr::Deserr;
 use schemars::JsonSchema;
 
@@ -64,12 +64,6 @@ impl Default for ChannelState {
     }
 }
 
-/// State for the Adsr module.
-#[derive(Default)]
-struct AdsrState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// An Attack-Decay-Sustain-Release envelope generator.
 ///
 /// Generates a control voltage envelope driven by a **gate** input.
@@ -90,7 +84,7 @@ struct AdsrState {
 #[module(name = "$adsr", args(gate))]
 pub struct Adsr {
     outputs: AdsrOutputs,
-    state: AdsrState,
+    channel_state: Box<[ChannelState]>,
     params: AdsrParams,
 }
 
@@ -106,7 +100,7 @@ impl Adsr {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             // Smooth parameter targets to avoid clicks when values change (times in seconds)
             state.attack = self.params.attack.value_or(ch, 0.0).max(0.0);

--- a/crates/modular_core/src/dsp/utilities/buffer.rs
+++ b/crates/modular_core/src/dsp/utilities/buffer.rs
@@ -99,9 +99,9 @@ struct BufferWriteBlockOutputs {
 }
 
 impl BufferWriteBlockOutputs {
-    pub fn new(block_size: usize) -> Self {
+    pub fn new(block_size: usize, channel_count: usize) -> Self {
         Self {
-            sample: crate::block_port::BlockPort::new(block_size),
+            sample: crate::block_port::BlockPort::new(block_size, channel_count),
         }
     }
 
@@ -122,7 +122,7 @@ impl BufferWriteBlockOutputs {
     }
 
     pub fn copy_from_inner(&mut self, inner: &BufferWriteOutputs, slot: usize) {
-        for ch in 0..crate::poly::PORT_MAX_CHANNELS {
+        for ch in 0..self.sample.channels() {
             self.sample.set(slot, ch, inner.sample.get_cycling(ch));
         }
     }

--- a/crates/modular_core/src/dsp/utilities/clock_divider.rs
+++ b/crates/modular_core/src/dsp/utilities/clock_divider.rs
@@ -3,7 +3,7 @@ use napi::Result;
 use schemars::JsonSchema;
 
 use crate::dsp::utils::{SchmittTrigger, TempGate, TempGateState, min_gate_samples};
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::ClockMessages;
 
 fn default_division() -> u32 {
@@ -40,12 +40,6 @@ struct ChannelState {
     trigger_gate: TempGate,
 }
 
-/// State for the ClockDivider module.
-#[derive(Default)]
-struct ClockDividerState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Divides an incoming clock signal so it fires less often.
 ///
 /// Feed it a clock and set **division** to an integer — the output will
@@ -60,7 +54,7 @@ struct ClockDividerState {
 pub struct ClockDivider {
     params: ClockDividerParams,
     outputs: ClockDividerOutputs,
-    state: ClockDividerState,
+    channel_state: Box<[ChannelState]>,
 }
 
 message_handlers!(impl ClockDivider {
@@ -72,7 +66,7 @@ impl ClockDivider {
         match m {
             ClockMessages::Start => {
                 // Reset all channel counters on start
-                for state in self.state.channels.iter_mut() {
+                for state in self.channel_state.iter_mut() {
                     state.counter = 0;
                 }
             }
@@ -89,7 +83,7 @@ impl ClockDivider {
         let hold = min_gate_samples(sample_rate);
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             // Reset counter on rising edge of reset trigger
             if state

--- a/crates/modular_core/src/dsp/utilities/delay.rs
+++ b/crates/modular_core/src/dsp/utilities/delay.rs
@@ -47,8 +47,7 @@ impl DelayRead {
         // Without the per-slot offset every slot in the block would read
         // the same delay position — 64× sample-and-hold artefact at
         // `block_size = 64`.
-        let write_index =
-            (self.params.buffer.read_write_index() as f64) + (slot as f64);
+        let write_index = (self.params.buffer.read_write_index() as f64) + (slot as f64);
         let frame_count = self.params.buffer.frame_count();
         let channels = self.channel_count();
 

--- a/crates/modular_core/src/dsp/utilities/lag.rs
+++ b/crates/modular_core/src/dsp/utilities/lag.rs
@@ -1,5 +1,4 @@
 use crate::{
-    PORT_MAX_CHANNELS,
     dsp::utils::sanitize,
     poly::{PolyOutput, PolySignal, PolySignalExt},
 };
@@ -35,12 +34,6 @@ struct SlewChannelState {
     initialized: bool,
 }
 
-/// State for the LagProcessor module.
-#[derive(Default)]
-struct LagProcessorState {
-    channels: [SlewChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Slew limiter that smooths abrupt voltage changes.
 ///
 /// Separate **rise** and **fall** times control how quickly the output can
@@ -60,7 +53,7 @@ struct LagProcessorState {
 pub struct LagProcessor {
     outputs: LagProcessorOutputs,
     params: LagProcessorParams,
-    state: LagProcessorState,
+    channel_state: Box<[SlewChannelState]>,
 }
 
 impl LagProcessor {
@@ -68,7 +61,7 @@ impl LagProcessor {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
             let input = self.params.input.get_value(ch);
             if !state.initialized {
                 state.current_value = sanitize(input);

--- a/crates/modular_core/src/dsp/utilities/logic.rs
+++ b/crates/modular_core/src/dsp/utilities/logic.rs
@@ -1,5 +1,4 @@
 use crate::{
-    PORT_MAX_CHANNELS,
     dsp::utils::{TempGate, TempGateState, min_gate_samples},
     poly::{PolyOutput, PolySignal},
 };
@@ -48,12 +47,6 @@ impl Default for EdgeChannelState {
     }
 }
 
-/// State for the RisingEdgeDetector module.
-#[derive(Default)]
-struct RisingEdgeDetectorState {
-    channels: [EdgeChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Detects rising edges in a signal and emits a short pulse.
 ///
 /// Outputs 5 V for a single sample whenever the input increases.
@@ -68,7 +61,7 @@ struct RisingEdgeDetectorState {
 pub struct RisingEdgeDetector {
     outputs: EdgeDetectorOutputs,
     params: RisingEdgeDetectorParams,
-    state: RisingEdgeDetectorState,
+    channel_state: Box<[EdgeChannelState]>,
 }
 
 impl RisingEdgeDetector {
@@ -77,7 +70,7 @@ impl RisingEdgeDetector {
         let hold = min_gate_samples(sample_rate);
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
             let input = self.params.input.get_value(ch);
 
             if input > state.last_input {
@@ -94,12 +87,6 @@ impl RisingEdgeDetector {
 
 message_handlers!(impl RisingEdgeDetector {});
 
-/// State for the FallingEdgeDetector module.
-#[derive(Default)]
-struct FallingEdgeDetectorState {
-    channels: [EdgeChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Detects falling edges in a signal and emits a short pulse.
 ///
 /// Outputs 5 V for a single sample whenever the input decreases.
@@ -114,7 +101,7 @@ struct FallingEdgeDetectorState {
 pub struct FallingEdgeDetector {
     outputs: EdgeDetectorOutputs,
     params: FallingEdgeDetectorParams,
-    state: FallingEdgeDetectorState,
+    channel_state: Box<[EdgeChannelState]>,
 }
 
 impl FallingEdgeDetector {
@@ -123,7 +110,7 @@ impl FallingEdgeDetector {
         let hold = min_gate_samples(sample_rate);
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
             let input = self.params.input.get_value(ch);
 
             if input < state.last_input {

--- a/crates/modular_core/src/dsp/utilities/percussion_envelope.rs
+++ b/crates/modular_core/src/dsp/utilities/percussion_envelope.rs
@@ -1,5 +1,5 @@
 use crate::dsp::utils::SchmittTrigger;
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use deserr::Deserr;
 use schemars::JsonSchema;
 
@@ -31,12 +31,6 @@ struct ChannelState {
     in_attack: bool,
 }
 
-/// State for the PercussionEnvelope module.
-#[derive(Default)]
-struct PercussionEnvelopeState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Simple envelope for percussive sounds.
 ///
 /// A rising edge on **trigger** starts the envelope at 5 V, which then
@@ -53,7 +47,7 @@ struct PercussionEnvelopeState {
 pub struct PercussionEnvelope {
     outputs: PercussionEnvelopeOutputs,
     params: PercussionEnvelopeParams,
-    state: PercussionEnvelopeState,
+    channel_state: Box<[ChannelState]>,
 }
 
 impl PercussionEnvelope {
@@ -61,7 +55,7 @@ impl PercussionEnvelope {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
 
             let decay_time = self.params.decay.value_or(ch, 0.1).max(0.001);
 

--- a/crates/modular_core/src/dsp/utilities/quantizer.rs
+++ b/crates/modular_core/src/dsp/utilities/quantizer.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use crate::{
     Patch,
     dsp::utils::{TempGate, TempGateState, min_gate_samples},
-    poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
+    poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Connect,
 };
 
@@ -253,7 +253,7 @@ struct QuantizerOutputs {
 }
 
 /// Per-channel state for tracking note changes.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 struct ChannelState {
     /// Previous quantized voltage (None if first sample)
     prev_quantized: Option<f64>,
@@ -261,19 +261,11 @@ struct ChannelState {
     trigger: TempGate,
 }
 
-/// State for the Quantizer module.
-struct QuantizerState {
-    /// Per-channel state for tracking note changes
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
-impl Default for QuantizerState {
+impl Default for ChannelState {
     fn default() -> Self {
         Self {
-            channels: std::array::from_fn(|_| ChannelState {
-                prev_quantized: None,
-                trigger: TempGate::new_gate(TempGateState::Low),
-            }),
+            prev_quantized: None,
+            trigger: TempGate::new_gate(TempGateState::Low),
         }
     }
 }
@@ -300,7 +292,7 @@ impl Default for QuantizerState {
 pub struct Quantizer {
     outputs: QuantizerOutputs,
     params: QuantizerParams,
-    state: QuantizerState,
+    channel_state: Box<[ChannelState]>,
 }
 
 impl Quantizer {
@@ -316,7 +308,7 @@ impl Quantizer {
 
             let quantized = if let Some(snapper) = self.params.scale.snapper() {
                 let raw_quantized = snapper.snap_voct(combined);
-                let state = &self.state.channels[ch];
+                let state = &self.channel_state[ch];
 
                 // Apply hysteresis: only change note if input overshoots the
                 // snap boundary by at least HYSTERESIS_VOCT.
@@ -348,7 +340,7 @@ impl Quantizer {
             };
 
             // Check if the note changed
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
             let note_changed = match state.prev_quantized {
                 Some(prev) => (quantized - prev).abs() > 1e-6,
                 None => true, // First sample counts as a change

--- a/crates/modular_core/src/dsp/utilities/quantizer.rs
+++ b/crates/modular_core/src/dsp/utilities/quantizer.rs
@@ -115,8 +115,9 @@ impl ScaleParam {
                 None => et_tuning(),
             };
 
-            let intervals: Vec<i8> =
-                tokens.map(|s| s.parse::<i8>().ok()).collect::<Option<_>>()?;
+            let intervals: Vec<i8> = tokens
+                .map(|s| s.parse::<i8>().ok())
+                .collect::<Option<_>>()?;
             if intervals.is_empty() {
                 return None;
             }
@@ -177,10 +178,7 @@ pub fn degree_to_voltage(
         (octave, wrapped as usize)
     };
 
-    let semitone_in_scale = scale_intervals
-        .get(wrapped_degree)
-        .copied()
-        .unwrap_or(0) as i32;
+    let semitone_in_scale = scale_intervals.get(wrapped_degree).copied().unwrap_or(0) as i32;
 
     let root_v = (base_midi - 60) as f64 / 12.0;
     let step_v = tuning

--- a/crates/modular_core/src/dsp/utilities/remap.rs
+++ b/crates/modular_core/src/dsp/utilities/remap.rs
@@ -1,7 +1,7 @@
 use deserr::Deserr;
 use schemars::JsonSchema;
 
-use crate::poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt};
+use crate::poly::{PolyOutput, PolySignal, PolySignalExt};
 use crate::types::Clickless;
 
 #[derive(Clone, Deserr, JsonSchema, Connect, ChannelCount, SignalParams)]
@@ -32,12 +32,6 @@ struct ChannelState {
     out_max: Clickless,
 }
 
-/// State for the Remap module.
-#[derive(Default)]
-struct RemapState {
-    channels: [ChannelState; PORT_MAX_CHANNELS],
-}
-
 #[derive(Outputs, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 struct RemapOutputs {
@@ -61,7 +55,7 @@ struct RemapOutputs {
 #[module(name = "$remap", args(input, outMin, outMax, inMin, inMax))]
 pub struct Remap {
     outputs: RemapOutputs,
-    state: RemapState,
+    channel_state: Box<[ChannelState]>,
     params: RemapParams,
 }
 
@@ -71,7 +65,7 @@ impl Remap {
 
         for i in 0..channels as usize {
             let input_val = self.params.input.get_value(i);
-            let state = &mut self.state.channels[i];
+            let state = &mut self.channel_state[i];
 
             // Smooth range parameters to avoid clicks
             state.in_min.update(self.params.in_min.get_value(i));

--- a/crates/modular_core/src/dsp/utilities/sample_and_hold.rs
+++ b/crates/modular_core/src/dsp/utilities/sample_and_hold.rs
@@ -1,8 +1,5 @@
 use crate::dsp::utils::{SchmittState, SchmittTrigger};
-use crate::{
-    PORT_MAX_CHANNELS,
-    poly::{PolyOutput, PolySignal},
-};
+use crate::poly::{PolyOutput, PolySignal};
 use deserr::Deserr;
 use schemars::JsonSchema;
 
@@ -30,12 +27,6 @@ struct SampleAndHoldChannelState {
     held_value: f32,
 }
 
-/// State for the SampleAndHold module.
-#[derive(Default)]
-struct SampleAndHoldState {
-    channels: [SampleAndHoldChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Captures and holds a voltage on each trigger.
 ///
 /// When **trigger** receives a rising edge, the current value of **input**
@@ -56,7 +47,7 @@ struct SampleAndHoldState {
 pub struct SampleAndHold {
     outputs: SampleAndHoldOutputs,
     params: SampleAndHoldParams,
-    state: SampleAndHoldState,
+    channel_state: Box<[SampleAndHoldChannelState]>,
 }
 
 impl SampleAndHold {
@@ -64,7 +55,7 @@ impl SampleAndHold {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
             let input = self.params.input.get_value(ch);
             let trigger = self.params.trigger.get_value(ch);
 
@@ -107,12 +98,6 @@ struct TrackAndHoldChannelState {
     gate: SchmittTrigger,
 }
 
-/// State for the TrackAndHold module.
-#[derive(Default)]
-struct TrackAndHoldState {
-    channels: [TrackAndHoldChannelState; PORT_MAX_CHANNELS],
-}
-
 /// Follows the input while the gate is low, and holds the value when the
 /// gate goes high.
 ///
@@ -127,7 +112,7 @@ struct TrackAndHoldState {
 pub struct TrackAndHold {
     outputs: TrackAndHoldOutputs,
     params: TrackAndHoldParams,
-    state: TrackAndHoldState,
+    channel_state: Box<[TrackAndHoldChannelState]>,
 }
 
 impl TrackAndHold {
@@ -135,7 +120,7 @@ impl TrackAndHold {
         let num_channels = self.channel_count();
 
         for ch in 0..num_channels {
-            let state = &mut self.state.channels[ch];
+            let state = &mut self.channel_state[ch];
             let input = self.params.input.get_value(ch);
             let gate = self.params.gate.get_value(ch);
 

--- a/crates/modular_core/src/dsp/utilities/spread.rs
+++ b/crates/modular_core/src/dsp/utilities/spread.rs
@@ -15,7 +15,7 @@ struct SpreadParams {
     min: MonoSignal,
     /// upper bound of the spread range
     max: MonoSignal,
-    /// number of output channels (1–16)
+    /// number of output channels (1–64)
     count: usize,
     /// distribution bias (-5 to 5): positive biases toward max, negative toward min
     #[signal(default = 0.0, range = (-5.0, 5.0))]

--- a/crates/modular_core/src/dsp/utilities/unison.rs
+++ b/crates/modular_core/src/dsp/utilities/unison.rs
@@ -14,7 +14,7 @@ fn default_count() -> usize {
 struct UnisonParams {
     /// input signal to expand (typically V/Oct pitch)
     input: PolySignal,
-    /// number of unison voices per input channel (1–16)
+    /// number of unison voices per input channel (1–64)
     #[serde(default = "default_count")]
     #[deserr(default = default_count())]
     count: usize,
@@ -23,7 +23,7 @@ struct UnisonParams {
     spread: Option<PolySignal>,
 }
 
-/// Custom channel count: max(all PolySignal channels) * count, clamped to 16.
+/// Custom channel count: max(all PolySignal channels) * count, clamped to 64.
 #[allow(private_interfaces)]
 pub fn unison_derive_channel_count(params: &UnisonParams) -> usize {
     let fields = params.poly_signal_fields();
@@ -46,10 +46,10 @@ struct UnisonOutputs {
 /// Takes a signal (typically V/Oct pitch) and multiplies channels by the
 /// unison count, applying symmetric detuning controlled by the spread parameter.
 ///
-/// - **count** — number of detuned copies per input channel (1–16)
+/// - **count** — number of detuned copies per input channel (1–64)
 /// - **spread** — detune amount with exponential curve (0–10V → 0–1 octave V/Oct)
 ///
-/// Output channels = `input_channels × count`, clamped to 16.
+/// Output channels = `input_channels × count`, clamped to 64.
 ///
 /// ## Example
 ///
@@ -202,20 +202,16 @@ mod tests {
     }
 
     #[test]
-    fn test_clamp_to_16_channels() {
-        // 4-channel input, count=5 -> 20 desired, clamped to 16
+    fn test_clamp_to_max_channels() {
+        // 16-channel input, count=5 -> 80 desired, clamped to PORT_MAX_CHANNELS
+        let input: Vec<Signal> = (0..16).map(|i| Signal::Volts(i as f32)).collect();
         let mut u = make_unison(UnisonParams {
-            input: PolySignal::poly(&[
-                Signal::Volts(0.0),
-                Signal::Volts(1.0),
-                Signal::Volts(2.0),
-                Signal::Volts(3.0),
-            ]),
+            input: PolySignal::poly(&input),
             count: 5,
             spread: None,
         });
         u.update(48000.0);
-        assert_eq!(u.outputs.sample.channels(), 16);
+        assert_eq!(u.outputs.sample.channels(), PORT_MAX_CHANNELS);
     }
 
     #[test]
@@ -236,13 +232,13 @@ mod tests {
         };
         assert_eq!(unison_derive_channel_count(&params), 15);
 
-        // 3 channels * 6 = 18, clamped to 16
+        // 3 channels * 6 = 18, within the PORT_MAX_CHANNELS cap
         let params = UnisonParams {
             input: PolySignal::poly(&[Signal::Volts(0.0), Signal::Volts(0.0), Signal::Volts(0.0)]),
             count: 6,
             spread: None,
         };
-        assert_eq!(unison_derive_channel_count(&params), 16);
+        assert_eq!(unison_derive_channel_count(&params), 18);
     }
 
     #[test]

--- a/crates/modular_core/src/lib.rs
+++ b/crates/modular_core/src/lib.rs
@@ -40,7 +40,7 @@ pub use params::{
 };
 
 pub use types::{
-    Buffer, BufferData, ExternalClockState, Module, ModuleSchema, ModuleState, PatchGraph,
+    Buffer, BufferData, ExternalClockState, Module, ModuleSchema, ModuleSpec, PatchGraph,
     ProcessingMode, ROOT_ID, ROOT_OUTPUT_PORT, SampleBuffer, Sampleable, SampleableConstructor,
     SampleableMap, Signal, SignalExt, SignalParamSchema, Wav, WavData,
 };

--- a/crates/modular_core/src/pattern_system/applicative.rs
+++ b/crates/modular_core/src/pattern_system/applicative.rs
@@ -55,9 +55,7 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
                     };
 
                     for hap_val in haps_val.iter() {
-                        if &hap_val.part.begin >= window_end
-                            || hap_val.part.end <= *window_begin
-                        {
+                        if &hap_val.part.begin >= window_end || hap_val.part.end <= *window_begin {
                             continue;
                         }
                         if let Some(part) = fn_part.intersection(&hap_val.part) {
@@ -119,9 +117,7 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
                         &lookup_span.end
                     };
                     for hap_fn in haps_fn.iter() {
-                        if &hap_fn.part.begin >= window_end
-                            || hap_fn.part.end <= *window_begin
-                        {
+                        if &hap_fn.part.begin >= window_end || hap_fn.part.end <= *window_begin {
                             continue;
                         }
                         if let Some(part) = hap_fn.part.intersection(&hap_val.part) {
@@ -201,9 +197,9 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
 #[cfg(test)]
 mod tests {
     use crate::pattern_system::Fraction;
+    use crate::pattern_system::Pattern;
     use crate::pattern_system::combinators::fastcat;
     use crate::pattern_system::constructors::pure;
-    use crate::pattern_system::Pattern;
 
     #[test]
     fn test_app_left_structure() {

--- a/crates/modular_core/src/pattern_system/combinators.rs
+++ b/crates/modular_core/src/pattern_system/combinators.rs
@@ -273,7 +273,10 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
             out.reserve(scratch.len());
             for hap in scratch {
                 let new_part = hap.part.with_time(|t| t / &factor_clone);
-                let new_whole = hap.whole.as_ref().map(|w| w.with_time(|t| t / &factor_clone));
+                let new_whole = hap
+                    .whole
+                    .as_ref()
+                    .map(|w| w.with_time(|t| t / &factor_clone));
                 out.push(crate::pattern_system::ArenaHap {
                     whole: new_whole,
                     part: new_part,
@@ -317,7 +320,6 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
         }
         Pattern::new_fast_const(self.clone(), Fraction::from_integer(1) / factor)
     }
-
 }
 
 /// Compute the least common multiple of two fractions.

--- a/crates/modular_core/src/pattern_system/euclidean.rs
+++ b/crates/modular_core/src/pattern_system/euclidean.rs
@@ -335,5 +335,4 @@ mod tests {
         let true_count = haps.iter().filter(|h| h.value).count();
         assert_eq!(true_count, 3);
     }
-
 }

--- a/crates/modular_core/src/pattern_system/fraction.rs
+++ b/crates/modular_core/src/pattern_system/fraction.rs
@@ -89,10 +89,7 @@ impl Fraction {
     pub fn whole_cycle(&self) -> super::TimeSpan {
         // Share floor_value between sam and next_sam.
         let f = self.floor_value();
-        super::TimeSpan::new(
-            Fraction { num: f, den: 1 },
-            Fraction { num: f + 1, den: 1 },
-        )
+        super::TimeSpan::new(Fraction { num: f, den: 1 }, Fraction { num: f + 1, den: 1 })
     }
 
     /// Convert to f64 (lossy).

--- a/crates/modular_core/src/pattern_system/hap.rs
+++ b/crates/modular_core/src/pattern_system/hap.rs
@@ -65,7 +65,6 @@ impl HapContext {
         }
     }
 
-
     /// Combine two contexts (e.g., when combining haps in applicative operations).
     pub fn combine(&self, other: &HapContext) -> HapContext {
         let mut combined = self.clone();
@@ -323,10 +322,7 @@ impl<'b> ArenaHapContext<'b> {
 
     /// Wrap so all spans (including modifier-side) appear as source on extract.
     #[inline]
-    pub fn strip_in(
-        ctx: &'b ArenaHapContext<'b>,
-        bump: &'b Bump,
-    ) -> &'b ArenaHapContext<'b> {
+    pub fn strip_in(ctx: &'b ArenaHapContext<'b>, bump: &'b Bump) -> &'b ArenaHapContext<'b> {
         if matches!(ctx, ArenaHapContext::Empty) {
             return ctx;
         }
@@ -407,11 +403,7 @@ impl<'b> ArenaHapContext<'b> {
         let mut current_extras: Vec<SourceSpan> = Vec::new();
         self.walk(&mut |idx, span| {
             if idx as i32 != current_idx {
-                flush_owned_extras(
-                    &mut owned,
-                    current_idx,
-                    std::mem::take(&mut current_extras),
-                );
+                flush_owned_extras(&mut owned, current_idx, std::mem::take(&mut current_extras));
                 current_idx = idx as i32;
             }
             current_extras.push(span.clone());
@@ -419,7 +411,6 @@ impl<'b> ArenaHapContext<'b> {
         flush_owned_extras(&mut owned, current_idx, current_extras);
         owned
     }
-
 }
 
 fn flush_owned_extras(owned: &mut HapContext, pattern_idx: i32, spans: Vec<SourceSpan>) {

--- a/crates/modular_core/src/pattern_system/mini/mod.rs
+++ b/crates/modular_core/src/pattern_system/mini/mod.rs
@@ -55,8 +55,6 @@ pub fn parse<T: FromMiniAtom>(
 /// Test-only entry point: parse a mini-notation string into a `MiniAST`.
 /// Kept so in-crate fixtures that used `mini::parse_ast` continue to work.
 #[doc(hidden)]
-pub fn parse_ast(
-    source: &str,
-) -> Result<MiniAST, test_parser::ParseError> {
+pub fn parse_ast(source: &str) -> Result<MiniAST, test_parser::ParseError> {
     test_parser::parse(source)
 }

--- a/crates/modular_core/src/pattern_system/mini/test_parser.rs
+++ b/crates/modular_core/src/pattern_system/mini/test_parser.rs
@@ -375,11 +375,7 @@ impl<'a> Parser<'a> {
         // hz suffix?
         if self.matches_keyword_ci("hz") {
             let end = self.pos;
-            return Ok(MiniAST::Pure(Located::new(
-                AtomValue::Hz(n),
-                start,
-                end,
-            )));
+            return Ok(MiniAST::Pure(Located::new(AtomValue::Hz(n), start, end)));
         }
         let end = self.pos;
         Ok(MiniAST::Pure(Located::new(
@@ -416,7 +412,11 @@ impl<'a> Parser<'a> {
         if self.peek() == Some(b'.') {
             // Optional fractional part (must have digits after .)
             let after_dot = self.pos + 1;
-            if self.input.get(after_dot).is_some_and(|c| c.is_ascii_digit()) {
+            if self
+                .input
+                .get(after_dot)
+                .is_some_and(|c| c.is_ascii_digit())
+            {
                 self.pos += 1;
                 while matches!(self.peek(), Some(b'0'..=b'9')) {
                     self.pos += 1;
@@ -541,7 +541,12 @@ impl<'a> Parser<'a> {
         let mut elems: Vec<(MiniASTF64, Option<f64>)> = Vec::new();
         loop {
             self.skip_ws();
-            if self.at_end() || matches!(self.peek(), Some(b']') | Some(b'>') | Some(b')') | Some(b',')) {
+            if self.at_end()
+                || matches!(
+                    self.peek(),
+                    Some(b']') | Some(b'>') | Some(b')') | Some(b',')
+                )
+            {
                 break;
             }
             let base = self.mod_operand_f64()?;
@@ -630,7 +635,12 @@ impl<'a> Parser<'a> {
         let mut elems: Vec<(MiniASTU32, Option<f64>)> = Vec::new();
         loop {
             self.skip_ws();
-            if self.at_end() || matches!(self.peek(), Some(b']') | Some(b'>') | Some(b')') | Some(b',')) {
+            if self.at_end()
+                || matches!(
+                    self.peek(),
+                    Some(b']') | Some(b'>') | Some(b')') | Some(b',')
+                )
+            {
                 break;
             }
             let base = self.mod_operand_u32()?;
@@ -709,7 +719,12 @@ impl<'a> Parser<'a> {
         let mut elems: Vec<(MiniASTI32, Option<f64>)> = Vec::new();
         loop {
             self.skip_ws();
-            if self.at_end() || matches!(self.peek(), Some(b']') | Some(b'>') | Some(b')') | Some(b',')) {
+            if self.at_end()
+                || matches!(
+                    self.peek(),
+                    Some(b']') | Some(b'>') | Some(b')') | Some(b',')
+                )
+            {
                 break;
             }
             let base = self.mod_operand_i32()?;
@@ -910,9 +925,9 @@ mod tests {
             MiniAST::Replicate(inner, count) => {
                 assert_eq!(*count, 3);
                 match inner.as_ref() {
-                    MiniAST::Pure(l) => assert!(
-                        matches!(l.node, AtomValue::Note { letter: 'a', .. })
-                    ),
+                    MiniAST::Pure(l) => {
+                        assert!(matches!(l.node, AtomValue::Note { letter: 'a', .. }))
+                    }
                     other => panic!("expected Pure note, got {:?}", other),
                 }
             }

--- a/crates/modular_core/src/pattern_system/mod.rs
+++ b/crates/modular_core/src/pattern_system/mod.rs
@@ -320,8 +320,7 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
                 &State,
                 &'b bumpalo::Bump,
                 &mut bumpalo::collections::Vec<'b, ArenaHap<'b, T>>,
-            )
-            + Send
+            ) + Send
             + Sync
             + 'static,
     {
@@ -613,7 +612,10 @@ fn fastcat_query_into<'b, T: Clone + Send + Sync + 'static>(
             out.reserve(scratch.len());
             for hap in scratch {
                 let new_part = hap.part.with_time(|t| t * &inv_n + &b_r);
-                let new_whole = hap.whole.as_ref().map(|w| w.with_time(|t| t * &inv_n + &b_r));
+                let new_whole = hap
+                    .whole
+                    .as_ref()
+                    .map(|w| w.with_time(|t| t * &inv_n + &b_r));
                 out.push(ArenaHap {
                     whole: new_whole,
                     part: new_part,
@@ -751,7 +753,10 @@ fn compress_query_into<'b, T: Clone + Send + Sync + 'static>(
         let b_r = &compressed_begin - &(&cycle * duration);
         for hap in scratch {
             let new_part = hap.part.with_time(|t| t * duration + &b_r);
-            let new_whole = hap.whole.as_ref().map(|w| w.with_time(|t| t * duration + &b_r));
+            let new_whole = hap
+                .whole
+                .as_ref()
+                .map(|w| w.with_time(|t| t * duration + &b_r));
             if let Some(final_part) = new_part.intersection(&cycle_span) {
                 out.push(ArenaHap {
                     whole: new_whole,
@@ -996,8 +1001,8 @@ mod tests {
         use crate::pattern_system::constructors::pure_with_span;
         use crate::pattern_system::hap::SourceSpan;
 
-        let pat = pure_with_span(1.0f64, SourceSpan::new(0, 1))
-            .with_modifier_span(SourceSpan::new(5, 6));
+        let pat =
+            pure_with_span(1.0f64, SourceSpan::new(0, 1)).with_modifier_span(SourceSpan::new(5, 6));
         let stripped = pat.strip_modifier_spans();
         let haps = stripped.query_arc(
             Fraction::from_integer(0.into()),

--- a/crates/modular_core/src/pattern_system/monadic.rs
+++ b/crates/modular_core/src/pattern_system/monadic.rs
@@ -76,12 +76,7 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
     pub fn inner_join_into<U, F>(&self, f: F) -> Pattern<U>
     where
         U: Clone + Send + Sync + 'static,
-        F: for<'b> Fn(
-                &T,
-                &State,
-                &'b Bump,
-                &mut BumpVec<'b, ArenaHap<'b, U>>,
-            )
+        F: for<'b> Fn(&T, &State, &'b Bump, &mut BumpVec<'b, ArenaHap<'b, U>>)
             + Send
             + Sync
             + 'static,
@@ -118,7 +113,6 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
             },
         )
     }
-
 }
 
 #[cfg(test)]

--- a/crates/modular_core/src/pattern_system/sp_combine.rs
+++ b/crates/modular_core/src/pattern_system/sp_combine.rs
@@ -134,10 +134,7 @@ fn squeeze_into<'b, O, I, V, G>(
             // Map inner_hap's part/whole from inner cycle space back into
             // the outer target span.
             let mapped_part = map_span(&inner_hap.part, &target, &dur);
-            let mapped_whole = inner_hap
-                .whole
-                .as_ref()
-                .map(|w| map_span(w, &target, &dur));
+            let mapped_whole = inner_hap.whole.as_ref().map(|w| map_span(w, &target, &dur));
 
             let part = match mapped_part.intersection(&outer_hap.part) {
                 Some(p) => p,
@@ -223,23 +220,20 @@ where
 
                 // We want inner shifted later by `shift`. Query inner at
                 // state.span - shift, then re-add shift to result haps.
-                let inner_state_span = TimeSpan::new(
-                    &state.span.begin - &shift,
-                    &state.span.end - &shift,
-                );
+                let inner_state_span =
+                    TimeSpan::new(&state.span.begin - &shift, &state.span.end - &shift);
                 let inner_state = State::new(inner_state_span);
 
                 let mut inner_haps: BumpVec<'_, ArenaHap<'_, T>> = BumpVec::new_in(bump);
                 left.query_into(&inner_state, bump, &mut inner_haps);
 
                 for inner_hap in &inner_haps {
-                    let shifted_part = TimeSpan::new(
-                        &inner_hap.part.begin + &shift,
-                        &inner_hap.part.end + &shift,
-                    );
-                    let shifted_whole = inner_hap.whole.as_ref().map(|w| {
-                        TimeSpan::new(&w.begin + &shift, &w.end + &shift)
-                    });
+                    let shifted_part =
+                        TimeSpan::new(&inner_hap.part.begin + &shift, &inner_hap.part.end + &shift);
+                    let shifted_whole = inner_hap
+                        .whole
+                        .as_ref()
+                        .map(|w| TimeSpan::new(&w.begin + &shift, &w.end + &shift));
 
                     let part = match shifted_part.intersection(&outer_hap.part) {
                         Some(p) => p,
@@ -254,11 +248,8 @@ where
                     };
 
                     let value = f(&inner_hap.value, &outer_hap.value);
-                    let context = ArenaHapContext::combine_in(
-                        &inner_hap.context,
-                        &outer_hap.context,
-                        bump,
-                    );
+                    let context =
+                        ArenaHapContext::combine_in(&inner_hap.context, &outer_hap.context, bump);
                     out.push(ArenaHap {
                         whole,
                         part,
@@ -275,8 +266,8 @@ where
 mod tests {
     use super::*;
     use crate::pattern_system::Fraction;
-    use crate::pattern_system::combinators::fastcat;
     use crate::pattern_system::SourceSpan;
+    use crate::pattern_system::combinators::fastcat;
     use crate::pattern_system::constructors::{pure, pure_with_span};
 
     fn ints(start: i64, end: i64, pat: &Pattern<i32>) -> Vec<i32> {
@@ -363,7 +354,10 @@ mod tests {
         let c = combine_sp(&a, &b, SpAlignmentMode::Squeeze, |x, y| x + y);
         let haps = c.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
 
-        assert!(!haps.is_empty(), "expected at least one hap from $p.s(A).squeeze(B)");
+        assert!(
+            !haps.is_empty(),
+            "expected at least one hap from $p.s(A).squeeze(B)"
+        );
         for hap in &haps {
             // Left operand A is pattern_idx 0 → ends up as source_span.
             let source = hap
@@ -405,7 +399,10 @@ mod tests {
         let c = combine_sp(&a, &b, SpAlignmentMode::SqueezeOut, |x, y| x + y);
         let haps = c.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
 
-        assert!(!haps.is_empty(), "expected at least one hap from $p.s(A).squeezeOut(B)");
+        assert!(
+            !haps.is_empty(),
+            "expected at least one hap from $p.s(A).squeezeOut(B)"
+        );
         for hap in &haps {
             let source = hap
                 .context
@@ -434,10 +431,8 @@ mod tests {
         use crate::pattern_system::mini;
 
         // 1+2. Lower mini-notation to Pattern<IntervalValue>.
-        let left: Pattern<IntervalValue> =
-            mini::parse("0 1 2 3").expect("parse '0 1 2 3'");
-        let right: Pattern<IntervalValue> =
-            mini::parse("0 5").expect("parse '0 5'");
+        let left: Pattern<IntervalValue> = mini::parse("0 1 2 3").expect("parse '0 1 2 3'");
+        let right: Pattern<IntervalValue> = mini::parse("0 5").expect("parse '0 5'");
 
         // 3. Strip modifier spans before combining (matches from_sp_payload).
         let left = left.strip_modifier_spans();
@@ -448,11 +443,11 @@ mod tests {
             combine_sp(&left, &right, SpAlignmentMode::In, sub_interval_values);
 
         // 5. Query 1 cycle.
-        let haps = combined.query_arc(
-            Fraction::from_integer(0),
-            Fraction::from_integer(1),
+        let haps = combined.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
+        assert!(
+            !haps.is_empty(),
+            "expected haps from sub combine over 1 cycle"
         );
-        assert!(!haps.is_empty(), "expected haps from sub combine over 1 cycle");
 
         // 6. For each hap, walk the context tree and collect
         //    (pattern_idx, (start, end)) tuples. The walk lives on

--- a/crates/modular_core/src/pattern_system/timespan.rs
+++ b/crates/modular_core/src/pattern_system/timespan.rs
@@ -211,5 +211,4 @@ mod tests {
         let span = TimeSpan::new(Fraction::new(1, 4), Fraction::new(3, 4));
         assert_eq!(span.duration(), Fraction::new(1, 2));
     }
-
 }

--- a/crates/modular_core/src/poly.rs
+++ b/crates/modular_core/src/poly.rs
@@ -7,78 +7,55 @@
 //! - `PolySignal`: A fixed-capacity input buffer containing Signal values (for polyphonic module inputs)
 
 use crate::{dsp::utils::sanitize, types::Signal};
-use arrayvec::ArrayVec;
 use deserr::{DeserializeError, ErrorKind, IntoValue, ValuePointerRef};
 use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::Cow;
 
-/// Maximum channels per cable (matches VCV Rack / MIDI convention)
-pub const PORT_MAX_CHANNELS: usize = 16;
+/// Maximum channels per cable. A hard cap on polyphony — buffers are sized to
+/// each module's actual channel count, so this only bounds the maximum, it is
+/// not allocated up front.
+pub const PORT_MAX_CHANNELS: usize = 64;
 
-/// A polyphonic output buffer with channel count metadata.
+/// A polyphonic output buffer holding one voltage per active channel.
 ///
-/// This is a fixed-capacity buffer that can hold up to 16 channels.
-/// The `channels` field indicates how many channels are semantically valid:
-/// - 0 = disconnected
-/// - 1 = monophonic
-/// - 2-16 = polyphonic
-#[derive(Clone, Copy, Debug)]
+/// The backing slice is sized to the module's channel count (1..=16) on the
+/// main thread at construction (`set_channels`), never on the audio thread.
+/// `voltages.len()` is the active channel count: 0 = disconnected, 1 = mono,
+/// 2-16 = polyphonic.
+#[derive(Clone, Debug, PartialEq)]
 pub struct PolyOutput {
-    /// Voltage values for each channel (always allocated, not all may be active)
-    voltages: [f32; PORT_MAX_CHANNELS],
-    /// Number of active channels: 0 = disconnected, 1 = mono, 2-16 = poly
-    channels: usize,
+    /// One voltage per active channel. Length is the channel count.
+    voltages: Box<[f32]>,
 }
 
 impl Default for PolyOutput {
     fn default() -> Self {
         Self {
-            voltages: [0.0; PORT_MAX_CHANNELS],
-            channels: 0, // Disconnected
+            voltages: Box::new([]), // Disconnected (0 channels)
         }
-    }
-}
-
-impl PartialEq for PolyOutput {
-    fn eq(&self, other: &Self) -> bool {
-        if self.channels != other.channels {
-            return false;
-        }
-        // Only compare active channels
-        for i in 0..self.channels as usize {
-            if self.voltages[i] != other.voltages[i] {
-                return false;
-            }
-        }
-        true
     }
 }
 
 impl PolyOutput {
     /// Create a monophonic signal with a single value
     pub fn mono(value: f32) -> Self {
-        let mut sig = Self::default();
-        sig.voltages[0] = value;
-        sig.channels = 1;
-        sig
+        Self {
+            voltages: vec![value].into_boxed_slice(),
+        }
     }
 
     // === Accessors ===
 
     /// Get voltage for a specific channel (returns 0.0 if out of range)
     pub fn get(&self, channel: usize) -> f32 {
-        if channel < self.channels as usize {
-            self.voltages[channel]
-        } else {
-            0.0
-        }
+        self.voltages.get(channel).copied().unwrap_or(0.0)
     }
 
     /// Set voltage for a specific channel
     pub fn set(&mut self, channel: usize, value: f32) {
-        if channel < PORT_MAX_CHANNELS {
-            self.voltages[channel] = sanitize(value);
+        if let Some(slot) = self.voltages.get_mut(channel) {
+            *slot = sanitize(value);
         }
     }
 
@@ -86,29 +63,28 @@ impl PolyOutput {
     /// This is consistent with Vec::cycle_get for non-signal params.
     /// A mono signal cycles to all channels, a 2-ch signal alternates, etc.
     pub fn get_cycling(&self, channel: usize) -> f32 {
-        if self.channels == 0 {
+        let n = self.voltages.len();
+        if n == 0 {
             0.0 // Disconnected
         } else {
-            self.voltages[channel % self.channels as usize]
+            self.voltages[channel % n]
         }
     }
 
-    /// Set the number of active channels (clears higher channels to 0)
+    /// Size the buffer to `channels` active channels.
+    ///
+    /// Reallocates when the count changes — **main thread only** (called once
+    /// per output at construction via `OutputStruct::set_all_channels`). When
+    /// the count is unchanged this is a no-op, so it is safe to re-invoke.
     pub fn set_channels(&mut self, channels: usize) {
-        let channels = channels.clamp(0, PORT_MAX_CHANNELS);
-        // Clear channels beyond the new count
-        for c in channels..self.channels {
-            self.voltages[c] = 0.0;
+        let channels = channels.min(PORT_MAX_CHANNELS);
+        if self.voltages.len() != channels {
+            self.voltages = vec![0.0; channels].into_boxed_slice();
         }
-        self.channels = channels;
     }
 
     pub fn channels(&self) -> usize {
-        self.channels
-    }
-
-    pub fn set_all(&mut self, voltages: &[f32; PORT_MAX_CHANNELS]) {
-        self.voltages = *voltages;
+        self.voltages.len()
     }
 }
 
@@ -122,8 +98,8 @@ impl Serialize for PolyOutput {
         // Serialize as a struct with channels and voltages array
         use serde::ser::SerializeStruct;
         let mut state = serializer.serialize_struct("PolyOutput", 2)?;
-        state.serialize_field("channels", &self.channels)?;
-        state.serialize_field("voltages", &self.voltages[..self.channels as usize])?;
+        state.serialize_field("channels", &self.voltages.len())?;
+        state.serialize_field("voltages", &self.voltages[..])?;
         state.end()
     }
 }
@@ -140,12 +116,12 @@ impl<'de> Deserialize<'de> for PolyOutput {
         }
 
         let de = PolyOutputDe::deserialize(deserializer)?;
-        let mut sig = PolyOutput::default();
-        sig.channels = de.channels.min(PORT_MAX_CHANNELS);
-        for (i, &v) in de.voltages.iter().enumerate().take(sig.channels as usize) {
-            sig.voltages[i] = v;
+        let channels = de.channels.min(PORT_MAX_CHANNELS);
+        let mut voltages = vec![0.0f32; channels].into_boxed_slice();
+        for (i, &v) in de.voltages.iter().enumerate().take(channels) {
+            voltages[i] = v;
         }
-        Ok(sig)
+        Ok(PolyOutput { voltages })
     }
 }
 
@@ -181,25 +157,29 @@ impl JsonSchema for PolyOutput {
 /// - 2-16 = polyphonic (multiple signals)
 ///
 /// Disconnected inputs are represented as `Option<PolySignal>` at the param level.
-#[derive(Clone, Debug, Connect)]
+#[derive(Clone, Debug)]
 pub struct PolySignal {
-    /// Active signal channels (always at least 1, up to PORT_MAX_CHANNELS)
-    channels: ArrayVec<Signal, PORT_MAX_CHANNELS>,
+    /// Active signal channels (always at least 1, up to PORT_MAX_CHANNELS).
+    /// Sized to the actual channel count on the main thread at deserialize.
+    channels: Box<[Signal]>,
 }
 
-impl<const CAP: usize> crate::types::Connect for ArrayVec<Signal, CAP> {
+// Hand-written rather than `#[derive(Connect)]`: deriving would require a
+// `Connect for Box<[Signal]>` impl, which overlaps the blanket `Connect for
+// Box<T>` under coherence. Forwarding over the slice directly sidesteps that.
+impl crate::types::Connect for PolySignal {
     fn connect(&mut self, patch: &crate::Patch) {
-        for signal in self.iter_mut() {
+        for signal in self.channels.iter_mut() {
             signal.connect(patch);
         }
     }
     fn collect_cables(&self, sink: &mut Vec<String>) {
-        for signal in self.iter() {
+        for signal in self.channels.iter() {
             signal.collect_cables(sink);
         }
     }
     fn inject_index_ptr(&mut self, ptr: *const std::cell::Cell<usize>) {
-        for signal in self.iter_mut() {
+        for signal in self.channels.iter_mut() {
             signal.inject_index_ptr(ptr);
         }
     }
@@ -208,9 +188,9 @@ impl<const CAP: usize> crate::types::Connect for ArrayVec<Signal, CAP> {
 impl PolySignal {
     /// Create a mono (1-channel) PolySignal from a single Signal.
     pub fn mono(signal: Signal) -> Self {
-        let mut channels = ArrayVec::new();
-        channels.push(signal);
-        Self { channels }
+        Self {
+            channels: vec![signal].into_boxed_slice(),
+        }
     }
 
     /// Create a polyphonic PolySignal from a slice of Signals.
@@ -219,10 +199,12 @@ impl PolySignal {
             !signals.is_empty(),
             "PolySignal must have at least 1 channel"
         );
-        let mut channels = ArrayVec::new();
-        for s in signals.iter().take(PORT_MAX_CHANNELS) {
-            channels.push(s.clone());
-        }
+        let channels = signals
+            .iter()
+            .take(PORT_MAX_CHANNELS)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
         Self { channels }
     }
 

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -2599,7 +2599,7 @@ pub struct ModuleSchema {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
-pub struct ModuleState {
+pub struct ModuleSpec {
     pub id: String,
     pub module_type: String,
     pub id_is_explicit: Option<bool>,
@@ -2707,7 +2707,7 @@ pub struct ScopeXyRanges {
 // #[serde(rename_all = "camelCase")]
 #[napi(object)]
 pub struct PatchGraph {
-    pub modules: Vec<ModuleState>,
+    pub modules: Vec<ModuleSpec>,
     pub module_id_remaps: Option<Vec<ModuleIdRemap>>,
     // #[serde(default)]
     pub scopes: Vec<Scope>,

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -1478,9 +1478,7 @@ impl Buffer {
     }
 
     pub fn frame_count(&self) -> usize {
-        self.buffer_ref()
-            .map(|b| b.frame_count())
-            .unwrap_or(0)
+        self.buffer_ref().map(|b| b.frame_count()).unwrap_or(0)
     }
 
     pub fn is_connected(&self) -> bool {
@@ -1511,9 +1509,7 @@ impl Buffer {
     }
 
     pub fn read_write_index(&self) -> usize {
-        self.buffer_ref()
-            .map(|b| b.read_write_index())
-            .unwrap_or(0)
+        self.buffer_ref().map(|b| b.read_write_index()).unwrap_or(0)
     }
 
     pub fn fill(&self, value: f32) {
@@ -1539,13 +1535,11 @@ impl Buffer {
     }
 
     pub fn with_data<R>(&self, f: impl FnOnce(&Vec<Vec<f32>>) -> R) -> Option<R> {
-        self.buffer_ref()
-            .map(|buffer| buffer.with_data(f))
+        self.buffer_ref().map(|buffer| buffer.with_data(f))
     }
 
     pub fn with_data_mut<R>(&self, f: impl FnOnce(&mut Vec<Vec<f32>>) -> R) -> Option<R> {
-        self.buffer_ref()
-            .map(|buffer| buffer.with_data_mut(f))
+        self.buffer_ref().map(|buffer| buffer.with_data_mut(f))
     }
 
     pub fn read_hermite_wrapped(&self, channel: usize, frame: f32) -> f32 {
@@ -2441,7 +2435,7 @@ impl PartialEq for Signal {
     Deserialize,
     JsonSchema,
     Deserr,
-    Connect
+    Connect,
 )]
 #[serde(rename_all = "camelCase")]
 #[deserr(rename_all = camelCase)]

--- a/crates/modular_core/tests/block_outputs_tests.rs
+++ b/crates/modular_core/tests/block_outputs_tests.rs
@@ -25,7 +25,7 @@ struct SimpleOutputs {
 
 #[test]
 fn block_outputs_struct_exists() {
-    let bo = SimpleBlockOutputs::new(4);
+    let bo = SimpleBlockOutputs::new(4, 1);
     // Fresh buffer returns 0.0 at every index.
     assert_eq!(bo.get_at(0, 0, 0), 0.0);
     assert_eq!(bo.get_at(1, 2, 3), 0.0);
@@ -37,7 +37,7 @@ fn copy_from_inner_fills_block_outputs() {
         value: 2.5,
         poly: PolyOutput::mono(1.0),
     };
-    let mut bo = SimpleBlockOutputs::new(4);
+    let mut bo = SimpleBlockOutputs::new(4, 1);
     bo.copy_from_inner(&inner, 2);
     let value_idx = SimpleBlockOutputs::port_index("value").unwrap();
     let poly_idx = SimpleBlockOutputs::port_index("poly").unwrap();
@@ -63,7 +63,7 @@ fn get_at_reads_correct_port() {
         value: 7.5,
         poly: PolyOutput::mono(3.5),
     };
-    let mut bo = SimpleBlockOutputs::new(4);
+    let mut bo = SimpleBlockOutputs::new(4, 1);
     bo.copy_from_inner(&inner, 1);
     assert!((bo.get_at(0, 0, 1) - 7.5).abs() < 1e-6); // value
     assert!((bo.get_at(1, 0, 1) - 3.5).abs() < 1e-6); // poly
@@ -71,6 +71,6 @@ fn get_at_reads_correct_port() {
 
 #[test]
 fn get_at_out_of_range_returns_zero() {
-    let bo = SimpleBlockOutputs::new(4);
+    let bo = SimpleBlockOutputs::new(4, 1);
     assert_eq!(bo.get_at(99, 0, 0), 0.0);
 }

--- a/crates/modular_core/tests/dsp_fresh_tests.rs
+++ b/crates/modular_core/tests/dsp_fresh_tests.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use modular_core::dsp::{get_constructors, get_params_deserializers};
 use modular_core::params::DeserializedParams;
 use modular_core::patch::Patch;
-use modular_core::types::{ModuleState, PatchGraph, Sampleable};
+use modular_core::types::{ModuleSpec, PatchGraph, Sampleable};
 use serde_json::{Value, json};
 
 /// Helper — build a mini-notation payload shaped like what `$p(source)`
@@ -472,7 +472,7 @@ fn make_graph(modules: Vec<(&str, &str, serde_json::Value)>) -> PatchGraph {
     PatchGraph {
         modules: modules
             .into_iter()
-            .map(|(id, module_type, params)| ModuleState {
+            .map(|(id, module_type, params)| ModuleSpec {
                 id: id.to_string(),
                 module_type: module_type.to_string(),
                 id_is_explicit: None,

--- a/crates/modular_core/tests/peggy_parser_parity.rs
+++ b/crates/modular_core/tests/peggy_parser_parity.rs
@@ -132,8 +132,8 @@ fn rust_descent_parser_matches_peggy_for_overlapping_grammar() {
              regenerate with: yarn gen:parser-parity-fixture",
         )
     });
-    let rows: Vec<ParityRow> = serde_json::from_str(&text)
-        .expect("peggy_parser_parity.json must parse as ParityRow[]");
+    let rows: Vec<ParityRow> =
+        serde_json::from_str(&text).expect("peggy_parser_parity.json must parse as ParityRow[]");
 
     assert!(
         rows.len() >= 20,
@@ -155,8 +155,7 @@ fn rust_descent_parser_matches_peggy_for_overlapping_grammar() {
                 continue;
             }
         };
-        let rust_json = serde_json::to_value(&rust_ast)
-            .expect("MiniAST must serialize to JSON");
+        let rust_json = serde_json::to_value(&rust_ast).expect("MiniAST must serialize to JSON");
         let rust_canonical = normalize(&rust_json);
         let peggy_canonical = normalize(&row.peggy_ast);
 

--- a/crates/modular_core/tests/profiling_integration.rs
+++ b/crates/modular_core/tests/profiling_integration.rs
@@ -11,7 +11,7 @@ use modular_core::profiling::{
     self, ModuleProfileAccum, build_seed, drain_collection, new_collection, swap_records,
     try_swap_shared,
 };
-use modular_core::types::{ModuleState, PatchGraph};
+use modular_core::types::{ModuleSpec, PatchGraph};
 use serde_json::json;
 
 const SAMPLE_RATE: f32 = 48000.0;
@@ -21,7 +21,7 @@ fn make_graph(modules: Vec<(&str, &str, serde_json::Value)>) -> PatchGraph {
     PatchGraph {
         modules: modules
             .into_iter()
-            .map(|(id, module_type, params)| ModuleState {
+            .map(|(id, module_type, params)| ModuleSpec {
                 id: id.to_string(),
                 module_type: module_type.to_string(),
                 id_is_explicit: None,

--- a/crates/modular_core/tests/sp_combine_strudel_parity.rs
+++ b/crates/modular_core/tests/sp_combine_strudel_parity.rs
@@ -64,8 +64,8 @@ fn parse_mode(s: &str) -> SpAlignmentMode {
 }
 
 fn parse_pattern(source: &str) -> Pattern<IntervalValue> {
-    let ast = mini::parse_ast(source)
-        .unwrap_or_else(|e| panic!("parse error for `{source}`: {e:?}"));
+    let ast =
+        mini::parse_ast(source).unwrap_or_else(|e| panic!("parse error for `{source}`: {e:?}"));
     mini::convert::<IntervalValue>(&ast)
         .unwrap_or_else(|e| panic!("convert error for `{source}`: {e:?}"))
 }
@@ -100,8 +100,7 @@ struct Extracted {
 }
 
 fn extract_actual(pat: &Pattern<IntervalValue>) -> Extracted {
-    let haps =
-        pat.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
+    let haps = pat.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
     let pre_filter_count = haps.len();
     let mut rest_count = 0usize;
     let mut out: Vec<CmpHap> = haps
@@ -130,8 +129,10 @@ fn extract_actual(pat: &Pattern<IntervalValue>) -> Extracted {
 }
 
 fn extract_expected(haps: &[FixtureHap]) -> Vec<CmpHap> {
-    let mut out: Vec<CmpHap> =
-        haps.iter().map(|h| (h.whole, h.part, h.value as i32)).collect();
+    let mut out: Vec<CmpHap> = haps
+        .iter()
+        .map(|h| (h.whole, h.part, h.value as i32))
+        .collect();
     out.sort_by(|a, b| sort_key(a).cmp(&sort_key(b)));
     out
 }
@@ -234,14 +235,12 @@ const FAILURE_RENDER_CAP: usize = 25;
 fn combine_sp_matches_strudel_for_full_grammar_cross() {
     ensure_fixtures();
     let path = fixture_path("sp_combine.json");
-    let text = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("missing fixture at {path:?}: {e}"));
-    let rows: Vec<Row1> =
-        serde_json::from_str(&text).expect("fixture must parse as Row1[]");
+    let text =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("missing fixture at {path:?}: {e}"));
+    let rows: Vec<Row1> = serde_json::from_str(&text).expect("fixture must parse as Row1[]");
 
     let mut failures: Vec<String> = Vec::new();
-    let mut hist: std::collections::BTreeMap<String, usize> =
-        std::collections::BTreeMap::new();
+    let mut hist: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
     let mut compared = 0usize;
 
     for row in &rows {
@@ -349,14 +348,12 @@ struct Row2 {
 fn combine_sp_chain2_matches_strudel() {
     ensure_fixtures();
     let path = fixture_path("sp_combine_chain2.json");
-    let text = fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("missing fixture at {path:?}: {e}"));
-    let rows: Vec<Row2> =
-        serde_json::from_str(&text).expect("fixture must parse as Row2[]");
+    let text =
+        fs::read_to_string(&path).unwrap_or_else(|e| panic!("missing fixture at {path:?}: {e}"));
+    let rows: Vec<Row2> = serde_json::from_str(&text).expect("fixture must parse as Row2[]");
 
     let mut failures: Vec<String> = Vec::new();
-    let mut hist: std::collections::BTreeMap<String, usize> =
-        std::collections::BTreeMap::new();
+    let mut hist: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
     let mut compared = 0usize;
 
     for row in &rows {
@@ -367,12 +364,15 @@ fn combine_sp_chain2_matches_strudel() {
             continue;
         };
         let mode1 = parse_mode(&row.mode1);
-        let mode2 = parse_mode(row.mode2.as_deref().unwrap_or_else(|| {
-            panic!("non-error row missing mode2: {row:?}")
-        }));
-        let op2 = row.op2.as_deref().unwrap_or_else(|| {
-            panic!("non-error row missing op2: {row:?}")
-        });
+        let mode2 = parse_mode(
+            row.mode2
+                .as_deref()
+                .unwrap_or_else(|| panic!("non-error row missing mode2: {row:?}")),
+        );
+        let op2 = row
+            .op2
+            .as_deref()
+            .unwrap_or_else(|| panic!("non-error row missing op2: {row:?}"));
 
         let lhs = parse_pattern(&row.lhs_source);
         let rhs1 = parse_pattern(&row.rhs1_source);

--- a/crates/modular_core/tests/types_tests.rs
+++ b/crates/modular_core/tests/types_tests.rs
@@ -64,7 +64,6 @@ impl Sampleable for DummySampleable {
 
 impl MessageHandler for DummySampleable {}
 
-
 fn make_empty_patch() -> Patch {
     Patch::new()
 }

--- a/crates/modular_derive/src/connect.rs
+++ b/crates/modular_derive/src/connect.rs
@@ -252,66 +252,71 @@ pub fn impl_connect_macro(ast: &DeriveInput) -> TokenStream {
 
     let (default_connection_stmts, connect_body, collect_cables_body, inject_index_body) =
         match &ast.data {
-        Data::Struct(data) => match &data.fields {
-            Fields::Named(fields) => {
-                let mut default_stmts = TokenStream2::new();
-                let mut connect_stmts = TokenStream2::new();
-                let mut collect_cables_stmts = TokenStream2::new();
-                let mut inject_index_stmts = TokenStream2::new();
+            Data::Struct(data) => match &data.fields {
+                Fields::Named(fields) => {
+                    let mut default_stmts = TokenStream2::new();
+                    let mut connect_stmts = TokenStream2::new();
+                    let mut collect_cables_stmts = TokenStream2::new();
+                    let mut inject_index_stmts = TokenStream2::new();
 
-                for field in fields.named.iter() {
-                    if let Err(e) = emit_field_named_struct(
-                        field,
-                        &mut default_stmts,
-                        &mut connect_stmts,
-                        &mut collect_cables_stmts,
-                        &mut inject_index_stmts,
-                    ) {
-                        return e.to_compile_error().into();
+                    for field in fields.named.iter() {
+                        if let Err(e) = emit_field_named_struct(
+                            field,
+                            &mut default_stmts,
+                            &mut connect_stmts,
+                            &mut collect_cables_stmts,
+                            &mut inject_index_stmts,
+                        ) {
+                            return e.to_compile_error().into();
+                        }
+                    }
+
+                    (
+                        default_stmts,
+                        connect_stmts,
+                        collect_cables_stmts,
+                        inject_index_stmts,
+                    )
+                }
+                Fields::Unnamed(_) | Fields::Unit => {
+                    return syn::Error::new(
+                        ast.span(),
+                        "#[derive(Connect)] on a struct requires named fields",
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+            },
+            Data::Enum(data) => {
+                let mut connect_arms = TokenStream2::new();
+                let mut collect_arms = TokenStream2::new();
+                let mut inject_arms = TokenStream2::new();
+                for variant in data.variants.iter() {
+                    match emit_variant_arms(name, variant) {
+                        Ok((c_arm, cc_arm, ii_arm)) => {
+                            connect_arms.extend(c_arm);
+                            connect_arms.extend(quote! { , });
+                            collect_arms.extend(cc_arm);
+                            collect_arms.extend(quote! { , });
+                            inject_arms.extend(ii_arm);
+                            inject_arms.extend(quote! { , });
+                        }
+                        Err(e) => return e.to_compile_error().into(),
                     }
                 }
-
-                (default_stmts, connect_stmts, collect_cables_stmts, inject_index_stmts)
-            }
-            Fields::Unnamed(_) | Fields::Unit => {
-                return syn::Error::new(
-                    ast.span(),
-                    "#[derive(Connect)] on a struct requires named fields",
+                (
+                    TokenStream2::new(),
+                    quote! { match self { #connect_arms } },
+                    quote! { match self { #collect_arms } },
+                    quote! { match self { #inject_arms } },
                 )
-                .to_compile_error()
-                .into();
             }
-        },
-        Data::Enum(data) => {
-            let mut connect_arms = TokenStream2::new();
-            let mut collect_arms = TokenStream2::new();
-            let mut inject_arms = TokenStream2::new();
-            for variant in data.variants.iter() {
-                match emit_variant_arms(name, variant) {
-                    Ok((c_arm, cc_arm, ii_arm)) => {
-                        connect_arms.extend(c_arm);
-                        connect_arms.extend(quote! { , });
-                        collect_arms.extend(cc_arm);
-                        collect_arms.extend(quote! { , });
-                        inject_arms.extend(ii_arm);
-                        inject_arms.extend(quote! { , });
-                    }
-                    Err(e) => return e.to_compile_error().into(),
-                }
+            Data::Union(_) => {
+                return syn::Error::new(ast.span(), "#[derive(Connect)] does not support unions")
+                    .to_compile_error()
+                    .into();
             }
-            (
-                TokenStream2::new(),
-                quote! { match self { #connect_arms } },
-                quote! { match self { #collect_arms } },
-                quote! { match self { #inject_arms } },
-            )
-        }
-        Data::Union(_) => {
-            return syn::Error::new(ast.span(), "#[derive(Connect)] does not support unions")
-                .to_compile_error()
-                .into();
-        }
-    };
+        };
 
     let generated = quote! {
         impl crate::types::Connect for #name {

--- a/crates/modular_derive/src/module_attr.rs
+++ b/crates/modular_derive/src/module_attr.rs
@@ -326,10 +326,7 @@ fn impl_module_macro_attr(
                     format!("{name}BlockOutputs")
                 };
                 last.ident = Ident::new(&new_name, last.ident.span());
-                Ok(Type::Path(syn::TypePath {
-                    qself: None,
-                    path,
-                }))
+                Ok(Type::Path(syn::TypePath { qself: None, path }))
             }
             _ => Err(syn::Error::new(
                 Span::call_site(),
@@ -390,9 +387,7 @@ fn impl_module_macro_attr(
                                 "_channel_count" => {
                                     Ok(quote! { _channel_count: deserialized.channel_count })
                                 }
-                                "_block_index" => {
-                                    Ok(quote! { _block_index: Default::default() })
-                                }
+                                "_block_index" => Ok(quote! { _block_index: Default::default() }),
                                 "outputs" | "state" => {
                                     Ok(quote! { #field_name: Default::default() })
                                 }
@@ -971,7 +966,7 @@ fn impl_module_macro_attr(
             fn get_schema() -> crate::types::ModuleSchema {
                 let params_schema = schemars::schema_for!(#params_struct_name);
                 let outputs = <#outputs_ty as crate::types::OutputStruct>::schemas();
-           
+
                 crate::types::ModuleSchema {
                     name: #module_name.to_string(),
                     documentation: #module_documentation_token,

--- a/crates/modular_derive/src/module_attr.rs
+++ b/crates/modular_derive/src/module_attr.rs
@@ -84,7 +84,7 @@ impl syn::parse::Parse for ModuleAttrArgs {
                     let lit: syn::LitInt = input.parse()?;
                     let n: u8 = lit.base10_parse()?;
                     // Must match modular_core::poly::PORT_MAX_CHANNELS
-                    const MAX: u8 = 16;
+                    const MAX: u8 = 64;
                     if n < 1 || n > MAX {
                         return Err(syn::Error::new(
                             lit.span(),
@@ -335,48 +335,60 @@ fn impl_module_macro_attr(
         }
     }
 
-    let (outputs_ty, module_field_inits, has_state_field): (Type, Vec<TokenStream2>, bool) =
-        match ast.data {
-            Data::Struct(ref data) => match data.fields {
-                Fields::Named(ref fields) => {
-                    // Disallow legacy per-field #[output] annotations on the module struct.
-                    if fields
-                        .named
-                        .iter()
-                        .any(|f| unwrap_attr(&f.attrs, "output").is_some())
-                    {
+    let (outputs_ty, module_field_inits, has_state_field, has_channel_state_field): (
+        Type,
+        Vec<TokenStream2>,
+        bool,
+        bool,
+    ) = match ast.data {
+        Data::Struct(ref data) => match data.fields {
+            Fields::Named(ref fields) => {
+                // Disallow legacy per-field #[output] annotations on the module struct.
+                if fields
+                    .named
+                    .iter()
+                    .any(|f| unwrap_attr(&f.attrs, "output").is_some())
+                {
+                    return Err(syn::Error::new(
+                        Span::call_site(),
+                        "#[module] expects an `outputs` field (a struct that derives Outputs); do not annotate module fields with #[output(...)]",
+                    ));
+                }
+
+                let outputs_field = fields
+                    .named
+                    .iter()
+                    .find(|f| f.ident.as_ref().map(|i| i == "outputs").unwrap_or(false));
+
+                let outputs_ty = match outputs_field {
+                    Some(f) => f.ty.clone(),
+                    None => {
                         return Err(syn::Error::new(
                             Span::call_site(),
-                            "#[module] expects an `outputs` field (a struct that derives Outputs); do not annotate module fields with #[output(...)]",
+                            "#[module] requires a field named `outputs` whose type derives Outputs",
                         ));
                     }
+                };
 
-                    let outputs_field = fields
-                        .named
-                        .iter()
-                        .find(|f| f.ident.as_ref().map(|i| i == "outputs").unwrap_or(false));
+                let has_state = fields
+                    .named
+                    .iter()
+                    .any(|f| f.ident.as_ref().map(|i| i == "state").unwrap_or(false));
+                let has_channel_state = fields.named.iter().any(|f| {
+                    f.ident
+                        .as_ref()
+                        .map(|i| i == "channel_state")
+                        .unwrap_or(false)
+                });
 
-                    let outputs_ty = match outputs_field {
-                        Some(f) => f.ty.clone(),
-                        None => {
-                            return Err(syn::Error::new(
-                                Span::call_site(),
-                                "#[module] requires a field named `outputs` whose type derives Outputs",
-                            ));
-                        }
-                    };
-
-                    let has_state = fields
-                        .named
-                        .iter()
-                        .any(|f| f.ident.as_ref().map(|i| i == "state").unwrap_or(false));
-
-                    // Generate per-field initialization for the inner module struct.
-                    // - `params` → use deserialized params
-                    // - `_channel_count` → use deserialized channel count
-                    // - `outputs` and `state` → use Default::default()
-                    // - other fields → error
-                    let field_inits: Vec<TokenStream2> = fields
+                // Generate per-field initialization for the inner module struct.
+                // - `params` → use deserialized params
+                // - `_channel_count` → use deserialized channel count
+                // - `outputs` and `state` → use Default::default()
+                // - `channel_state` → a boxed slice of `channel_count` default
+                //   elements (per-channel state, sized to the patch's channels)
+                // - other fields → error
+                let field_inits: Vec<TokenStream2> = fields
                         .named
                         .iter()
                         .map(|f| {
@@ -391,11 +403,17 @@ fn impl_module_macro_attr(
                                 "outputs" | "state" => {
                                     Ok(quote! { #field_name: Default::default() })
                                 }
+                                "channel_state" => Ok(quote! {
+                                    channel_state: (0..deserialized.channel_count)
+                                        .map(|_| ::core::default::Default::default())
+                                        .collect::<::std::vec::Vec<_>>()
+                                        .into_boxed_slice()
+                                }),
                                 other => Err(syn::Error::new(
                                     field_name.span(),
                                     format!(
-                                        "Module struct field `{other}` is not allowed. \
-                                     Only `state`, `outputs`, and `params` fields are permitted.",
+                                        "Module struct field `{other}` is not allowed. Only \
+                                     `state`, `channel_state`, `outputs`, and `params` are permitted.",
                                     ),
                                 )),
                             }
@@ -404,22 +422,22 @@ fn impl_module_macro_attr(
                         .into_iter()
                         .collect();
 
-                    (outputs_ty, field_inits, has_state)
-                }
-                Fields::Unnamed(_) | Fields::Unit => {
-                    return Err(syn::Error::new(
-                        Span::call_site(),
-                        "#[module] can only be applied to structs with named fields",
-                    ));
-                }
-            },
-            Data::Enum(_) | Data::Union(_) => {
+                (outputs_ty, field_inits, has_state, has_channel_state)
+            }
+            Fields::Unnamed(_) | Fields::Unit => {
                 return Err(syn::Error::new(
                     Span::call_site(),
-                    "#[module] can only be applied to structs",
+                    "#[module] can only be applied to structs with named fields",
                 ));
             }
-        };
+        },
+        Data::Enum(_) | Data::Union(_) => {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "#[module] can only be applied to structs",
+            ));
+        }
+    };
     let block_outputs_ty = block_outputs_type_from(&outputs_ty)?;
 
     let struct_name = format_ident!("{}Sampleable", name);
@@ -589,14 +607,39 @@ fn impl_module_macro_attr(
         quote! {}
     };
 
-    // Generate transfer_state_from body - only swap state if the module has a `state` field
-    let transfer_state_body = if has_state_field {
+    // Generate transfer_state_from body.
+    //
+    // `state` (module-level, non-per-channel) is always carried over with a
+    // swap — it is the same size in both modules.
+    let state_transfer = if has_state_field {
         quote! {
             std::mem::swap(&mut new_inner.state, &mut old_inner.state);
         }
     } else {
-        // No state field, nothing to transfer (buffer transfer handled below)
         quote! {}
+    };
+    // `channel_state` (per-channel) carries over the overlapping channels:
+    // equal lengths swap the whole boxed slice (O(1) pointer swap); otherwise
+    // the first `min(old, new)` channels are swapped element-wise and the
+    // surplus keeps its freshly-initialised value. Neither path allocates or
+    // clones on the audio thread.
+    let channel_state_transfer = if has_channel_state_field {
+        quote! {
+            let new_len = new_inner.channel_state.len();
+            let old_len = old_inner.channel_state.len();
+            if new_len == old_len {
+                std::mem::swap(&mut new_inner.channel_state, &mut old_inner.channel_state);
+            } else {
+                let n = new_len.min(old_len);
+                new_inner.channel_state[..n].swap_with_slice(&mut old_inner.channel_state[..n]);
+            }
+        }
+    } else {
+        quote! {}
+    };
+    let transfer_state_body = quote! {
+        #state_transfer
+        #channel_state_transfer
     };
 
     // Generate the channel count derivation function name
@@ -888,6 +931,10 @@ fn impl_module_macro_attr(
                     }
                     let new_inner = unsafe { &mut *self.module.get() };
                     let old_inner = unsafe { &mut *old_typed.module.get() };
+                    // Block-sized output buffers and per-channel state are sized
+                    // to the module's channel count, so they can only be moved
+                    // between modules of the same count.
+                    let same_channels = new_inner._channel_count == old_inner._channel_count;
                     #transfer_state_body
                     // Transfer buffer data (no-op for modules without buffer outputs)
                     crate::types::OutputStruct::transfer_buffers_from(
@@ -900,10 +947,14 @@ fn impl_module_macro_attr(
                     // Without this swap the "second" module in a cycle would
                     // see zeros from the freshly-constructed wrapper and
                     // inject a one-sample discontinuity into the feedback loop.
-                    unsafe {
-                        let new_block_outputs = &mut *self.block_outputs.get();
-                        let old_block_outputs = &mut *old_typed.block_outputs.get();
-                        std::mem::swap(new_block_outputs, old_block_outputs);
+                    // Skipped on a channel-count change: the buffers differ in
+                    // width, and the fresh wrapper's buffer is the correct size.
+                    if same_channels {
+                        unsafe {
+                            let new_block_outputs = &mut *self.block_outputs.get();
+                            let old_block_outputs = &mut *old_typed.block_outputs.get();
+                            std::mem::swap(new_block_outputs, old_block_outputs);
+                        }
                     }
                 }
             }
@@ -936,7 +987,7 @@ fn impl_module_macro_attr(
                 module: std::cell::UnsafeCell::new(inner),
                 argument_spans: std::cell::UnsafeCell::new(deserialized.argument_spans),
                 index: std::cell::Cell::new(0),
-                block_outputs: std::cell::UnsafeCell::new(<#block_outputs_ty>::new(_block_size)),
+                block_outputs: std::cell::UnsafeCell::new(<#block_outputs_ty>::new(_block_size, deserialized.channel_count)),
                 block_size: _block_size,
                 mode: _mode,
                 computing: std::cell::Cell::new(false),

--- a/crates/modular_derive/src/outputs.rs
+++ b/crates/modular_derive/src/outputs.rs
@@ -378,11 +378,21 @@ pub fn impl_outputs_macro(ast: &DeriveInput) -> TokenStream {
         })
         .collect();
 
+    // Each port is sized to its true width: f32 outputs are mono (1 channel,
+    // broadcast to consumers via cycling-on-read), PolyOutput ports get the
+    // module's derived channel count.
     let block_new_inits: Vec<_> = outputs
         .iter()
         .map(|o| {
             let field_name = &o.field_name;
-            quote! { #field_name: crate::block_port::BlockPort::new(block_size) }
+            match o.precision {
+                OutputPrecision::F32 => {
+                    quote! { #field_name: crate::block_port::BlockPort::new(block_size, 1) }
+                }
+                OutputPrecision::PolySignal => {
+                    quote! { #field_name: crate::block_port::BlockPort::new(block_size, channel_count) }
+                }
+            }
         })
         .collect();
 
@@ -414,26 +424,21 @@ pub fn impl_outputs_macro(ast: &DeriveInput) -> TokenStream {
             let field_name = &o.field_name;
             match o.precision {
                 OutputPrecision::F32 => quote! {
-                    // Broadcast the mono f32 value to every channel slot.
-                    // Mirrors the old `PolyOutput::mono(value).get_cycling(ch)`
-                    // path that downstream cables relied on: an f32 output
-                    // reads as the same value on any consumer channel rather
-                    // than silence on channels >= 1.
-                    let v = inner.#field_name;
-                    for ch in 0..crate::poly::PORT_MAX_CHANNELS {
-                        self.#field_name.data[slot][ch] = v;
-                    }
+                    // f32 output is mono: write the single value to the port's
+                    // one channel. Consumers on any channel read it back via
+                    // BlockPort::get's cycling (`ch % 1 == 0`), preserving the
+                    // mono-broadcast semantics downstream cables rely on.
+                    self.#field_name.set(slot, 0, inner.#field_name);
                 },
                 OutputPrecision::PolySignal => quote! {
                     {
-                        // `get_cycling` mirrors the old `PolyOutput::get_cycling`
-                        // semantics that `get_poly_sample(...).get_cycling(ch)`
-                        // used to provide: a mono producer broadcasts its single
-                        // value to all consumer channels rather than producing
-                        // silence on channels >= producer channel count.
+                        // Write each of this port's channels. `get_cycling`
+                        // fills the port even when the producer is narrower
+                        // than the port width; reads at higher consumer
+                        // channels wrap via BlockPort::get's modulo.
                         let poly = &inner.#field_name;
-                        for ch in 0..crate::poly::PORT_MAX_CHANNELS {
-                            self.#field_name.data[slot][ch] = poly.get_cycling(ch);
+                        for ch in 0..self.#field_name.channels() {
+                            self.#field_name.set(slot, ch, poly.get_cycling(ch));
                         }
                     }
                 },
@@ -449,8 +454,10 @@ pub fn impl_outputs_macro(ast: &DeriveInput) -> TokenStream {
         }
 
         impl #block_outputs_name {
-            /// Allocate all ports for the given block size. Call only on the main thread.
-            pub fn new(block_size: usize) -> Self {
+            /// Allocate all ports for the given block size and channel count.
+            /// Call only on the main thread. f32 ports are mono; PolyOutput
+            /// ports are sized to `channel_count`.
+            pub fn new(block_size: usize, channel_count: usize) -> Self {
                 Self {
                     #(#block_new_inits,)*
                 }

--- a/src/main/dsl/GraphBuilder.ts
+++ b/src/main/dsl/GraphBuilder.ts
@@ -1,6 +1,6 @@
 import type {
     ModuleSchema,
-    ModuleState,
+    ModuleSpec,
     PatchGraph,
     Scope,
     ScopeChannel,
@@ -18,7 +18,7 @@ import { captureSourceLocation } from './captureSourceLocation';
 
 import z from 'zod';
 
-export const PORT_MAX_CHANNELS = 16;
+export const PORT_MAX_CHANNELS = 64;
 
 /** Exponent used by .gain() for perceptual amplitude curve */
 const GAIN_CURVE_EXP = 3;
@@ -575,7 +575,7 @@ export interface SourceLocation {
  * consistency across all module creation paths.
  */
 export class GraphBuilder {
-    private modules = new Map<string, ModuleState>();
+    private modules = new Map<string, ModuleSpec>();
     private counters = new Map<string, number>();
     private schemas: ProcessedModuleSchema[] = [];
     private schemaByName = new Map<string, ProcessedModuleSchema>();
@@ -705,7 +705,7 @@ export class GraphBuilder {
             });
         }
 
-        const moduleState: ModuleState = {
+        const moduleState: ModuleSpec = {
             id,
             idIsExplicit: Boolean(explicitId),
             moduleType,
@@ -719,7 +719,7 @@ export class GraphBuilder {
     /**
      * Get a module by ID
      */
-    getModule(id: string): ModuleState | undefined {
+    getModule(id: string): ModuleSpec | undefined {
         return this.modules.get(id);
     }
 

--- a/src/main/dsl/executor.ts
+++ b/src/main/dsl/executor.ts
@@ -26,6 +26,7 @@ import {
     Bus,
     ModuleOutput,
     replaceSignals,
+    PORT_MAX_CHANNELS,
 } from './GraphBuilder';
 import { analyzeSourceSpans } from './analyzeSource';
 import type { CallSiteSpanRegistry } from './analyzeSource';
@@ -211,7 +212,7 @@ export function executePatchScript(
         // and costs a per-sample read on the audio thread, so an uncapped
         // max(len(x), len(y)) would let user input balloon audio-thread work
         // for traces that are never shown.
-        const MAX_SCOPE_XY_TRACES = 16;
+        const MAX_SCOPE_XY_TRACES = 64;
         const requested = Math.max(xs.length, ys.length);
         const n = Math.min(requested, MAX_SCOPE_XY_TRACES);
         if (requested > MAX_SCOPE_XY_TRACES) {
@@ -242,12 +243,12 @@ export function executePatchScript(
     /**
      * Create a DeferredCollection with placeholder signals that can be assigned later.
      * Useful for feedback loops and forward references.
-     * @param channels - Number of deferred outputs (1-16, default 1)
+     * @param channels - Number of deferred outputs (1-64, default 1)
      */
     const $deferred = (channels: number = 1): DeferredCollection => {
-        if (channels < 1 || channels > 16) {
+        if (channels < 1 || channels > PORT_MAX_CHANNELS) {
             throw new Error(
-                `deferred() channels must be between 1 and 16, got ${channels}`,
+                `deferred() channels must be between 1 and ${PORT_MAX_CHANNELS}, got ${channels}`,
             );
         }
         const items: DeferredModuleOutput[] = [];

--- a/src/main/dsl/typescriptLibGen.ts
+++ b/src/main/dsl/typescriptLibGen.ts
@@ -1289,7 +1289,7 @@ function $setTimeSignature(numerator: number, denominator: number): void;
 /**
  * Create a DeferredCollection with placeholder signals that can be assigned later.
  * Useful for feedback loops and forward references.
- * @param channels - Number of deferred outputs (1-16, default 1)
+ * @param channels - Number of deferred outputs (1-64, default 1)
  * @example
  * const feedback = $deferred();
  * const delayed = $delay(osc.out, feedback[0]);

--- a/src/main/patchSimilarityRemap.ts
+++ b/src/main/patchSimilarityRemap.ts
@@ -1,6 +1,6 @@
 import type { PatchGraph } from '../shared/ipcTypes';
 
-type ModuleState = PatchGraph['modules'][number];
+type ModuleSpec = PatchGraph['modules'][number];
 
 const RESERVED_MODULE_IDS = new Set([
     'ROOT_OUTPUT',
@@ -23,7 +23,7 @@ function isLikelyImplicitId(id: string, moduleType: string): boolean {
     return re.test(id);
 }
 
-function isExplicitId(module: Pick<ModuleState, 'id' | 'moduleType'>): boolean {
+function isExplicitId(module: Pick<ModuleSpec, 'id' | 'moduleType'>): boolean {
     // Prefer the real DSL-provided flag when present.
     // (napi-rs typically maps Option<bool> to `boolean | null | undefined` in TS)
     const maybeFlag = (module as unknown as { idIsExplicit?: boolean | null })
@@ -187,7 +187,7 @@ function _canonicalizeForFingerprint(
 
 function extractFeatures(
     ctx: Pick<GraphContext, 'typeById'>,
-    module: ModuleState,
+    module: ModuleSpec,
 ): Map<string, Feature> {
     const features = new Map<string, Feature>();
 
@@ -431,9 +431,9 @@ function multisetJaccard(
 
 function moduleSimilarity(
     desiredGraph: PatchGraph,
-    desired: ModuleState,
+    desired: ModuleSpec,
     currentGraph: PatchGraph,
-    current: ModuleState,
+    current: ModuleSpec,
     desiredDownstream: Map<string, Map<string, number>>,
     currentDownstream: Map<string, Map<string, number>>,
     desiredCtx: GraphContext,
@@ -641,12 +641,12 @@ export function reconcilePatchBySimilarity(
     const ambiguityMargin = options.ambiguityMargin ?? DEFAULT_AMBIGUITY_MARGIN;
     const { debugLog } = options;
 
-    const currentById = new Map<string, ModuleState>();
+    const currentById = new Map<string, ModuleSpec>();
     for (const m of currentGraph.modules) {
         currentById.set(m.id, m);
     }
 
-    const desiredById = new Map<string, ModuleState>();
+    const desiredById = new Map<string, ModuleSpec>();
     for (const m of desiredGraph.modules) {
         desiredById.set(m.id, m);
     }
@@ -693,8 +693,8 @@ export function reconcilePatchBySimilarity(
 
     // 2) Per-type optimal assignment for remaining modules.
 
-    const desiredByType = new Map<string, ModuleState[]>();
-    const currentByType = new Map<string, ModuleState[]>();
+    const desiredByType = new Map<string, ModuleSpec[]>();
+    const currentByType = new Map<string, ModuleSpec[]>();
 
     for (const desired of desiredGraph.modules) {
         if (RESERVED_MODULE_IDS.has(desired.id)) {

--- a/src/renderer/app/scopexy/lanczos.ts
+++ b/src/renderer/app/scopexy/lanczos.ts
@@ -1,8 +1,9 @@
 // Sample-buffer dimensions and the GPU Lanczos upsampler kernel for the XY
 // scope. SCOPE_XY_CAPACITY mirrors the Rust ring size (audio.rs); MAX_TRACES
-// caps how many traces the pipeline draws (and the DSL pair count).
+// caps how many traces the pipeline draws (and the DSL pair count) — one per
+// channel, so it matches PORT_MAX_CHANNELS.
 
-export const MAX_TRACES = 16;
+export const MAX_TRACES = 64;
 export const SCOPE_XY_CAPACITY = 2048;
 
 // Lanczos upsampler tuning: each input sample produces STEPS interpolated

--- a/src/shared/dsl/typeDocs.ts
+++ b/src/shared/dsl/typeDocs.ts
@@ -651,7 +651,7 @@ export const GLOBAL_DOCS: GlobalFunctionDoc[] = [
             {
                 name: 'channels',
                 type: 'number',
-                description: 'Number of deferred outputs (1-16, default 1)',
+                description: 'Number of deferred outputs (1-64, default 1)',
             },
         ],
         returns: 'DeferredCollection',


### PR DESCRIPTION
## Summary

Polyphonic signal buffers were always allocated to a fixed **16 channels**, regardless of how many a patch actually used. This makes every per-channel allocation **dynamic** — sized to the patch's real channel count — and raises the hard cap to **64**.

Because allocation is now dynamic, the higher cap costs nothing for patches that don't use the channels: only the patches that go wide pay for it.

## What changed

**Dynamic allocation (all on the main thread at construction; never on the audio thread):**
- `PolySignal` / `PolyOutput` / `BlockPort` and every module's per-channel state become `Box<[T]>` sized to `channel_count`.
- `BlockPort` flattened to a `block_size * channels` slice; cycling moved to **read time** (`ch % width`) so a mono producer still broadcasts to a poly consumer after the buffers shrank.

**Cap raised 16 → 64:** `PORT_MAX_CHANNELS` (Rust + TS mirror) and the `#[module(channels = N)]` validator. scopeXY's trace cap (`MAX_TRACES` / `MAX_SCOPE_XY_TRACES`) raised to match so it draws all channels.

**Module state split into two `#[module]`-managed fields:**
- `state: FooState` — module-level scalars; transferred by swap.
- `channel_state: Box<[FooChannel]>` — per-channel; sized to `channel_count`; transferred by carrying over the overlapping channels (swap the whole slice on equal length, else element-swap the `min` prefix and leave the surplus freshly initialized) — no allocation or clone on the audio thread.

Removes the interim `ModuleState` trait / `#[derive(ModuleState)]` / `#[channels]` machinery. Renames the patch-graph `ModuleState` type to `ModuleSpec` to free the name (wire format unchanged — the struct name isn't serialized).

~40 DSP modules converted; special cases handled by hand (lowpass 7 arrays → one channel struct, midi_cv/seq combined channel structs, supersaw phase matrix, plaits voices, stereo_mixer input-sized pan state, dattorro/plate fixed-topology reverbs).

## Verification

| Check | Result |
|---|---|
| `cargo test -p modular_core` | 537 pass |
| `cargo test -p modular` | 67 pass |
| `yarn build-native` | ok (schemas/`index.d.ts` only reflect doc + `ModuleSpec` rename) |
| `yarn test:unit` | 395 pass |
| `yarn typecheck` | clean |

`dsp_fresh_tests` (poly reads at ch 0/1, feedback prev-slot reads) verifies the cycling-on-read correctness end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
