### PR TITLE
feat(seq): add ribbon loop window to $cycle

### DIFF
--- a/crates/modular/schemas.json
+++ b/crates/modular/schemas.json
@@ -7811,6 +7811,28 @@
               "type": "null"
             }
           ]
+        },
+        "ribbon": {
+          "description": "loop window [offset, length] in cycles",
+          "type": "array",
+          "default": [
+            0,
+            1024
+          ],
+          "maxItems": 2,
+          "minItems": 2,
+          "prefixItems": [
+            {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          ]
         }
       },
       "required": [

--- a/crates/modular/schemas.json
+++ b/crates/modular/schemas.json
@@ -7813,24 +7813,22 @@
           ]
         },
         "ribbon": {
-          "description": "loop window [offset, length] in cycles",
+          "description": "loop window [offset, length] in cycles (fractional allowed)",
           "type": "array",
           "default": [
-            0,
-            1024
+            0.0,
+            1024.0
           ],
           "maxItems": 2,
           "minItems": 2,
           "prefixItems": [
             {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0
+              "type": "number",
+              "format": "double"
             },
             {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0
+              "type": "number",
+              "format": "double"
             }
           ]
         }

--- a/crates/modular_core/src/dsp/seq/cache.rs
+++ b/crates/modular_core/src/dsp/seq/cache.rs
@@ -1,9 +1,8 @@
 //! Shared cycle-cache primitives for the pattern-based sequencer modules.
 //!
-//! `Seq` caches pre-computed hap data in two tiers:
-//! the param cache (cycles `0..PARAM_CACHE_CYCLES`, built at parse time on
-//! the main thread) and the audio-thread module cache (cycles past the
-//! param cache horizon, up to `MAX_MODULE_CYCLES` slots, populated lazily).
+//! `Seq` bakes every cycle of its ribbon loop window `[offset, offset+length)`
+//! once at parse time on the main thread, then loops that window forever — the
+//! audio thread never re-evaluates the pattern.
 //!
 //! Each cycle's data lives in a [`CycleStorage`] holding two parallel
 //! pre-sized `Vec`s: one of scalar haps `H`, one of span entries `S`.
@@ -13,23 +12,12 @@
 
 use crate::pattern_system::{ArenaHap, Pattern};
 
-/// Number of cycles pre-computed at parse time on the main thread. Cycles
-/// beyond this fall through to the per-module audio-thread cache.
-pub(crate) const PARAM_CACHE_CYCLES: usize = 1024;
-
-/// Maximum number of cycles cached by the audio thread past the param
-/// cache. Slots are pre-allocated, so this is a memory/latency tradeoff.
-pub(crate) const MAX_MODULE_CYCLES: usize = 64;
-
-/// Heuristic floor for `max_haps_per_cycle`. Keeps the per-slot Vec from
-/// reallocating on an occasional cycle whose hap count exceeds the
-/// param-time observed maximum.
+/// Initial per-slot `haps` Vec capacity used when baking a cycle. A floor so
+/// the bake-time `push` loop rarely reallocates; the main-thread bake may grow
+/// it past this for dense cycles.
 pub(crate) const MIN_HAPS_CAP_HINT: usize = 16;
 
-/// Heuristic floor for `max_spans_per_cycle`.
-pub(crate) const MIN_SPANS_CAP_HINT: usize = 32;
-
-/// Initial span_arena sizing per cached cycle.
+/// Initial span_arena sizing per cached cycle (`MIN_HAPS_CAP_HINT * this`).
 pub(crate) const SPANS_RESERVE_PER_HAP: usize = 4;
 
 /// Flat span entry tagged with the source pattern it belongs to. Used by
@@ -75,57 +63,18 @@ impl<H, S> CycleStorage<H, S> {
     }
 }
 
-/// Pre-allocate `module_cache` to [`MAX_MODULE_CYCLES`] slots, each sized
-/// to the supplied capacity hints. Call from the main thread on patch
-/// update so the audio thread never reallocates the cache.
-pub(crate) fn rebuild_module_cache<H, S>(
-    module_cache: &mut Vec<CycleStorage<H, S>>,
-    module_cache_populated: &mut Vec<bool>,
-    hap_cap: usize,
-    span_cap: usize,
-) {
-    module_cache.clear();
-    module_cache.reserve_exact(MAX_MODULE_CYCLES);
-    for _ in 0..MAX_MODULE_CYCLES {
-        module_cache.push(CycleStorage::with_capacity(hap_cap, span_cap));
-    }
-    module_cache_populated.clear();
-    module_cache_populated.resize(MAX_MODULE_CYCLES, false);
-}
-
-/// Clear every slot's content but keep their allocated capacities. Reset
-/// the populated flags. Voices keep their cached scalar copy so any
-/// sounding note can still be released by its `whole_end` afterwards.
-pub(crate) fn invalidate_module_cache<H, S>(
-    module_cache: &mut [CycleStorage<H, S>],
-    module_cache_populated: &mut [bool],
-) {
-    for slot in module_cache.iter_mut() {
-        slot.reset();
-    }
-    for p in module_cache_populated.iter_mut() {
-        *p = false;
-    }
-}
-
-/// Look up `cycle`'s storage. Cycles in `0..PARAM_CACHE_CYCLES` come from
-/// the param cache; later cycles come from the audio-thread module cache
-/// (if a slot has been populated for that cycle).
-pub(crate) fn get_cycle_storage<'a, H, S>(
+/// Look up `cycle`'s storage in the baked ribbon window. `cached` holds the
+/// haps for cycles `[offset, offset+cached.len())`; a `cycle` below `offset`
+/// or past the end of the window has no storage.
+pub(crate) fn get_cycle_storage<H, S>(
     cycle: i64,
-    param_cache: &'a [CycleStorage<H, S>],
-    module_cache: &'a [CycleStorage<H, S>],
-    module_cache_populated: &[bool],
-) -> Option<&'a CycleStorage<H, S>> {
-    if cycle < PARAM_CACHE_CYCLES as i64 {
-        param_cache.get(cycle as usize)
+    offset: u64,
+    cached: &[CycleStorage<H, S>],
+) -> Option<&CycleStorage<H, S>> {
+    if cycle < offset as i64 {
+        None
     } else {
-        let module_idx = (cycle - PARAM_CACHE_CYCLES as i64) as usize;
-        if module_idx < module_cache.len() && module_cache_populated[module_idx] {
-            Some(&module_cache[module_idx])
-        } else {
-            None
-        }
+        cached.get((cycle - offset as i64) as usize)
     }
 }
 

--- a/crates/modular_core/src/dsp/seq/cache.rs
+++ b/crates/modular_core/src/dsp/seq/cache.rs
@@ -64,17 +64,17 @@ impl<H, S> CycleStorage<H, S> {
 }
 
 /// Look up `cycle`'s storage in the baked ribbon window. `cached` holds the
-/// haps for cycles `[offset, offset+cached.len())`; a `cycle` below `offset`
-/// or past the end of the window has no storage.
+/// haps for cycles `[base, base+cached.len())` where `base = floor(offset)`; a
+/// `cycle` below `base` or past the end of the window has no storage.
 pub(crate) fn get_cycle_storage<H, S>(
     cycle: i64,
-    offset: u64,
+    base: i64,
     cached: &[CycleStorage<H, S>],
 ) -> Option<&CycleStorage<H, S>> {
-    if cycle < offset as i64 {
+    if cycle < base {
         None
     } else {
-        cached.get((cycle - offset as i64) as usize)
+        cached.get((cycle - base) as usize)
     }
 }
 

--- a/crates/modular_core/src/dsp/seq/seq.rs
+++ b/crates/modular_core/src/dsp/seq/seq.rs
@@ -18,6 +18,7 @@ use arrayvec::ArrayVec;
 use crate::{
     MonoSignal,
     dsp::utils::{TempGate, TempGateState, min_gate_samples},
+    param_errors::ModuleParamErrors,
     poly::{MonoSignalExt, PORT_MAX_CHANNELS, PolyOutput},
 };
 
@@ -29,19 +30,27 @@ use super::seq_value::{SeqCycleStorage, SeqPatternParam, SeqValue};
 struct CachedHap {
     /// Index of this hap within the owning cycle's `haps` vector.
     hap_index: u32,
-    /// The cycle this hap belongs to.
+    /// The baked cycle this hap belongs to, in `[offset, offset+length)`.
     cached_cycle: i64,
-    /// Cached `whole_begin` for the release check.
+    /// `whole_begin` in the pattern's logical (cycle) frame. Kept for
+    /// `get_state` highlight geometry; NOT used for release, since the
+    /// logical frame wraps at the ribbon seam.
     whole_begin: f64,
-    /// Cached `whole_end` for the release check.
+    /// `whole_end` in the logical frame (see `whole_begin`).
     whole_end: f64,
+    /// Note onset in the monotonic clock (`raw`) frame.
+    raw_begin: f64,
+    /// Note end in the monotonic clock (`raw`) frame. Release keys off `raw`
+    /// so a note plays its full length across the ribbon wrap, where the
+    /// logical frame is non-monotonic.
+    raw_end: f64,
     /// Cached value for CV/rest detection.
     value: SeqValue,
 }
 
 impl CachedHap {
-    fn contains(&self, playhead: f64) -> bool {
-        playhead >= self.whole_begin && playhead < self.whole_end
+    fn contains(&self, raw: f64) -> bool {
+        raw >= self.raw_begin && raw < self.raw_end
     }
 
     fn get_cv(&self) -> Option<f64> {
@@ -87,9 +96,25 @@ fn default_channels() -> usize {
     4
 }
 
+/// Default ribbon loop length in cycles. Same memory/cost as the old
+/// param cache (cycles `0..1024` baked at parse time).
+const DEFAULT_RIBBON_LENGTH: u64 = 1024;
+
+/// Largest ribbon loop length. The whole window bakes synchronously on the
+/// main thread on every pattern/ribbon edit, so it is capped.
+const MAX_RIBBON_LENGTH: u64 = 8192;
+
+/// Largest ribbon offset. Generous, and keeps `offset + length` exact in
+/// `f64` (well under 2^53).
+const MAX_RIBBON_OFFSET: u64 = 1_000_000;
+
+fn default_ribbon() -> (u64, u64) {
+    (0, DEFAULT_RIBBON_LENGTH)
+}
+
 #[derive(Clone, Deserr, ChannelCount, JsonSchema, Connect, Debug, SignalParams)]
 #[serde(rename_all = "camelCase")]
-#[deserr(rename_all = camelCase, deny_unknown_fields)]
+#[deserr(rename_all = camelCase, deny_unknown_fields, validate = seq_bake_ribbon -> ModuleParamErrors)]
 pub struct SeqParams {
     /// pattern string in mini-notation
     pattern: SeqPatternParam,
@@ -101,11 +126,52 @@ pub struct SeqParams {
     /// Number of polyphonic voices (1-16)
     #[deserr(default)]
     pub channels: Option<usize>,
+    /// loop window [offset, length] in cycles
+    #[serde(default = "default_ribbon")]
+    #[deserr(default = default_ribbon())]
+    ribbon: (u64, u64),
     /// The pattern string (used for serialization)
     #[serde(skip)]
     #[deserr(skip)]
     #[schemars(skip)]
     pub pattern_source: String,
+}
+
+/// Struct-level `deserr` validate hook. Runs after every field (and its
+/// default) is deserialized but before channel-count derivation, so both
+/// `pattern` and `ribbon` are present. Validates the ribbon bounds, then
+/// bakes the pattern's haps for the loop window `[offset, offset+length)`.
+fn seq_bake_ribbon(
+    mut params: SeqParams,
+    _location: deserr::ValuePointerRef,
+) -> Result<SeqParams, ModuleParamErrors> {
+    let (offset, length) = params.ribbon;
+    if length == 0 {
+        let mut err = ModuleParamErrors::default();
+        err.add(
+            "ribbon".to_string(),
+            "ribbon loop length must be greater than 0".to_string(),
+        );
+        return Err(err);
+    }
+    if length > MAX_RIBBON_LENGTH {
+        let mut err = ModuleParamErrors::default();
+        err.add(
+            "ribbon".to_string(),
+            format!("ribbon loop length must be {MAX_RIBBON_LENGTH} cycles or fewer"),
+        );
+        return Err(err);
+    }
+    if offset > MAX_RIBBON_OFFSET {
+        let mut err = ModuleParamErrors::default();
+        err.add(
+            "ribbon".to_string(),
+            format!("ribbon offset must be {MAX_RIBBON_OFFSET} cycles or fewer"),
+        );
+        return Err(err);
+    }
+    params.pattern.bake(offset, length);
+    Ok(params)
 }
 
 /// Channel count derivation for Seq.
@@ -280,7 +346,6 @@ struct SeqOutputs {
     channels_derive = seq_derive_channel_count,
     args(pattern),
     stateful,
-    patch_update,
 )]
 pub struct Seq {
     outputs: SeqOutputs,
@@ -288,34 +353,18 @@ pub struct Seq {
     state: SeqState,
 }
 
-/// Number of cycles pre-computed at parse time on the main thread.
-/// Cycles beyond this fall through to module_cache on the audio thread.
-use super::cache::PARAM_CACHE_CYCLES;
-
 /// State for the Seq module.
 struct SeqState {
     /// Per-voice state array
     voices: [VoiceState; PORT_MAX_CHANNELS],
     /// Round-robin voice index for allocation
     next_voice: usize,
-    /// Current cycle number (integer part of playhead)
-    current_cycle: Option<i64>,
-    /// Module-level cache for cycles >= PARAM_CACHE_CYCLES. Pre-allocated to
-    /// MAX_MODULE_CYCLES slots at patch update time.
-    module_cache: Vec<SeqCycleStorage>,
-    /// Parallel `populated[i] == true` iff `module_cache[i]` was filled for
-    /// cycle `PARAM_CACHE_CYCLES + i`.
-    module_cache_populated: Vec<bool>,
     /// Last CV voltage per channel — holds through rest periods and state transfers
     last_cv: [f32; PORT_MAX_CHANNELS],
     /// Scratch buffer for voice release — reused each frame to avoid heap alloc
     voices_to_release: ArrayVec<usize, PORT_MAX_CHANNELS>,
     /// Scratch buffer for onset events awaiting voice allocation.
     events_to_process: ArrayVec<PendingEvent, PORT_MAX_CHANNELS>,
-    /// Bumpalo arena reused across `ensure_cycle_cached` calls. Reset before
-    /// each miss-path query so the pattern_system combinator chain allocates
-    /// intermediates from a single chunk.
-    query_arena: bumpalo::Bump,
 }
 
 impl Default for SeqState {
@@ -323,94 +372,53 @@ impl Default for SeqState {
         Self {
             voices: std::array::from_fn(|_| VoiceState::default()),
             next_voice: 0,
-            current_cycle: None,
-            module_cache: Vec::new(),
-            module_cache_populated: Vec::new(),
             last_cv: [0.0; PORT_MAX_CHANNELS],
             voices_to_release: ArrayVec::new(),
             events_to_process: ArrayVec::new(),
-            query_arena: bumpalo::Bump::new(),
         }
     }
 }
 
 impl Seq {
-    /// Invalidate the cycle cache. Keeps allocated Vec capacities so the
-    /// audio thread can re-fill without reallocation.
-    fn invalidate_cache(&mut self) {
-        self.state.current_cycle = None;
-        super::cache::invalidate_module_cache(
-            &mut self.state.module_cache,
-            &mut self.state.module_cache_populated,
-        );
-    }
-
-    /// Resize the module_cache to MAX_MODULE_CYCLES with each slot pre-sized
-    /// to the param's capacity hints. Called on patch update.
-    fn rebuild_module_cache(&mut self) {
-        super::cache::rebuild_module_cache(
-            &mut self.state.module_cache,
-            &mut self.state.module_cache_populated,
-            self.params.pattern.max_haps_per_cycle(),
-            self.params.pattern.max_spans_per_cycle(),
-        );
-    }
-
-    /// Ensure that the given cycle's haps are available. For cycles
-    /// `0..PARAM_CACHE_CYCLES` the param cache already has them. For cycles
-    /// in the audio-thread cache range, fill the slot in place using the
-    /// reusable bumpalo arena.
-    fn ensure_cycle_cached(&mut self, cycle: i64) {
-        if cycle < PARAM_CACHE_CYCLES as i64 {
-            return;
-        }
-        let module_idx = (cycle - PARAM_CACHE_CYCLES as i64) as usize;
-        if module_idx >= self.state.module_cache.len() {
-            return; // Beyond cache horizon
-        }
-        if self.state.module_cache_populated[module_idx] {
-            return;
-        }
-        let Some(pattern) = self.params.pattern.pattern() else {
-            return;
-        };
-        let slot = &mut self.state.module_cache[module_idx];
-        super::seq_value::populate_cycle_storage(
-            pattern,
-            cycle,
-            &mut self.state.query_arena,
-            slot,
-        );
-        self.state.module_cache_populated[module_idx] = true;
-    }
-
-    /// Look up the storage for `cycle` from param cache or module cache.
+    /// Look up the storage for `cycle` in the baked ribbon window.
     fn get_cycle_storage(&self, cycle: i64) -> Option<&SeqCycleStorage> {
         super::cache::get_cycle_storage(
             cycle,
+            self.params.ribbon.0,
             self.params.pattern.cached_haps(),
-            &self.state.module_cache,
-            &self.state.module_cache_populated,
         )
     }
 
     fn update(&mut self, sample_rate: f32) {
-        let playhead = self.params.playhead.value_or_zero() as f64;
+        // `raw` is the monotonic clock playhead (cycles, fractional). The
+        // ribbon folds it into the baked window with an unsigned modulo:
+        // clock cycle 0 maps to baked cycle `offset`, and the window loops
+        // forever, phase-locked to the clock.
+        let raw = self.params.playhead.value_or_zero() as f64;
         let hold = min_gate_samples(sample_rate);
         let num_channels = self.channel_count();
-        let current_cycle = playhead.floor() as i64;
 
-        // On a new cycle, populate the module cache slot if needed.
-        if self.state.current_cycle != Some(current_cycle) {
-            self.ensure_cycle_cached(current_cycle);
-            self.state.current_cycle = Some(current_cycle);
-        }
+        let (offset, length) = self.params.ribbon; // length > 0 (validated)
+        // Fold the clock into the baked window. Clamp once for the window math
+        // so a (deliberately wired) negative playhead pins to the cycle start
+        // rather than producing a spurious mid-cycle phase. Release below keys
+        // off the unclamped monotonic `raw`, tracking each note's true span.
+        let raw_clamped = raw.max(0.0);
+        let raw_cycle = raw_clamped.floor() as u64;
+        let slot = raw_cycle % length; // 0..length
+        let current_cycle = (offset + slot) as i64; // baked cycle ∈ [offset, offset+length)
+        // Playhead in the baked cycle's logical frame — the same absolute
+        // frame the cycle's haps live in, so onset / `already_assigned`
+        // checks work exactly as before.
+        let logical = current_cycle as f64 + (raw_clamped - raw_clamped.floor());
 
-        // Release voices whose haps have ended.
+        // Release voices whose notes have ended. A note's life is tracked in
+        // the monotonic `raw` frame (two-sided, so a backward scrub also
+        // frees), because `logical` wraps at the ribbon seam.
         self.state.voices_to_release.clear();
         for i in 0..num_channels {
             if let Some(cached) = self.state.voices[i].cached_hap {
-                if !cached.contains(playhead) {
+                if !cached.contains(raw) {
                     self.state.voices_to_release.push(i);
                 }
             }
@@ -442,24 +450,13 @@ impl Seq {
         let SeqState {
             voices,
             events_to_process,
-            module_cache,
-            module_cache_populated,
             ..
         } = &mut self.state;
         events_to_process.clear();
-        let storage_opt: Option<&SeqCycleStorage> = if current_cycle < PARAM_CACHE_CYCLES as i64 {
-            self.params.pattern.cached_haps().get(current_cycle as usize)
-        } else {
-            let module_idx = (current_cycle - PARAM_CACHE_CYCLES as i64) as usize;
-            if module_idx < module_cache.len() && module_cache_populated[module_idx] {
-                Some(&module_cache[module_idx])
-            } else {
-                None
-            }
-        };
+        let storage_opt = self.params.pattern.cached_haps().get(slot as usize);
         if let Some(storage) = storage_opt {
             for (hap_index, hap) in storage.haps.iter().enumerate() {
-                if !hap.has_onset || playhead < hap.part_begin || playhead >= hap.part_end {
+                if !hap.has_onset || logical < hap.part_begin || logical >= hap.part_end {
                     continue;
                 }
                 if hap.value.is_rest() {
@@ -497,18 +494,23 @@ impl Seq {
                 let idx = (state.next_voice + i) % num_channels;
                 if !state.voices[idx].active {
                     state.next_voice = (idx + 1) % num_channels;
-                    state.voices[idx].last_assigned = playhead;
+                    state.voices[idx].last_assigned = raw;
                     found = Some(idx);
                     break;
                 }
             }
             let Some(voice_idx) = found else { continue };
             let voice = &mut state.voices[voice_idx];
+            // Map the note's logical span onto the current absolute lap so
+            // release keys off the monotonic `raw` clock and the note plays
+            // its full length even across the ribbon wrap.
             voice.cached_hap = Some(CachedHap {
                 hap_index: event.hap_index,
                 cached_cycle: current_cycle,
                 whole_begin: event.whole_begin,
                 whole_end: event.whole_end,
+                raw_begin: raw - (logical - event.whole_begin),
+                raw_end: raw + (event.whole_end - logical),
                 value: event.value,
             });
             voice.active = true;
@@ -590,8 +592,7 @@ impl crate::types::StatefulModule for Seq {
         let num_sources = per_source.len().max(1);
 
         // Per-pattern active spans from all active voices.
-        let mut per_pattern_spans: Vec<Vec<(usize, usize)>> =
-            vec![Vec::new(); num_sources];
+        let mut per_pattern_spans: Vec<Vec<(usize, usize)>> = vec![Vec::new(); num_sources];
         let mut any_non_rest = false;
 
         for voice in self.state.voices.iter().take(num_channels) {
@@ -608,8 +609,7 @@ impl crate::types::StatefulModule for Seq {
                     for span in &storage.span_arena[start..end] {
                         let idx = span.pattern_idx as usize;
                         if idx < num_sources {
-                            per_pattern_spans[idx]
-                                .push((span.start as usize, span.end as usize));
+                            per_pattern_spans[idx].push((span.start as usize, span.end as usize));
                         }
                     }
                 }
@@ -631,7 +631,10 @@ impl crate::types::StatefulModule for Seq {
             // pattern_idx > 0 to those.
             let is_multi = self.params.pattern.is_multi_source();
             let mut param_spans = serde_json::Map::new();
-            if !is_multi && num_sources == 1 && let Some(meta) = per_source.first() {
+            if !is_multi
+                && num_sources == 1
+                && let Some(meta) = per_source.first()
+            {
                 param_spans.insert(
                     "pattern".to_string(),
                     serde_json::json!({
@@ -661,13 +664,6 @@ impl crate::types::StatefulModule for Seq {
                 "num_channels": num_channels,
             }))
         }
-    }
-}
-
-impl crate::types::PatchUpdateHandler for Seq {
-    fn on_patch_update(&mut self) {
-        self.rebuild_module_cache();
-        self.invalidate_cache();
     }
 }
 

--- a/crates/modular_core/src/dsp/seq/seq.rs
+++ b/crates/modular_core/src/dsp/seq/seq.rs
@@ -98,18 +98,19 @@ fn default_channels() -> usize {
 
 /// Default ribbon loop length in cycles. Same memory/cost as the old
 /// param cache (cycles `0..1024` baked at parse time).
-const DEFAULT_RIBBON_LENGTH: u64 = 1024;
+const DEFAULT_RIBBON_LENGTH: f64 = 1024.0;
 
-/// Largest ribbon loop length. The whole window bakes synchronously on the
-/// main thread on every pattern/ribbon edit, so it is capped.
-const MAX_RIBBON_LENGTH: u64 = 8192;
+/// Largest ribbon loop length. The window touches `ceil(offset+length) -
+/// floor(offset)` integer cycles, each baked synchronously on the main thread
+/// on every pattern/ribbon edit, so it is capped.
+const MAX_RIBBON_LENGTH: f64 = 8192.0;
 
 /// Largest ribbon offset. Generous, and keeps `offset + length` exact in
 /// `f64` (well under 2^53).
-const MAX_RIBBON_OFFSET: u64 = 1_000_000;
+const MAX_RIBBON_OFFSET: f64 = 1_000_000.0;
 
-fn default_ribbon() -> (u64, u64) {
-    (0, DEFAULT_RIBBON_LENGTH)
+fn default_ribbon() -> (f64, f64) {
+    (0.0, DEFAULT_RIBBON_LENGTH)
 }
 
 #[derive(Clone, Deserr, ChannelCount, JsonSchema, Connect, Debug, SignalParams)]
@@ -126,10 +127,10 @@ pub struct SeqParams {
     /// Number of polyphonic voices (1-16)
     #[deserr(default)]
     pub channels: Option<usize>,
-    /// loop window [offset, length] in cycles
+    /// loop window [offset, length] in cycles (fractional allowed)
     #[serde(default = "default_ribbon")]
     #[deserr(default = default_ribbon())]
-    ribbon: (u64, u64),
+    ribbon: (f64, f64),
     /// The pattern string (used for serialization)
     #[serde(skip)]
     #[deserr(skip)]
@@ -146,29 +147,31 @@ fn seq_bake_ribbon(
     _location: deserr::ValuePointerRef,
 ) -> Result<SeqParams, ModuleParamErrors> {
     let (offset, length) = params.ribbon;
-    if length == 0 {
+    let reject = |msg: String| {
         let mut err = ModuleParamErrors::default();
-        err.add(
-            "ribbon".to_string(),
-            "ribbon loop length must be greater than 0".to_string(),
-        );
-        return Err(err);
+        err.add("ribbon".to_string(), msg);
+        Err(err)
+    };
+    // Finiteness first, so ±∞ reports as non-finite rather than over-cap and
+    // NaN never reaches the comparisons below (where it would silently pass).
+    if !offset.is_finite() || !length.is_finite() {
+        return reject("ribbon values must be finite".to_string());
+    }
+    if length <= 0.0 {
+        return reject("ribbon loop length must be greater than 0".to_string());
     }
     if length > MAX_RIBBON_LENGTH {
-        let mut err = ModuleParamErrors::default();
-        err.add(
-            "ribbon".to_string(),
-            format!("ribbon loop length must be {MAX_RIBBON_LENGTH} cycles or fewer"),
-        );
-        return Err(err);
+        return reject(format!(
+            "ribbon loop length must be {MAX_RIBBON_LENGTH} cycles or fewer"
+        ));
+    }
+    if offset < 0.0 {
+        return reject("ribbon offset must be 0 or greater".to_string());
     }
     if offset > MAX_RIBBON_OFFSET {
-        let mut err = ModuleParamErrors::default();
-        err.add(
-            "ribbon".to_string(),
-            format!("ribbon offset must be {MAX_RIBBON_OFFSET} cycles or fewer"),
-        );
-        return Err(err);
+        return reject(format!(
+            "ribbon offset must be {MAX_RIBBON_OFFSET} cycles or fewer"
+        ));
     }
     params.pattern.bake(offset, length);
     Ok(params)
@@ -384,33 +387,39 @@ impl Seq {
     fn get_cycle_storage(&self, cycle: i64) -> Option<&SeqCycleStorage> {
         super::cache::get_cycle_storage(
             cycle,
-            self.params.ribbon.0,
+            self.params.ribbon.0.floor() as i64,
             self.params.pattern.cached_haps(),
         )
     }
 
     fn update(&mut self, sample_rate: f32) {
         // `raw` is the monotonic clock playhead (cycles, fractional). The
-        // ribbon folds it into the baked window with an unsigned modulo:
-        // clock cycle 0 maps to baked cycle `offset`, and the window loops
-        // forever, phase-locked to the clock.
+        // ribbon folds it into the baked window with a continuous-time modulo,
+        // so a fractional `offset`/`length` defines a loop window whose seam
+        // can fall mid-cycle. The window loops forever, phase-locked to the
+        // clock: clock pos 0 plays the window start (`offset`).
         let raw = self.params.playhead.value_or_zero() as f64;
         let hold = min_gate_samples(sample_rate);
         let num_channels = self.channel_count();
 
         let (offset, length) = self.params.ribbon; // length > 0 (validated)
         // Fold the clock into the baked window. Clamp once for the window math
-        // so a (deliberately wired) negative playhead pins to the cycle start
+        // so a (deliberately wired) negative playhead pins to the window start
         // rather than producing a spurious mid-cycle phase. Release below keys
         // off the unclamped monotonic `raw`, tracking each note's true span.
         let raw_clamped = raw.max(0.0);
-        let raw_cycle = raw_clamped.floor() as u64;
-        let slot = raw_cycle % length; // 0..length
-        let current_cycle = (offset + slot) as i64; // baked cycle ∈ [offset, offset+length)
-        // Playhead in the baked cycle's logical frame — the same absolute
-        // frame the cycle's haps live in, so onset / `already_assigned`
-        // checks work exactly as before.
-        let logical = current_cycle as f64 + (raw_clamped - raw_clamped.floor());
+        let base = offset.floor() as i64; // first baked cycle = floor(offset)
+        let phase = raw_clamped.rem_euclid(length); // [0, length)
+        let pos = offset + phase; // playhead in the window, ∈ [offset, offset+length)
+        // Integer cycle for the storage lookup and the `already_assigned`
+        // dedup key. `pos.floor() >= base`, so the index below is never
+        // negative.
+        let current_cycle = pos.floor() as i64;
+        // Playhead in the pattern's absolute frame — the same frame the baked
+        // cycle's haps live in, so onset / `already_assigned` checks work
+        // exactly as before. (For integer offset/length, `pos == old logical`.)
+        let logical = pos;
+        let storage_index = (current_cycle - base) as usize;
 
         // Release voices whose notes have ended. A note's life is tracked in
         // the monotonic `raw` frame (two-sided, so a backward scrub also
@@ -453,7 +462,7 @@ impl Seq {
             ..
         } = &mut self.state;
         events_to_process.clear();
-        let storage_opt = self.params.pattern.cached_haps().get(slot as usize);
+        let storage_opt = self.params.pattern.cached_haps().get(storage_index);
         if let Some(storage) = storage_opt {
             for (hap_index, hap) in storage.haps.iter().enumerate() {
                 if !hap.has_onset || logical < hap.part_begin || logical >= hap.part_end {
@@ -668,3 +677,57 @@ impl crate::types::StatefulModule for Seq {
 }
 
 message_handlers!(impl Seq {});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params_with_ribbon(ribbon: (f64, f64)) -> SeqParams {
+        SeqParams {
+            pattern: SeqPatternParam::default(),
+            playhead: None,
+            channels: None,
+            ribbon,
+            pattern_source: String::new(),
+        }
+    }
+
+    fn reject_message(ribbon: (f64, f64)) -> Option<String> {
+        seq_bake_ribbon(params_with_ribbon(ribbon), deserr::ValuePointerRef::Origin)
+            .err()
+            .map(|e| e.to_string())
+    }
+
+    /// NaN / ±∞ cannot reach this hook through the JSON graph (serde_json
+    /// rejects non-finite numbers), but the hook guards finiteness directly so
+    /// no caller can ever drive `floor`/`ceil`/`rem_euclid` with a non-finite
+    /// ribbon value. The finite check runs first, ahead of the magnitude
+    /// bounds, so ±∞ is reported as non-finite rather than over-cap.
+    #[test]
+    fn seq_bake_ribbon_rejects_non_finite() {
+        for bad in [
+            (f64::NAN, 4.0),
+            (0.0, f64::NAN),
+            (f64::INFINITY, 4.0),
+            (0.0, f64::INFINITY),
+            (f64::NEG_INFINITY, 4.0),
+            (0.0, f64::NEG_INFINITY),
+        ] {
+            let msg = reject_message(bad)
+                .unwrap_or_else(|| panic!("expected rejection for ribbon {bad:?}"));
+            assert!(
+                msg.contains("ribbon values must be finite"),
+                "ribbon {bad:?} got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn seq_bake_ribbon_accepts_finite_fractional() {
+        assert!(
+            seq_bake_ribbon(params_with_ribbon((0.5, 1.5)), deserr::ValuePointerRef::Origin)
+                .is_ok(),
+            "a finite fractional ribbon must pass the bounds hook"
+        );
+    }
+}

--- a/crates/modular_core/src/dsp/seq/seq_value.rs
+++ b/crates/modular_core/src/dsp/seq/seq_value.rs
@@ -598,24 +598,30 @@ impl SeqPatternParam {
         &self.cached_haps
     }
 
-    /// Bake every cycle of the ribbon window `[offset, offset+length)` into
-    /// `cached_haps`, replacing any previous bake. Runs on the main thread at
-    /// parse time (from `Seq`'s `validate` hook), never on the audio thread.
-    pub(crate) fn bake(&mut self, offset: u64, length: u64) {
+    /// Bake every integer cycle the ribbon window `[offset, offset+length)`
+    /// touches into `cached_haps`, replacing any previous bake. Runs on the
+    /// main thread at parse time (from `Seq`'s `validate` hook), never on the
+    /// audio thread.
+    pub(crate) fn bake(&mut self, offset: f64, length: f64) {
         if let Some(pattern) = self.pattern.as_ref() {
             self.cached_haps = bake_cycles(pattern, offset, length);
         }
     }
 }
 
-/// Bake cycles `[offset, offset+length)` of a `Pattern<SeqValue>` into one
-/// `SeqCycleStorage` per cycle. Runs on the main thread, so allocation here is
-/// fine; the audio thread only ever reads the result.
-fn bake_cycles(pattern: &Pattern<SeqValue>, offset: u64, length: u64) -> Vec<SeqCycleStorage> {
+/// Bake the integer cycles the ribbon window `[offset, offset+length)` touches
+/// — `[floor(offset), ceil(offset+length))` — into one `SeqCycleStorage` per
+/// cycle (`cached_haps[i]` holds cycle `floor(offset) + i`). Runs on the main
+/// thread, so allocation here is fine; the audio thread only ever reads the
+/// result.
+fn bake_cycles(pattern: &Pattern<SeqValue>, offset: f64, length: f64) -> Vec<SeqCycleStorage> {
+    let base = offset.floor() as i64;
+    let end = (offset + length).ceil() as i64; // exclusive
+    let count = (end - base).max(0) as usize;
     let mut bump = bumpalo::Bump::new();
-    let mut cached_haps: Vec<SeqCycleStorage> = Vec::with_capacity(length as usize);
-    for i in 0..length {
-        let cycle = (offset + i) as i64;
+    let mut cached_haps: Vec<SeqCycleStorage> = Vec::with_capacity(count);
+    for i in 0..count {
+        let cycle = base + i as i64;
         let mut storage = SeqCycleStorage::with_capacity(
             MIN_HAPS_CAP_HINT,
             MIN_HAPS_CAP_HINT * SPANS_RESERVE_PER_HAP,

--- a/crates/modular_core/src/dsp/seq/seq_value.rs
+++ b/crates/modular_core/src/dsp/seq/seq_value.rs
@@ -4,7 +4,7 @@
 //! - Voltage values (V/Oct, pre-converted at parse time)
 //! - Rests
 
-use deserr::{Deserr, DeserializeError, ErrorKind, IntoValue, Map, Sequence, ValuePointerRef};
+use deserr::{DeserializeError, Deserr, ErrorKind, IntoValue, Map, Sequence, ValuePointerRef};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use super::cache::{
-    CycleStorage, MIN_HAPS_CAP_HINT, MIN_SPANS_CAP_HINT, PARAM_CACHE_CYCLES, SPANS_RESERVE_PER_HAP,
+    CycleStorage, MIN_HAPS_CAP_HINT, SPANS_RESERVE_PER_HAP,
     populate_cycle_storage as cache_populate,
 };
 
@@ -440,14 +440,9 @@ pub struct SeqPatternParam {
     /// The parsed pattern.
     pub(crate) pattern: Option<Pattern<SeqValue>>,
 
-    /// Pre-computed haps for cycles 0..PARAM_CACHE_CYCLES.
+    /// Baked haps for the ribbon window `[offset, offset+length)`, one
+    /// `SeqCycleStorage` per cycle. Filled by [`SeqPatternParam::bake`].
     pub(crate) cached_haps: Vec<SeqCycleStorage>,
-
-    /// Largest `haps.len()` seen across the cached cycles.
-    pub(crate) max_haps_per_cycle: usize,
-
-    /// Largest `span_arena.len()` seen across the cached cycles.
-    pub(crate) max_spans_per_cycle: usize,
 }
 
 impl JsonSchema for SeqPatternParam {
@@ -479,15 +474,13 @@ impl SeqPatternParam {
             all_spans: payload.all_spans,
         }];
 
-        let (cached_haps, max_haps_per_cycle, max_spans_per_cycle) = bake_cycles(&pattern);
-
+        // Parse-only: leave `cached_haps` empty. `Seq`'s `validate` hook
+        // bakes the ribbon window once both `pattern` and `ribbon` are known.
         Ok(Self {
             per_source,
             is_multi_source: false,
             pattern: Some(pattern),
-            cached_haps,
-            max_haps_per_cycle,
-            max_spans_per_cycle,
+            cached_haps: Vec::new(),
         })
     }
 
@@ -573,15 +566,12 @@ impl SeqPatternParam {
             })
             .collect();
 
-        let (cached_haps, max_haps_per_cycle, max_spans_per_cycle) = bake_cycles(&voltage_pattern);
-
+        // Parse-only: leave `cached_haps` empty (see `from_payload`).
         Ok(Self {
             per_source,
             is_multi_source: true,
             pattern: Some(voltage_pattern),
-            cached_haps,
-            max_haps_per_cycle,
-            max_spans_per_cycle,
+            cached_haps: Vec::new(),
         })
     }
 
@@ -603,28 +593,29 @@ impl SeqPatternParam {
         self.is_multi_source
     }
 
-    /// Get the pre-computed cached cycle storages for cycles 0..PARAM_CACHE_CYCLES.
+    /// Get the baked cycle storages for the ribbon window.
     pub(crate) fn cached_haps(&self) -> &[SeqCycleStorage] {
         &self.cached_haps
     }
 
-    /// Capacity hint for sizing audio-thread cycle storages.
-    pub(crate) fn max_haps_per_cycle(&self) -> usize {
-        self.max_haps_per_cycle
-    }
-
-    /// Capacity hint for sizing audio-thread span arenas.
-    pub(crate) fn max_spans_per_cycle(&self) -> usize {
-        self.max_spans_per_cycle
+    /// Bake every cycle of the ribbon window `[offset, offset+length)` into
+    /// `cached_haps`, replacing any previous bake. Runs on the main thread at
+    /// parse time (from `Seq`'s `validate` hook), never on the audio thread.
+    pub(crate) fn bake(&mut self, offset: u64, length: u64) {
+        if let Some(pattern) = self.pattern.as_ref() {
+            self.cached_haps = bake_cycles(pattern, offset, length);
+        }
     }
 }
 
-/// Pre-compute cycles 0..PARAM_CACHE_CYCLES of a `Pattern<SeqValue>`
-/// into `SeqCycleStorage` slots and derive audio-thread capacity hints.
-fn bake_cycles(pattern: &Pattern<SeqValue>) -> (Vec<SeqCycleStorage>, usize, usize) {
+/// Bake cycles `[offset, offset+length)` of a `Pattern<SeqValue>` into one
+/// `SeqCycleStorage` per cycle. Runs on the main thread, so allocation here is
+/// fine; the audio thread only ever reads the result.
+fn bake_cycles(pattern: &Pattern<SeqValue>, offset: u64, length: u64) -> Vec<SeqCycleStorage> {
     let mut bump = bumpalo::Bump::new();
-    let mut cached_haps: Vec<SeqCycleStorage> = Vec::with_capacity(PARAM_CACHE_CYCLES);
-    for cycle in 0..PARAM_CACHE_CYCLES as i64 {
+    let mut cached_haps: Vec<SeqCycleStorage> = Vec::with_capacity(length as usize);
+    for i in 0..length {
+        let cycle = (offset + i) as i64;
         let mut storage = SeqCycleStorage::with_capacity(
             MIN_HAPS_CAP_HINT,
             MIN_HAPS_CAP_HINT * SPANS_RESERVE_PER_HAP,
@@ -632,15 +623,7 @@ fn bake_cycles(pattern: &Pattern<SeqValue>) -> (Vec<SeqCycleStorage>, usize, usi
         populate_cycle_storage(pattern, cycle, &mut bump, &mut storage);
         cached_haps.push(storage);
     }
-    let max_haps = cached_haps.iter().map(|c| c.haps.len()).max().unwrap_or(0);
-    let max_spans = cached_haps
-        .iter()
-        .map(|c| c.span_arena.len())
-        .max()
-        .unwrap_or(0);
-    let max_haps_per_cycle = (max_haps.max(MIN_HAPS_CAP_HINT) * 3) / 2;
-    let max_spans_per_cycle = (max_spans.max(MIN_SPANS_CAP_HINT) * 3) / 2;
-    (cached_haps, max_haps_per_cycle, max_spans_per_cycle)
+    cached_haps
 }
 
 // deserr implementation: reads either a plain `ParsedPatternPayload`

--- a/crates/modular_core/tests/dsp_fresh_tests.rs
+++ b/crates/modular_core/tests/dsp_fresh_tests.rs
@@ -1747,3 +1747,89 @@ fn seq_ribbon_rejects_invalid_bounds() {
         "fractional value must be rejected"
     );
 }
+
+/// Count low→high transitions in a port trace.
+fn rising_edges(trace: &[f32]) -> usize {
+    let mut n = 0;
+    let mut prev = false;
+    for &v in trace {
+        let high = v > 2.5;
+        if high && !prev {
+            n += 1;
+        }
+        prev = high;
+    }
+    n
+}
+
+/// For a `$cycle` patch: gate state at each cycle midpoint (`true` = sounding)
+/// and the trig onset count over `cycles`. (A trig onset leads its gate rising
+/// edge by the min-gate hold, so terminate the trace in a silent stretch to
+/// keep the onset count free of boundary-straddle artifacts.)
+fn cycle_gate_and_onsets(pattern: &str, ribbon: [u64; 2], cycles: usize) -> (Vec<bool>, usize) {
+    const SPC: usize = 240;
+    let gate = cycle_port_trace(
+        &make_cycle_patch(mini_payload(pattern), Some(ribbon)),
+        "gate",
+        cycles * SPC,
+    );
+    let trig = cycle_port_trace(
+        &make_cycle_patch(mini_payload(pattern), Some(ribbon)),
+        "trig",
+        cycles * SPC,
+    );
+    let mids = (0..cycles).map(|c| gate[c * SPC + SPC / 2] > 2.5).collect();
+    (mids, rising_edges(&trig))
+}
+
+/// A note LONGER than the ribbon window plays its full length, then goes
+/// silent until the window's loop point realigns with the onset — a
+/// deterministic gap, never a stuck note, a double-trigger, or an early cut.
+///
+/// The onset hap lives only at baked cycle `offset` (slot 0), which recurs
+/// every `length` clock cycles. `c4/3` (3-cycle note) in a 2-cycle window
+/// releases at clock cycle 3, but slot 0 next comes around at clock cycle 4,
+/// so it re-onsets there: 3 cycles sounding + 1 cycle gap, period 4.
+#[test]
+fn seq_ribbon_note_longer_than_window_plays_full_then_gaps() {
+    // Trace 11 cycles — ends in the third gap, so the next group's onset is
+    // outside the window and the onset count is exactly one-per-group.
+    let (mids, onsets) = cycle_gate_and_onsets("c4/3", [0, 2], 11);
+    let expected = [
+        true, true, true, false, // sound 0,1,2; gap 3
+        true, true, true, false, // sound 4,5,6; gap 7
+        true, true, true, // sound 8,9,10  (gap 11 not traced)
+    ];
+    assert_eq!(
+        mids, expected,
+        "3-cycle note in a 2-cycle window: 3 sounding + 1 gap, period 4"
+    );
+    // Three sounding groups, one onset each — no seam re-trigger while a note
+    // is still sounding, no double-fire.
+    assert_eq!(onsets, 3, "exactly one onset per sounding group");
+}
+
+/// A note whose length divides the ribbon window loops with NO gap: it
+/// re-articulates exactly at the loop point (a fresh trig each lap), and the
+/// gate is continuous across cycle midpoints. `c4/2` (2-cycle note, window 2)
+/// and `c4/4` (4-cycle note, window 2 — 4 % 2 == 0) both loop seamlessly.
+#[test]
+fn seq_ribbon_note_dividing_window_loops_seamlessly() {
+    let (mids2, onsets2) = cycle_gate_and_onsets("c4/2", [0, 2], 8);
+    assert!(
+        mids2.iter().all(|&g| g),
+        "2-cycle note in a 2-cycle window sounds at every cycle midpoint (no gap): {mids2:?}"
+    );
+    // Re-articulates each lap (a fresh trig per loop) rather than holding one
+    // gate forever — looping a held note re-triggers it.
+    assert!(
+        onsets2 >= 3,
+        "re-triggers once per 2-cycle loop over 8 cycles: {onsets2}"
+    );
+
+    let (mids4, _) = cycle_gate_and_onsets("c4/4", [0, 2], 8);
+    assert!(
+        mids4.iter().all(|&g| g),
+        "4-cycle note (4 % 2 == 0) also loops with no gap: {mids4:?}"
+    );
+}

--- a/crates/modular_core/tests/dsp_fresh_tests.rs
+++ b/crates/modular_core/tests/dsp_fresh_tests.rs
@@ -493,7 +493,8 @@ fn from_graph_creates_patch_with_modules() {
         ("osc1", "$sine", json!({ "freq": 0.0 })),
         ("osc2", "$saw", json!({ "freq": 1.0 })),
     ]);
-    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     // Both oscillators plus the hidden AudioIn
     assert!(patch.sampleables.contains_key("osc1"));
@@ -524,7 +525,8 @@ fn from_graph_params_are_applied() {
         "$scaleAndShift",
         json!({ "input": 2.0, "scale": 5.0, "shift": 1.0 }),
     )]);
-    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     // Let param smoothing converge
     for _ in 0..500 {
@@ -553,7 +555,8 @@ fn from_graph_cable_routing_sine_to_signal() {
             }),
         ),
     ]);
-    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     // Collect samples from the $signal module — it should reproduce the sine output
     let sig_module = patch.sampleables.get("sig").unwrap();
@@ -605,7 +608,8 @@ fn from_graph_multi_module_osc_to_filter_to_mix() {
             }),
         ),
     ]);
-    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     // Also build a direct (unfiltered) patch for comparison
     let direct_graph = make_graph(vec![
@@ -620,7 +624,9 @@ fn from_graph_multi_module_osc_to_filter_to_mix() {
             }),
         ),
     ]);
-    let direct_patch = Patch::from_graph(&direct_graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let direct_patch =
+        Patch::from_graph(&direct_graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+            .expect("from_graph failed");
 
     // Let filter settle
     for _ in 0..500 {
@@ -665,7 +671,8 @@ fn from_graph_process_frame_advances_all_modules() {
         ("fast", "$sine", json!({ "freq": 3.0 })),
         ("slow", "$sine", json!({ "freq": -3.0 })),
     ]);
-    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     for _ in 0..500 {
         process_frame(&patch);
@@ -720,7 +727,6 @@ fn step_rejects_empty_steps() {
         }
     }
 }
-
 
 // ─── Curve ───────────────────────────────────────────────────────────────────
 
@@ -824,7 +830,8 @@ fn buffer_and_delay_read_pipeline() {
             }),
         ),
     ]);
-    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     // 0.001s delay at 48 kHz = 48 frames.
     // Process 500 frames so param smoothing converges and the buffer is well-filled.
@@ -895,7 +902,8 @@ fn buffer_feedback_cycle_propagates_through_delay_read() {
             }),
         ),
     ]);
-    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     for _ in 0..20_000 {
         process_frame(&patch);
@@ -940,7 +948,8 @@ fn delay_read_output_lags_behind_buffer_passthrough() {
             }),
         ),
     ]);
-    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     // Let oscillator and buffer settle for 500 frames
     for _ in 0..500 {
@@ -1027,7 +1036,8 @@ fn transfer_state_from_preserves_wrapper_outputs_for_feedback_cycles() {
         ),
     ]);
 
-    let old_patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let old_patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     // Run 200 frames to reach steady state
     // With gain=0.5 and shift=1.0:
@@ -1060,7 +1070,8 @@ fn transfer_state_from_preserves_wrapper_outputs_for_feedback_cycles() {
     );
 
     // Build a new patch with identical graph and transfer state
-    let new_patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("from_graph failed");
+    let new_patch = Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed");
 
     // Transfer state from old modules to new modules
     for (id, new_module) in &new_patch.sampleables {
@@ -1247,11 +1258,10 @@ fn seq_highlight_survives_state_transfer_from_single_to_multi_source() {
     // (is_multi_source=true, per_source=2, a freshly baked multi-source
     // cached_haps), but transfer_state_from std::mem::swaps the OLD SeqState
     // (voices[].cached_hap holding a hap_index computed against the OLD
-    // single-source pattern) into the new module. on_patch_update clears
-    // current_cycle + module_cache but NOT voices[].cached_hap.
+    // single-source pattern) into the new module.
     //
-    // The held voice still satisfies cached.contains(playhead) off its scalar
-    // whole_begin/whole_end, so it is not released and no fresh onset fires
+    // The held voice still satisfies cached.contains(raw) off its scalar
+    // raw_begin/raw_end window, so it is not released and no fresh onset fires
     // mid-step. The OLD pattern packed 7 sub-haps into the left half, so the
     // voice latched on the trailing `5` carries a hap_index (>= 2) that is OUT
     // OF RANGE in the new 2-hap multi-source storage — exactly the stale-index
@@ -1282,8 +1292,8 @@ fn seq_highlight_survives_state_transfer_from_single_to_multi_source() {
             json!({ "pattern": mini_payload("[0 1 2 3 4 5 6] 5") }),
         ),
     ]);
-    let old_patch =
-        Patch::from_graph(&graph_a, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("A from_graph failed");
+    let old_patch = Patch::from_graph(&graph_a, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("A from_graph failed");
 
     // One bar = 240 samples. The trailing `5` covers 0.5..1.0 (samples
     // 120..240). Advance ~180 samples so the playhead sits at ~0.75, latching
@@ -1324,8 +1334,8 @@ fn seq_highlight_survives_state_transfer_from_single_to_multi_source() {
             json!({ "pattern": sp_payload(&["0 5", "2 4"], "c(maj)", vec![("sub", "in")]) }),
         ),
     ]);
-    let new_patch =
-        Patch::from_graph(&graph_b, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("B from_graph failed");
+    let new_patch = Patch::from_graph(&graph_b, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("B from_graph failed");
 
     // Replicate apply_patch_update's reuse path: transfer state, reconnect,
     // on_patch_update. NO ClearPatch / transport reset.
@@ -1419,8 +1429,8 @@ fn seq_highlight_survives_state_transfer_from_single_to_multi_source() {
             json!({ "pattern": mini_payload("[0 1 2 3 4 5 6] 5") }),
         ),
     ]);
-    let ctrl_patch =
-        Patch::from_graph(&graph_c, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new()).expect("C from_graph failed");
+    let ctrl_patch = Patch::from_graph(&graph_c, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("C from_graph failed");
     for (id, new_module) in &ctrl_patch.sampleables {
         if let Some(old_module) = old_patch.sampleables.get(id) {
             new_module.transfer_state_from(old_module.as_ref());
@@ -1483,4 +1493,257 @@ fn track_clamps_playhead_above_one() {
 fn track_clamps_playhead_below_zero() {
     let v = track_value_at(-0.1, json!([[1.0, 0.0], [5.0, 1.0]]));
     assert!(approx_eq(v, 1.0, 0.01), "expected 1.0 (clamped), got {v}");
+}
+
+// ─── $cycle ribbon loop window ────────────────────────────────────────────────
+
+/// Build a `$cycle` patch clocked at 48000 BPM 4/4 (240 samples per cycle),
+/// optionally with a `ribbon: [offset, length]` window.
+fn make_cycle_patch(pattern: Value, ribbon: Option<[u64; 2]>) -> Patch {
+    let mut params = serde_json::Map::new();
+    params.insert("pattern".to_string(), pattern);
+    if let Some([offset, length]) = ribbon {
+        params.insert("ribbon".to_string(), json!([offset, length]));
+    }
+    let graph = make_graph(vec![
+        (
+            "ROOT_CLOCK",
+            "_clock",
+            json!({ "tempo": 48000.0, "numerator": 4, "denominator": 4 }),
+        ),
+        ("seq", "$cycle", Value::Object(params)),
+    ]);
+    Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+        .expect("from_graph failed")
+}
+
+/// Sample `port` at the midpoint of cycles `0..num_cycles` (240 samples/cycle).
+fn cycle_midpoint_values(patch: &Patch, port: &str, num_cycles: usize) -> Vec<f32> {
+    const SPC: usize = 240;
+    let targets: Vec<usize> = (0..num_cycles).map(|c| c * SPC + SPC / 2).collect();
+    let total = *targets.last().unwrap();
+    let mut out = Vec::with_capacity(num_cycles);
+    let mut ti = 0;
+    for s in 1..=total {
+        process_frame(patch);
+        if ti < targets.len() && targets[ti] == s {
+            out.push(
+                patch
+                    .sampleables
+                    .get("seq")
+                    .unwrap()
+                    .get_value_at(port, 0, 0),
+            );
+            ti += 1;
+        }
+    }
+    out
+}
+
+/// Per-sample trace of `port` over `total_samples` frames.
+fn cycle_port_trace(patch: &Patch, port: &str, total_samples: usize) -> Vec<f32> {
+    let mut out = Vec::with_capacity(total_samples);
+    for _ in 0..total_samples {
+        process_frame(patch);
+        out.push(
+            patch
+                .sampleables
+                .get("seq")
+                .unwrap()
+                .get_value_at(port, 0, 0),
+        );
+    }
+    out
+}
+
+#[test]
+fn seq_ribbon_default_window_plays_pattern_through() {
+    // Default ribbon [0, 1024]: the slowcat `<c4 e4 g4 b4>` advances every
+    // cycle for the first 4 cycles (far inside the window), so all four
+    // differ — identical to a direct pattern query, no early looping.
+    let patch = make_cycle_patch(mini_payload("<c4 e4 g4 b4>"), None);
+    let cv = cycle_midpoint_values(&patch, "cv", 4);
+    for i in 0..4 {
+        for j in (i + 1)..4 {
+            assert!(
+                (cv[i] - cv[j]).abs() > 0.05,
+                "default window should play 4 distinct cycles; cv[{i}]={} cv[{j}]={}",
+                cv[i],
+                cv[j]
+            );
+        }
+    }
+}
+
+#[test]
+fn seq_ribbon_loops_window() {
+    // ribbon [0, 2] bakes only cycles 0,1 of `<c4 e4 g4 b4>`, then loops them:
+    // clock cycles 2,3 replay baked cycles 0,1 instead of advancing to g4,b4.
+    let looped = cycle_midpoint_values(
+        &make_cycle_patch(mini_payload("<c4 e4 g4 b4>"), Some([0, 2])),
+        "cv",
+        4,
+    );
+    assert!(
+        (looped[0] - looped[1]).abs() > 0.05,
+        "the window's two cycles differ: {} vs {}",
+        looped[0],
+        looped[1]
+    );
+    assert!(
+        approx_eq(looped[2], looped[0], 0.01),
+        "cycle 2 loops back to cycle 0: {} vs {}",
+        looped[2],
+        looped[0]
+    );
+    assert!(
+        approx_eq(looped[3], looped[1], 0.01),
+        "cycle 3 loops back to cycle 1: {} vs {}",
+        looped[3],
+        looped[1]
+    );
+
+    // Without the ribbon the same clock cycle 2 advances to a different note,
+    // proving the ribbon — not the pattern — drives the loop.
+    let unlooped = cycle_midpoint_values(
+        &make_cycle_patch(mini_payload("<c4 e4 g4 b4>"), None),
+        "cv",
+        4,
+    );
+    assert!(
+        (looped[2] - unlooped[2]).abs() > 0.05,
+        "ribbon changes cycle-2 output: looped {} vs default {}",
+        looped[2],
+        unlooped[2]
+    );
+}
+
+#[test]
+fn seq_ribbon_offset_window_plays_and_loops() {
+    // ribbon [2, 2] bakes cycles 2,3 and loops them: clock cycle 0 plays the
+    // pattern's cycle 2, clock cycle 1 plays cycle 3, then it repeats.
+    let reference = cycle_midpoint_values(
+        &make_cycle_patch(mini_payload("<c4 e4 g4 b4>"), None),
+        "cv",
+        4,
+    );
+    let offset = cycle_midpoint_values(
+        &make_cycle_patch(mini_payload("<c4 e4 g4 b4>"), Some([2, 2])),
+        "cv",
+        4,
+    );
+    assert!(
+        approx_eq(offset[0], reference[2], 0.01),
+        "offset cycle 0 == pattern cycle 2: {} vs {}",
+        offset[0],
+        reference[2]
+    );
+    assert!(
+        approx_eq(offset[1], reference[3], 0.01),
+        "offset cycle 1 == pattern cycle 3: {} vs {}",
+        offset[1],
+        reference[3]
+    );
+    assert!(
+        approx_eq(offset[2], offset[0], 0.01),
+        "offset window loops: cycle 2 == cycle 0"
+    );
+    assert!(
+        approx_eq(offset[3], offset[1], 0.01),
+        "offset window loops: cycle 3 == cycle 1"
+    );
+}
+
+#[test]
+fn seq_ribbon_wrap_note_plays_full_length_then_releases_once() {
+    // `c4/3` slows c4 over 3 cycles: onset at cycle 0, whole span [0, 3].
+    // ribbon [0, 2] bakes cycles 0,1 only, so the note straddles the loop seam
+    // at the start of clock cycle 2. It must keep sounding through cycle 2
+    // (its full 3-cycle length, past the wrap), then release exactly once at
+    // cycle 3 — never cut early, never stuck.
+    let gate = cycle_port_trace(
+        &make_cycle_patch(mini_payload("c4/3"), Some([0, 2])),
+        "gate",
+        4 * 240,
+    );
+    for (cyc, s) in [(0usize, 120usize), (1, 360), (2, 600)] {
+        assert!(
+            gate[s] > 2.5,
+            "gate should be HIGH mid-cycle {cyc} (sample {s}) — note plays past the wrap, got {}",
+            gate[s]
+        );
+    }
+    assert!(
+        gate[840] < 2.5,
+        "gate should be LOW mid-cycle 3 — the note released, got {}",
+        gate[840]
+    );
+
+    // The looped slot re-presents the same onset hap at the seam (clock cycle
+    // 2 maps back to baked cycle 0), but a note longer than the window must
+    // NOT re-trigger while it is still sounding: exactly one onset over the
+    // three cycles it plays.
+    let trig = cycle_port_trace(
+        &make_cycle_patch(mini_payload("c4/3"), Some([0, 2])),
+        "trig",
+        3 * 240,
+    );
+    let mut onsets = 0;
+    let mut prev_high = false;
+    for &v in &trig {
+        let high = v > 2.5;
+        if high && !prev_high {
+            onsets += 1;
+        }
+        prev_high = high;
+    }
+    assert_eq!(
+        onsets, 1,
+        "a note longer than the window fires exactly one onset while sounding (no seam re-trigger)"
+    );
+}
+
+#[test]
+fn seq_ribbon_rejects_invalid_bounds() {
+    let attempt = |ribbon: Value| {
+        let graph = make_graph(vec![
+            (
+                "ROOT_CLOCK",
+                "_clock",
+                json!({ "tempo": 48000.0, "numerator": 4, "denominator": 4 }),
+            ),
+            (
+                "seq",
+                "$cycle",
+                json!({ "pattern": mini_payload("c4 e4"), "ribbon": ribbon }),
+            ),
+        ]);
+        Patch::from_graph(&graph, SAMPLE_RATE, TEST_BLOCK_SIZE, &HashMap::new())
+    };
+
+    match attempt(json!([0, 0])) {
+        Err(msg) => assert!(
+            msg.contains("ribbon loop length must be greater than 0"),
+            "got: {msg}"
+        ),
+        Ok(_) => panic!("expected error for zero ribbon length"),
+    }
+    match attempt(json!([0, 9000])) {
+        Err(msg) => assert!(msg.contains("8192 cycles or fewer"), "got: {msg}"),
+        Ok(_) => panic!("expected error for over-cap ribbon length"),
+    }
+    match attempt(json!([2_000_000, 4])) {
+        Err(msg) => assert!(msg.contains("ribbon offset must be"), "got: {msg}"),
+        Ok(_) => panic!("expected error for over-cap ribbon offset"),
+    }
+    // Structural: `u64` rejects a negative offset and a fractional value at
+    // parse time, before the bounds hook runs.
+    assert!(
+        attempt(json!([-1, 4])).is_err(),
+        "negative offset must be rejected"
+    );
+    assert!(
+        attempt(json!([0.5, 4])).is_err(),
+        "fractional value must be rejected"
+    );
 }

--- a/crates/modular_core/tests/dsp_fresh_tests.rs
+++ b/crates/modular_core/tests/dsp_fresh_tests.rs
@@ -1500,10 +1500,20 @@ fn track_clamps_playhead_below_zero() {
 /// Build a `$cycle` patch clocked at 48000 BPM 4/4 (240 samples per cycle),
 /// optionally with a `ribbon: [offset, length]` window.
 fn make_cycle_patch(pattern: Value, ribbon: Option<[u64; 2]>) -> Patch {
+    make_cycle_patch_ribbon(pattern, ribbon.map(|[offset, length]| json!([offset, length])))
+}
+
+/// Like [`make_cycle_patch`] but with a fractional `[offset, length]` ribbon.
+fn make_cycle_patch_frac(pattern: Value, ribbon: [f64; 2]) -> Patch {
+    let [offset, length] = ribbon;
+    make_cycle_patch_ribbon(pattern, Some(json!([offset, length])))
+}
+
+fn make_cycle_patch_ribbon(pattern: Value, ribbon: Option<Value>) -> Patch {
     let mut params = serde_json::Map::new();
     params.insert("pattern".to_string(), pattern);
-    if let Some([offset, length]) = ribbon {
-        params.insert("ribbon".to_string(), json!([offset, length]));
+    if let Some(ribbon) = ribbon {
+        params.insert("ribbon".to_string(), ribbon);
     }
     let graph = make_graph(vec![
         (
@@ -1736,15 +1746,19 @@ fn seq_ribbon_rejects_invalid_bounds() {
         Err(msg) => assert!(msg.contains("ribbon offset must be"), "got: {msg}"),
         Ok(_) => panic!("expected error for over-cap ribbon offset"),
     }
-    // Structural: `u64` rejects a negative offset and a fractional value at
-    // parse time, before the bounds hook runs.
+    // A negative offset is now rejected by the bounds hook (not structurally,
+    // since `f64` accepts it).
+    match attempt(json!([-1, 4])) {
+        Err(msg) => assert!(
+            msg.contains("ribbon offset must be 0 or greater"),
+            "got: {msg}"
+        ),
+        Ok(_) => panic!("expected error for negative ribbon offset"),
+    }
+    // Fractional values are now VALID — a fractional window is the whole point.
     assert!(
-        attempt(json!([-1, 4])).is_err(),
-        "negative offset must be rejected"
-    );
-    assert!(
-        attempt(json!([0.5, 4])).is_err(),
-        "fractional value must be rejected"
+        attempt(json!([0.5, 4])).is_ok(),
+        "fractional ribbon must be accepted"
     );
 }
 
@@ -1832,4 +1846,100 @@ fn seq_ribbon_note_dividing_window_loops_seamlessly() {
         mids4.iter().all(|&g| g),
         "4-cycle note (4 % 2 == 0) also loops with no gap: {mids4:?}"
     );
+}
+
+/// True if any sample in `trace` is within `eps` of `target`.
+fn trace_contains(trace: &[f32], target: f32, eps: f32) -> bool {
+    trace.iter().any(|&v| (v - target).abs() < eps)
+}
+
+/// A fractional ribbon LENGTH defines a loop window whose seam falls mid-cycle.
+/// `ribbon:[0, 1.5]` bakes the slice of cycles 0 and 1 the window touches and
+/// loops with period 1.5 cycles (360 samples): the slowcat only ever plays its
+/// cycle-0 (`c4`) and cycle-1 (`e4`) notes — never cycle 2 (`g4`) or cycle 3
+/// (`b4`) — and the cv trace repeats every 1.5 cycles in steady state.
+#[test]
+fn seq_ribbon_fractional_length_loops() {
+    const SPC: usize = 240;
+    // Reference voltages for the slowcat's first four cycles.
+    let notes = cycle_midpoint_values(
+        &make_cycle_patch(mini_payload("<c4 e4 g4 b4>"), None),
+        "cv",
+        4,
+    );
+    let (c4, e4, g4, b4) = (notes[0], notes[1], notes[2], notes[3]);
+
+    let trace = cycle_port_trace(
+        &make_cycle_patch_frac(mini_payload("<c4 e4 g4 b4>"), [0.0, 1.5]),
+        "cv",
+        9 * SPC,
+    );
+
+    // The window plays both of the cycles it touches...
+    assert!(trace_contains(&trace, c4, 0.01), "window plays cycle 0 (c4)");
+    assert!(trace_contains(&trace, e4, 0.01), "window plays cycle 1 (e4)");
+    // ...and never the cycles beyond it.
+    assert!(
+        !trace_contains(&trace, g4, 0.01),
+        "fractional window [0,1.5) never reaches cycle 2 (g4)"
+    );
+    assert!(
+        !trace_contains(&trace, b4, 0.01),
+        "fractional window [0,1.5) never reaches cycle 3 (b4)"
+    );
+
+    // Loops with period 1.5 cycles (360 samples), checked in steady state
+    // (after the first 4 cycles of warm-up).
+    let period = 360; // 1.5 * 240
+    for s in (4 * SPC)..(6 * SPC) {
+        assert!(
+            approx_eq(trace[s], trace[s + period], 0.01),
+            "cv repeats every 1.5 cycles: sample {s}={} vs {}={}",
+            trace[s],
+            s + period,
+            trace[s + period]
+        );
+    }
+}
+
+/// A fractional ribbon OFFSET starts the loop window partway into the pattern.
+/// `ribbon:[0.5, 2]` covers pattern positions [0.5, 2.5): cycle 0's second
+/// half, all of cycle 1, and cycle 2's first half — so the slowcat plays `c4`,
+/// `e4` AND `g4` (reaching into cycle 2, which an integer `[0,2]` window never
+/// would), but never cycle 3's `b4`. It loops with period 2 cycles.
+#[test]
+fn seq_ribbon_fractional_offset_window() {
+    const SPC: usize = 240;
+    let notes = cycle_midpoint_values(
+        &make_cycle_patch(mini_payload("<c4 e4 g4 b4>"), None),
+        "cv",
+        4,
+    );
+    let (c4, e4, g4, b4) = (notes[0], notes[1], notes[2], notes[3]);
+
+    let trace = cycle_port_trace(
+        &make_cycle_patch_frac(mini_payload("<c4 e4 g4 b4>"), [0.5, 2.0]),
+        "cv",
+        8 * SPC,
+    );
+
+    assert!(trace_contains(&trace, c4, 0.01), "window includes cycle 0 (c4)");
+    assert!(trace_contains(&trace, e4, 0.01), "window includes cycle 1 (e4)");
+    assert!(
+        trace_contains(&trace, g4, 0.01),
+        "fractional offset 0.5 reaches into cycle 2 (g4)"
+    );
+    assert!(
+        !trace_contains(&trace, b4, 0.01),
+        "window [0.5,2.5) never reaches cycle 3 (b4)"
+    );
+
+    // Loops with period 2 cycles (480 samples) in steady state.
+    for s in (4 * SPC)..(6 * SPC) {
+        assert!(
+            approx_eq(trace[s], trace[s + 2 * SPC], 0.01),
+            "cv repeats every 2 cycles: sample {s} vs {}",
+            s + 2 * SPC
+        );
+    }
 }

--- a/docs/superpowers/specs/2026-06-05-fractional-ribbon-design.md
+++ b/docs/superpowers/specs/2026-06-05-fractional-ribbon-design.md
@@ -1,0 +1,113 @@
+# Fractional ribbon window for `$cycle`
+
+## Goal
+
+Let the `$cycle` sequencer's `ribbon: [offset, length]` loop window accept
+fractional cycle values, not just whole-cycle integers. Currently
+`ribbon` is `(u64, u64)`; `ribbon:[0.5, 1.5]` is rejected. After this change a
+fractional ribbon defines a continuous-time loop window (the seam may fall
+mid-cycle) and integer ribbons behave exactly as they do today.
+
+## Motivation
+
+A whole-cycle-only loop window cannot express odd-length or phase-shifted
+loops (e.g. a 1.5-cycle loop, or a window starting half a cycle in). Both
+offset and length should be fractional.
+
+## Design
+
+### Param type
+
+- `ribbon: (f64, f64)` (was `(u64, u64)`), `(offset, length)` in cycles.
+- Default `(0.0, 1024.0)` — unchanged cost (1024 baked cycles).
+- Bounds constants become `f64`: `MAX_RIBBON_LENGTH = 8192.0`,
+  `MAX_RIBBON_OFFSET = 1_000_000.0`, `DEFAULT_RIBBON_LENGTH = 1024.0`.
+
+### Audio-thread fold (`Seq::update`)
+
+The window folds the monotonic clock with a continuous-time modulo instead of
+an integer one:
+
+```text
+raw_clamped = raw.max(0.0)
+phase       = raw_clamped.rem_euclid(length)   // [0, length)
+pos         = offset + phase                    // [offset, offset+length)
+pos_cycle   = pos.floor() as i64                // integer cycle for storage lookup
+logical     = pos                               // playhead in the pattern's absolute frame
+current_cycle = pos_cycle                        // dedup key
+```
+
+- Onset detection compares `logical` against `hap.part_begin/part_end` (the
+  baked cycle's absolute frame) — unchanged.
+- `already_assigned` dedup keys off `current_cycle` — unchanged.
+- Release stays in the monotonic `raw` frame:
+  `raw_begin = raw - (logical - whole_begin)`, `raw_end = raw + (whole_end - logical)`.
+  A note crossing the (now possibly mid-cycle) seam plays its full length into
+  the loop restart, exactly as in the integer design.
+
+Clock cycle 0 still plays the window start (`phase = 0 → pos = offset`):
+`offset` selects which pattern cycles are baked and where the window sits; the
+loop always begins at clock 0.
+
+### Backward compatibility (proof obligation)
+
+For integer `offset` and `length`:
+`pos.floor() == offset + (floor(raw) % length)` and `frac(pos) == frac(raw)`,
+which equal today's `current_cycle` and `logical`. The seven existing ribbon
+tests must pass **unmodified** (except the validation test below, where one
+input changes meaning).
+
+### Baking
+
+The window touches integer cycles `[floor(offset), ceil(offset + length))`.
+Bake one `SeqCycleStorage` per integer cycle in that range.
+
+- `base = floor(offset) as i64`; `cached_haps[i]` holds cycle `base + i`.
+- `SeqPatternParam::bake(offset, length)` computes `base` and `end =
+  ceil(offset + length) as i64`, baking cycles `base..end`.
+- `get_cycle_storage(cycle, base, cached)` indexes `cached[cycle - base]`
+  (signature changes from `offset: u64` to `base: i64`).
+- Bake count = `end - base` ≤ ~8194 with `length ≤ 8192` — bounded, all on the
+  main thread (`deserr` validate hook), never on the audio thread.
+
+### Validation (`seq_bake_ribbon`)
+
+`f64` no longer rejects negative or fractional values structurally, so the hook
+owns all bounds. Reject with a `ribbon`-keyed `ModuleParamErrors`:
+
+- `offset` or `length` not finite (NaN / ±∞) → "ribbon values must be finite"
+- `length <= 0.0` → "ribbon loop length must be greater than 0" (existing)
+- `length > MAX_RIBBON_LENGTH` → "...8192 cycles or fewer" (existing)
+- `offset < 0.0` → "ribbon offset must be 0 or greater" (new)
+- `offset > MAX_RIBBON_OFFSET` → "...1000000 cycles or fewer" (existing)
+
+### Schema / DSL surface
+
+- `yarn build-native` regenerates `schemas.json`: `prefixItems` become
+  `type: number`, default `[0.0, 1024.0]`.
+- `yarn generate-lib`: the generated DSL type stays `ribbon?: [number, number]`
+  (TS `number` already covered both). No hand-written TS references `ribbon`,
+  so there is no DSL-surface change — fractional values simply stop erroring.
+
+## Testing
+
+- **Unchanged:** `seq_ribbon_default_window_plays_pattern_through`,
+  `seq_ribbon_loops_window`, `seq_ribbon_offset_window_plays_and_loops`,
+  `seq_ribbon_wrap_note_plays_full_length_then_releases_once`,
+  `seq_ribbon_note_longer_than_window_plays_full_then_gaps`,
+  `seq_ribbon_note_dividing_window_loops_seamlessly`.
+- **Updated** `seq_ribbon_rejects_invalid_bounds`: `[0.5, 4]` flips from
+  rejected to **valid**; `[-1, 4]` still rejected (now by the hook, not
+  structurally). Add NaN / ∞ rejection cases.
+- **New:**
+  - Fractional length: `ribbon:[0, 1.5]` loops with period 1.5 cycles (seam at
+    mid-cycle); the value at clock pos 0.25, 1.25, and 2.75 follows the
+    folded window.
+  - Fractional offset: `ribbon:[0.5, 2]` — window starts half a cycle into the
+    pattern and loops.
+
+## Out of scope
+
+- Changing the "play full length across the seam" release semantics.
+- Any change to `$step`, `$track`, or other sequencer modules (they do not use
+  the ribbon).


### PR DESCRIPTION
## Summary
Adds a `ribbon: [offset, length]` prop (in **cycles**) to `$cycle` that defines a fixed loop window. The sequencer bakes every hap for `[offset, offset+length)` once at parse time and loops that window forever — the audio thread never re-evaluates the pattern (the old two-tier `module_cache` + audio-thread re-evaluation are removed).

- **Default `[0, 1024]`** — same memory/cost as the previous param cache.
- `length` ∈ `1..=8192`, `offset <= 1_000_000` (whole-cycle integers, `u64`); bounds enforced with clear `ribbon`-keyed param errors, arity/sign/integer enforced structurally by `deserr`.
- Baking moves to a struct-level `deserr` `validate` hook on `SeqParams` (the seam where both `pattern` and `ribbon` are visible); `SeqPatternParam` parse becomes parse-only with a separate `bake(offset, length)`.
- The audio thread folds the monotonic clock into the window with an unsigned modulo and tracks each note's release in the **monotonic frame**, so a note straddling the loop seam plays its full length and releases exactly once.

## ⚠️ Behavior change
At the default ribbon, cycles `>= 1024` now **loop** back to the window start instead of ceasing to fire new notes past the old module-cache horizon (`cycle >= 1088`). This is the intended effect.

## Test plan
- `cargo test -p modular_core` — 534 + new ribbon tests (default window, loop, offset window, seam wrap full-length + single onset, validation errors) + the two state-transfer regressions, all green.
- `yarn build-native` + `yarn generate-lib` — schema is `type:array` + `prefixItems` (uint64, default `[0,1024]`); generated DSL type is `ribbon?: [number, number]`.
- `yarn typecheck` (clean) + `yarn test:unit` (418 passed).
- Node DSL→N-API diagnostic + **live CoreAudio** run: `ribbon:[0,2]` window loops `c4,e4` and never advances to `g4,b4`; invalid `[0,0]`/`[0,9000]`/offset-cap/`[-1,4]`/`[0.5,4]` all rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)