### PR TITLE
Always process every module in cache-efficient order

### DIFF
--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1418,10 +1418,14 @@ impl AudioState {
       deserialized_modules.push((id, module_state.module_type, deserialized));
     }
 
-    // Tarjan SCC over the adjacency map. Cycle participants get `Sample`
-    // mode so the wrapper computes one sample at a time and the 1-sample
-    // feedback delay invariant holds; everyone else gets `Block`.
-    let mode_map = crate::graph_analysis::classify_modules(&adjacency);
+    // One Tarjan SCC pass over the adjacency map yields both the per-module
+    // processing mode and a cache-efficient processing order. Cycle
+    // participants get `Sample` mode so the wrapper computes one sample at a
+    // time and the 1-sample feedback delay invariant holds; everyone else
+    // gets `Block`. The order lists producers before consumers.
+    let analysis = crate::graph_analysis::analyze(&adjacency);
+    let mode_map = analysis.modes;
+    update.process_order_ids = analysis.order;
 
     // Pass 2 — construct modules on the main thread with the resolved mode.
     // The audio thread will always replace existing modules and transfer state.
@@ -1589,9 +1593,35 @@ fn chrono_simple_timestamp() -> String {
 
 /// Audio processor that runs on the audio thread.
 /// Owns the Patch directly and processes commands from the main thread.
+/// A raw handle into an audio-thread-owned module box, used to drive every
+/// module's processing in a cache-efficient order without a per-module hash
+/// lookup. SAFETY mirrors the cable `cached_source_ptr` (see
+/// `modular_core::types::SampleablePtr`): the pointer is resolved from a box
+/// in `AudioProcessor::patch.sampleables` after `connect()`, rebuilt on every
+/// structural patch change (insert/remove/remap/replace), and dereferenced
+/// only on the audio thread, which has exclusive access to the patch.
+/// `ensure_processed_to` takes `&self` and mutates only through the module's
+/// `UnsafeCell`, so shared aliasing with the owning `Box` is sound.
+struct ProcessHandle(modular_core::types::SampleablePtr);
+
+// SAFETY: the pointed-to module is `Send` (Sampleable: Send) and is only ever
+// dereferenced on the audio thread that owns the patch. This mirrors the
+// `unsafe impl Send` on `Signal`/`Buffer`, which cache the same pointer type.
+unsafe impl Send for ProcessHandle {}
+
 struct AudioProcessor {
   /// The DSP patch graph - owned directly, no mutex needed
   patch: Patch,
+  /// Cache-efficient processing order: raw handles into every module box in
+  /// `patch.sampleables`, ordered producers-before-consumers. Walked once per
+  /// block by `process_all_modules_to` so every module advances each block,
+  /// whether or not it is reachable from the output or a scope. Rebuilt from
+  /// `process_order_ids` on every structural patch change.
+  process_order: Vec<ProcessHandle>,
+  /// The module IDs behind `process_order`, in the same order, kept so the
+  /// pointer list can be rebuilt after a box moves (e.g. `SingleModuleUpdate`)
+  /// without re-running graph analysis.
+  process_order_ids: Vec<String>,
   /// Command queue consumer
   command_rx: CommandConsumer,
   /// Error queue producer
@@ -1655,6 +1685,8 @@ impl AudioProcessor {
   ) -> Self {
     Self {
       patch: Patch::new(),
+      process_order: Vec::new(),
+      process_order_ids: Vec::new(),
       command_rx,
       error_tx,
       garbage_tx,
@@ -1769,6 +1801,11 @@ impl AudioProcessor {
           for module in self.patch.sampleables.values() {
             module.on_patch_update();
           }
+          // The old box was dropped and a fresh one inserted at this id, so its
+          // cached pointer now dangles. The graph shape is unchanged (same
+          // modules and cables — only this module's params differ), so reuse
+          // `process_order_ids` and just re-resolve the pointers.
+          self.rebuild_process_order_ptrs();
         }
         GraphCommand::DispatchMessage(msg) => {
           if let Err(e) = self.patch.dispatch_message(&msg) {
@@ -1839,6 +1876,10 @@ impl AudioProcessor {
           }
           self.patch.insert_audio_in();
           self.patch.rebuild_message_listeners();
+          // No user modules remain (only the hidden audio-in, which is driven
+          // by injection), so there is nothing to force-process.
+          self.process_order.clear();
+          self.process_order_ids.clear();
         }
         GraphCommand::SetLink(new_resources) => {
           // Construction/destruction of `AblLink` (and `enable()`) are
@@ -1878,6 +1919,7 @@ impl AudioProcessor {
       remaps,
       inserts,
       desired_ids,
+      process_order_ids,
       scope_adds,
       scope_removes,
       scope_xy_adds,
@@ -1981,6 +2023,11 @@ impl AudioProcessor {
       module.on_patch_update();
     }
 
+    // Adopt the new processing order and resolve it to live box pointers. Must
+    // come after every structural mutation above so no pointer dangles.
+    self.process_order_ids = process_order_ids;
+    self.rebuild_process_order_ptrs();
+
     // Update scopes
     {
       let mut scope_collection = self.scope_collection.lock();
@@ -2074,6 +2121,53 @@ impl AudioProcessor {
     }
     if let Some(audio_in) = self.patch.sampleables.get(WellKnownModule::HiddenAudioIn.id()) {
       audio_in.inject_audio_in_block(&self.input_block_scratch);
+    }
+  }
+
+  /// Rebuild the cache-efficient processing-order pointer list from the
+  /// stored `process_order_ids`. Each `SampleablePtr` targets a module's heap
+  /// pointee (via `module.as_ref()`), which stays put when its `Box` is moved
+  /// (a HashMap rehash relocates the fat pointer, not the allocation) — that
+  /// stability is exactly what makes the cached-pointer scheme sound. A handle
+  /// only dangles when its module is dropped or replaced (the pointee is
+  /// freed), so this must run after ANY mutation of `patch.sampleables` that
+  /// removes/replaces a module — the same discipline the cable
+  /// `cached_source_ptr`s follow, which is why every such site also re-runs
+  /// `connect()`. IDs absent from the patch (e.g. dangling cable targets) are
+  /// skipped. Allocates, so it only runs on the patch-swap path, never in the
+  /// per-sample loop.
+  fn rebuild_process_order_ptrs(&mut self) {
+    let AudioProcessor {
+      patch,
+      process_order,
+      process_order_ids,
+      ..
+    } = self;
+    process_order.clear();
+    process_order.reserve(process_order_ids.len());
+    for id in process_order_ids.iter() {
+      if let Some(module) = patch.sampleables.get(id) {
+        process_order.push(ProcessHandle(modular_core::types::SampleablePtr::from(
+          module.as_ref(),
+        )));
+      }
+    }
+  }
+
+  /// Force every module — including those not reachable from the output or any
+  /// scope — to advance to slot `end` within the current internal block, in
+  /// cache-efficient producer-before-consumer order. Each wrapper memoises per
+  /// slot, so this is idempotent and any later root/scope `get_value_at` read
+  /// of an already-advanced slot is a pure cache hit. Cycles stay correct
+  /// regardless of which member is reached first: the wrapper's reentrancy
+  /// guard preserves the 1-sample feedback delay.
+  #[inline]
+  fn process_all_modules_to(&self, end: usize) {
+    for handle in &self.process_order {
+      // SAFETY: see `ProcessHandle`. Audio-thread-exclusive access; the
+      // pointer is live (rebuilt on every structural patch change) and
+      // `ensure_processed_to` mutates only through the module's UnsafeCell.
+      unsafe { handle.0.as_ref().ensure_processed_to(end) };
     }
   }
 
@@ -2310,6 +2404,16 @@ where
               };
 
               let end = trigger_sample.map(|n| n.min(scan_end)).unwrap_or(scan_end);
+
+              // Force every module to advance to `end`, in cache-efficient
+              // producer-before-consumer order, so modules not reachable from
+              // the output or any scope still process. The root/scope reads in
+              // the drain below then become pure cache hits. Skipped while
+              // stopped so the patch freezes on stop — the drain still ramps
+              // connected modules out via the root pull during the fade.
+              if end > audio_processor.block_pos && !audio_processor.is_stopped() {
+                audio_processor.process_all_modules_to(end);
+              }
 
               // Drain [block_pos, end) into cpal output, inlining the
               // volume-change state machine + soft clip that
@@ -3199,6 +3303,47 @@ mod tests {
     }
   }
 
+  /// A module whose `ensure_processed_to` bumps a shared counter, so tests can
+  /// verify the audio thread force-processes it even with no connections.
+  struct CountingProcessModule {
+    current_id: String,
+    processed: Arc<AtomicUsize>,
+  }
+
+  impl CountingProcessModule {
+    fn new(id: &str, processed: Arc<AtomicUsize>) -> Box<dyn modular_core::types::Sampleable> {
+      Box::new(Self {
+        current_id: id.to_string(),
+        processed,
+      })
+    }
+  }
+
+  impl MessageHandler for CountingProcessModule {}
+
+  impl modular_core::types::Sampleable for CountingProcessModule {
+    fn get_id(&self) -> &str {
+      &self.current_id
+    }
+    fn get_module_type(&self) -> &str {
+      "counting-process"
+    }
+    fn connect(&self, _patch: &modular_core::patch::Patch) {}
+    fn start_block(&self) {}
+    fn ensure_processed_to(&self, _target: usize) {
+      self.processed.fetch_add(1, Ordering::SeqCst);
+    }
+    fn ensure_processed(&self) {
+      self.ensure_processed_to(1);
+    }
+    fn get_value_at(&self, _port: &str, _ch: usize, _index: usize) -> f32 {
+      0.0
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+      self
+    }
+  }
+
   fn create_test_processor() -> (CommandProducer, AudioProcessor) {
     let (
       cmd_producer,
@@ -3471,6 +3616,104 @@ mod tests {
       .unwrap()
       .get_value_at("out", 0, 0);
     assert_eq!(updated, 7.25);
+  }
+
+  #[test]
+  fn process_order_drives_disconnected_module() {
+    // A module with no cables, feeding neither the output nor any scope, must
+    // still be force-processed each block.
+    let (_cmd_producer, mut processor) = create_test_processor();
+    let processed = Arc::new(AtomicUsize::new(0));
+
+    let mut update = PatchUpdate::new(48000.0);
+    update.inserts.push((
+      "iso".into(),
+      CountingProcessModule::new("iso", Arc::clone(&processed)),
+    ));
+    update.desired_ids.insert("iso".into());
+    update.process_order_ids = vec!["iso".into()];
+
+    processor.apply_patch_update(update, 0);
+
+    // apply_patch_update resolved the id order into a live pointer list.
+    assert_eq!(processor.process_order.len(), 1);
+
+    processor.process_all_modules_to(1);
+    assert_eq!(processed.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn process_order_skips_ids_absent_from_patch() {
+    // A dangling id in the order (e.g. a cable target that isn't a module) is
+    // skipped rather than resolved to a bogus pointer.
+    let (_cmd_producer, mut processor) = create_test_processor();
+    let processed = Arc::new(AtomicUsize::new(0));
+
+    let mut update = PatchUpdate::new(48000.0);
+    update.inserts.push((
+      "real".into(),
+      CountingProcessModule::new("real", Arc::clone(&processed)),
+    ));
+    update.desired_ids.insert("real".into());
+    update.process_order_ids = vec!["real".into(), "ghost".into()];
+
+    processor.apply_patch_update(update, 0);
+
+    // Only the real module yields a pointer; "ghost" is silently dropped.
+    assert_eq!(processor.process_order.len(), 1);
+    processor.process_all_modules_to(1);
+    assert_eq!(processed.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn process_order_repointed_after_single_module_update() {
+    // SingleModuleUpdate moves the box, so the cached pointer must be rebuilt
+    // to target the replacement, never the freed original.
+    let (mut cmd_producer, mut processor) = create_test_processor();
+    let old_processed = Arc::new(AtomicUsize::new(0));
+    let new_processed = Arc::new(AtomicUsize::new(0));
+
+    let mut update = PatchUpdate::new(48000.0);
+    update.inserts.push((
+      "m".into(),
+      CountingProcessModule::new("m", Arc::clone(&old_processed)),
+    ));
+    update.desired_ids.insert("m".into());
+    update.process_order_ids = vec!["m".into()];
+    processor.apply_patch_update(update, 0);
+
+    cmd_producer
+      .push(GraphCommand::SingleModuleUpdate {
+        module_id: "m".into(),
+        module: CountingProcessModule::new("m", Arc::clone(&new_processed)),
+      })
+      .unwrap();
+    processor.process_commands();
+
+    processor.process_all_modules_to(1);
+    assert_eq!(old_processed.load(Ordering::SeqCst), 0);
+    assert_eq!(new_processed.load(Ordering::SeqCst), 1);
+  }
+
+  #[test]
+  fn process_order_cleared_on_clear_patch() {
+    let (mut cmd_producer, mut processor) = create_test_processor();
+
+    let mut update = PatchUpdate::new(48000.0);
+    update.inserts.push((
+      "m".into(),
+      CountingProcessModule::new("m", Arc::new(AtomicUsize::new(0))),
+    ));
+    update.desired_ids.insert("m".into());
+    update.process_order_ids = vec!["m".into()];
+    processor.apply_patch_update(update, 0);
+    assert_eq!(processor.process_order.len(), 1);
+
+    cmd_producer.push(GraphCommand::ClearPatch).unwrap();
+    processor.process_commands();
+
+    assert!(processor.process_order.is_empty());
+    assert!(processor.process_order_ids.is_empty());
   }
 
   #[test]

--- a/crates/modular/src/commands.rs
+++ b/crates/modular/src/commands.rs
@@ -40,6 +40,13 @@ pub struct PatchUpdate {
   /// Any existing module not in this set (and not reserved) is stale.
   pub desired_ids: std::collections::HashSet<String>,
 
+  /// Module IDs in cache-efficient processing order (producers before the
+  /// consumers that read them), computed on the main thread by
+  /// `graph_analysis::analyze`. The audio thread resolves these to a
+  /// contiguous pointer list it walks every block to force-process every
+  /// module — including ones not reachable from the output or any scope.
+  pub process_order_ids: Vec<String>,
+
   /// ID remappings (applied before inserts/deletes)
   pub remaps: Vec<ModuleIdRemap>,
 
@@ -86,6 +93,7 @@ impl PatchUpdate {
       update_id: 0,
       inserts: Vec::new(),
       desired_ids: std::collections::HashSet::new(),
+      process_order_ids: Vec::new(),
       remaps: Vec::new(),
       scope_adds: Vec::new(),
       scope_removes: Vec::new(),

--- a/crates/modular/src/graph_analysis.rs
+++ b/crates/modular/src/graph_analysis.rs
@@ -1,8 +1,14 @@
-//! Graph cycle detection via [`petgraph::algo::tarjan_scc`].
+//! Graph analysis via [`petgraph::algo::tarjan_scc`].
 //!
-//! Returns `ProcessingMode` per module ID. Modules in a strongly-connected
-//! component with >1 member, or a single node with a self-loop, are assigned
-//! `Sample` mode. All others get `Block` mode.
+//! A single Tarjan pass yields two things the patch update needs:
+//!
+//! - A [`ProcessingMode`] per module ID. Modules in a strongly-connected
+//!   component with >1 member, or a single node with a self-loop, are assigned
+//!   `Sample` mode (so the wrapper computes one sample at a time and the
+//!   1-sample feedback delay invariant holds). All others get `Block` mode.
+//! - A cache-efficient processing order — every producer is listed before the
+//!   consumers that read it, so when a consumer runs its block the upstream
+//!   output buffers it reads are freshly written and hot in cache.
 //!
 //! Cable extraction lives elsewhere — callers walk deserialized params via
 //! the [`modular_core::types::CollectCables`] trait and pass the resulting
@@ -10,132 +16,200 @@
 //! the cable schema lives in exactly one place: each type's own `CollectCables`
 //! impl.
 
-#![allow(dead_code)]
-
 use modular_core::types::ProcessingMode;
 use petgraph::algo::tarjan_scc;
 use petgraph::graphmap::DiGraphMap;
 use std::collections::HashMap;
 
-/// Classify each module as `Block` or `Sample` based on adjacency.
+/// Result of analysing the cable adjacency graph: the per-module processing
+/// mode and a cache-efficient (producer-before-consumer) processing order.
+pub struct GraphAnalysis {
+  /// `Block` or `Sample` mode per module ID (cycle participants get `Sample`).
+  pub modes: HashMap<String, ProcessingMode>,
+  /// Module IDs in producer-before-consumer order. Cycle members are grouped
+  /// contiguously; their relative order is arbitrary for correctness (the
+  /// wrapper's reentrancy guard makes any order within a cycle valid). Within
+  /// each component IDs are sorted for deterministic output. Dangling
+  /// producer IDs (referenced by a cable but not themselves modules) appear
+  /// here too; callers skip any ID absent from their module map.
+  pub order: Vec<String>,
+}
+
+/// Analyse the cable adjacency graph in a single Tarjan SCC pass.
 ///
 /// `adjacency[consumer]` is the list of producer module IDs `consumer` reads
 /// from (one entry per cable; duplicates are tolerated). Producer IDs that
-/// are not also keys in `adjacency` are inserted as orphan `Block` nodes.
-pub fn classify_modules(
-    adjacency: &HashMap<String, Vec<String>>,
-) -> HashMap<String, ProcessingMode> {
-    let mut g: DiGraphMap<&str, ()> = DiGraphMap::new();
+/// are not also keys in `adjacency` are inserted as orphan `Block` nodes and
+/// still appear in `order`.
+pub fn analyze(adjacency: &HashMap<String, Vec<String>>) -> GraphAnalysis {
+  let mut g: DiGraphMap<&str, ()> = DiGraphMap::new();
 
-    for (consumer, producers) in adjacency {
-        g.add_node(consumer.as_str());
-        for producer in producers {
-            // `add_edge` inserts both endpoints if missing; safe even when the
-            // producer isn't a key in `adjacency` (e.g. a dangling cable).
-            g.add_edge(consumer.as_str(), producer.as_str(), ());
-        }
+  for (consumer, producers) in adjacency {
+    g.add_node(consumer.as_str());
+    for producer in producers {
+      // `add_edge` inserts both endpoints if missing; safe even when the
+      // producer isn't a key in `adjacency` (e.g. a dangling cable).
+      g.add_edge(consumer.as_str(), producer.as_str(), ());
     }
+  }
 
-    let mut result = HashMap::new();
-    for scc in tarjan_scc(&g) {
-        // A 1-node SCC is cyclic iff the node has an edge to itself.
-        let cyclic = scc.len() > 1 || (scc.len() == 1 && g.contains_edge(scc[0], scc[0]));
-        let mode = if cyclic {
-            ProcessingMode::Sample
-        } else {
-            ProcessingMode::Block
-        };
-        for id in scc {
-            result.insert(id.to_string(), mode);
-        }
+  let mut modes = HashMap::new();
+  let mut order = Vec::new();
+
+  // Edges point consumer→producer, and `tarjan_scc` returns components in
+  // reverse-topological order — i.e. a component appears before the
+  // components that have edges into it. With this edge orientation that is
+  // producer-before-consumer, exactly the cache-efficient processing order.
+  for mut scc in tarjan_scc(&g) {
+    // A 1-node SCC is cyclic iff the node has an edge to itself.
+    let cyclic = scc.len() > 1 || (scc.len() == 1 && g.contains_edge(scc[0], scc[0]));
+    let mode = if cyclic {
+      ProcessingMode::Sample
+    } else {
+      ProcessingMode::Block
+    };
+    // Deterministic order within a component (membership is arbitrary).
+    scc.sort_unstable();
+    for id in scc {
+      modes.insert(id.to_string(), mode);
+      order.push(id.to_string());
     }
-    result
+  }
+
+  GraphAnalysis { modes, order }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use modular_core::types::ProcessingMode;
+  use super::*;
+  use modular_core::types::ProcessingMode;
 
-    fn adj(edges: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
-        edges
-            .iter()
-            .map(|(consumer, producers)| {
-                (
-                    consumer.to_string(),
-                    producers.iter().map(|p| p.to_string()).collect(),
-                )
-            })
-            .collect()
-    }
+  fn adj(edges: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+    edges
+      .iter()
+      .map(|(consumer, producers)| {
+        (
+          consumer.to_string(),
+          producers.iter().map(|p| p.to_string()).collect(),
+        )
+      })
+      .collect()
+  }
 
-    #[test]
-    fn no_cycle_is_block_mode() {
-        // A -> B -> C (consumer C reads B; consumer B reads A)
-        let modes = classify_modules(&adj(&[
-            ("A", &[]),
-            ("B", &["A"]),
-            ("C", &["B"]),
-        ]));
-        assert_eq!(modes["A"], ProcessingMode::Block);
-        assert_eq!(modes["B"], ProcessingMode::Block);
-        assert_eq!(modes["C"], ProcessingMode::Block);
-    }
+  fn modes(edges: &[(&str, &[&str])]) -> HashMap<String, ProcessingMode> {
+    analyze(&adj(edges)).modes
+  }
 
-    #[test]
-    fn two_node_cycle_is_sample_mode() {
-        // A <-> B
-        let modes = classify_modules(&adj(&[("A", &["B"]), ("B", &["A"])]));
-        assert_eq!(modes["A"], ProcessingMode::Sample);
-        assert_eq!(modes["B"], ProcessingMode::Sample);
-    }
+  /// Index of `id` within a processing order, for before/after assertions.
+  fn pos(order: &[String], id: &str) -> usize {
+    order
+      .iter()
+      .position(|s| s == id)
+      .unwrap_or_else(|| panic!("{id} missing from order {order:?}"))
+  }
 
-    #[test]
-    fn self_loop_is_sample_mode() {
-        let modes = classify_modules(&adj(&[("A", &["A"])]));
-        assert_eq!(modes["A"], ProcessingMode::Sample);
-    }
+  #[test]
+  fn no_cycle_is_block_mode() {
+    // A -> B -> C (consumer C reads B; consumer B reads A)
+    let m = modes(&[("A", &[]), ("B", &["A"]), ("C", &["B"])]);
+    assert_eq!(m["A"], ProcessingMode::Block);
+    assert_eq!(m["B"], ProcessingMode::Block);
+    assert_eq!(m["C"], ProcessingMode::Block);
+  }
 
-    #[test]
-    fn three_node_cycle_is_sample_mode() {
-        // A → B → C → A (no shorter back-edges)
-        let modes = classify_modules(&adj(&[
-            ("A", &["C"]),
-            ("B", &["A"]),
-            ("C", &["B"]),
-        ]));
-        assert_eq!(modes["A"], ProcessingMode::Sample);
-        assert_eq!(modes["B"], ProcessingMode::Sample);
-        assert_eq!(modes["C"], ProcessingMode::Sample);
-    }
+  #[test]
+  fn two_node_cycle_is_sample_mode() {
+    // A <-> B
+    let m = modes(&[("A", &["B"]), ("B", &["A"])]);
+    assert_eq!(m["A"], ProcessingMode::Sample);
+    assert_eq!(m["B"], ProcessingMode::Sample);
+  }
 
-    #[test]
-    fn cycle_plus_independent_node() {
-        let modes = classify_modules(&adj(&[
-            ("A", &["B"]),
-            ("B", &["A"]),
-            ("C", &[]),
-        ]));
-        assert_eq!(modes["A"], ProcessingMode::Sample);
-        assert_eq!(modes["B"], ProcessingMode::Sample);
-        assert_eq!(modes["C"], ProcessingMode::Block);
-    }
+  #[test]
+  fn self_loop_is_sample_mode() {
+    let m = modes(&[("A", &["A"])]);
+    assert_eq!(m["A"], ProcessingMode::Sample);
+  }
 
-    #[test]
-    fn dangling_producer_is_inserted_as_block() {
-        // Consumer references a module ID that isn't a key — still treated as
-        // a node so it gets a mode entry.
-        let modes = classify_modules(&adj(&[("A", &["MISSING"])]));
-        assert_eq!(modes["A"], ProcessingMode::Block);
-        assert_eq!(modes["MISSING"], ProcessingMode::Block);
-    }
+  #[test]
+  fn three_node_cycle_is_sample_mode() {
+    // A → B → C → A (no shorter back-edges)
+    let m = modes(&[("A", &["C"]), ("B", &["A"]), ("C", &["B"])]);
+    assert_eq!(m["A"], ProcessingMode::Sample);
+    assert_eq!(m["B"], ProcessingMode::Sample);
+    assert_eq!(m["C"], ProcessingMode::Sample);
+  }
 
-    #[test]
-    fn duplicate_producer_edges_collapse() {
-        // Two cables from B reading A — adjacency contains "A" twice. Should
-        // not affect classification.
-        let modes = classify_modules(&adj(&[("B", &["A", "A"])]));
-        assert_eq!(modes["A"], ProcessingMode::Block);
-        assert_eq!(modes["B"], ProcessingMode::Block);
+  #[test]
+  fn cycle_plus_independent_node() {
+    let m = modes(&[("A", &["B"]), ("B", &["A"]), ("C", &[])]);
+    assert_eq!(m["A"], ProcessingMode::Sample);
+    assert_eq!(m["B"], ProcessingMode::Sample);
+    assert_eq!(m["C"], ProcessingMode::Block);
+  }
+
+  #[test]
+  fn dangling_producer_is_inserted_as_block() {
+    // Consumer references a module ID that isn't a key — still treated as
+    // a node so it gets a mode entry.
+    let m = modes(&[("A", &["MISSING"])]);
+    assert_eq!(m["A"], ProcessingMode::Block);
+    assert_eq!(m["MISSING"], ProcessingMode::Block);
+  }
+
+  #[test]
+  fn duplicate_producer_edges_collapse() {
+    // Two cables from B reading A — adjacency contains "A" twice. Should
+    // not affect classification.
+    let m = modes(&[("B", &["A", "A"])]);
+    assert_eq!(m["A"], ProcessingMode::Block);
+    assert_eq!(m["B"], ProcessingMode::Block);
+  }
+
+  #[test]
+  fn order_lists_producers_before_consumers() {
+    // Chain A → B → C (B reads A, C reads B). Processing order must run
+    // the producer before each consumer: A, then B, then C.
+    let order = analyze(&adj(&[("A", &[]), ("B", &["A"]), ("C", &["B"])])).order;
+    assert!(pos(&order, "A") < pos(&order, "B"));
+    assert!(pos(&order, "B") < pos(&order, "C"));
+  }
+
+  #[test]
+  fn order_diamond_producer_first() {
+    // D reads B and C; B and C both read A. A must come first, D last.
+    let order = analyze(&adj(&[
+      ("A", &[]),
+      ("B", &["A"]),
+      ("C", &["A"]),
+      ("D", &["B", "C"]),
+    ]))
+    .order;
+    assert!(pos(&order, "A") < pos(&order, "B"));
+    assert!(pos(&order, "A") < pos(&order, "C"));
+    assert!(pos(&order, "B") < pos(&order, "D"));
+    assert!(pos(&order, "C") < pos(&order, "D"));
+  }
+
+  #[test]
+  fn order_includes_every_module() {
+    // Fully disconnected modules (no cables at all) still appear, so they
+    // get force-processed by the audio thread.
+    let order = analyze(&adj(&[("A", &[]), ("B", &[]), ("C", &[])])).order;
+    assert_eq!(order.len(), 3);
+    for id in ["A", "B", "C"] {
+      assert!(order.contains(&id.to_string()), "{id} missing");
     }
+  }
+
+  #[test]
+  fn order_groups_cycle_before_downstream_consumer() {
+    // Cycle A <-> B feeds C. The two cycle members come before C and are
+    // adjacent to each other.
+    let order = analyze(&adj(&[("A", &["B"]), ("B", &["A"]), ("C", &["A"])])).order;
+    assert!(pos(&order, "A") < pos(&order, "C"));
+    assert!(pos(&order, "B") < pos(&order, "C"));
+    let span = pos(&order, "A").abs_diff(pos(&order, "B"));
+    assert_eq!(span, 1, "cycle members should be contiguous: {order:?}");
+  }
 }

--- a/crates/modular/src/lib.rs
+++ b/crates/modular/src/lib.rs
@@ -800,10 +800,10 @@ fn setup_streams(params: StreamSetupParams) -> Result<StreamSetupResult> {
 
   // Internal block size. The audio callback drains `block_size` cpal
   // frames per block-level pass (link sync, queued patch swap,
-  // `ensure_processed` on every module, transport-meter write). CPAL's
-  // own buffer size is independent — the callback handles any count of
-  // cpal frames per invocation, splitting them across internal blocks
-  // via `block_pos`.
+  // force-processing every module in dependency order, transport-meter
+  // write). CPAL's own buffer size is independent — the callback handles
+  // any count of cpal frames per invocation, splitting them across
+  // internal blocks via `block_pos`.
   //
   // 64 samples @ 48 kHz = ~1.33 ms per block. Chosen as a balance
   // between block-amortised CPU savings and per-bar-trigger jitter

--- a/crates/modular_core/src/params.rs
+++ b/crates/modular_core/src/params.rs
@@ -57,10 +57,10 @@ pub trait CloneableParams: Send + 'static {
     /// Walk the params and push every producer module ID it references
     /// (cables, buffer sources, table-internal signals) into `sink`.
     ///
-    /// Used by graph cycle classification before module construction so
-    /// downstream code (e.g. `graph_analysis::classify_modules`) can decide
-    /// whether each module needs `Block` or `Sample` processing without
-    /// requiring the audio thread to know the params type.
+    /// Used to build the cable adjacency map before module construction so
+    /// `graph_analysis::analyze` can decide whether each module needs `Block`
+    /// or `Sample` processing and compute the cache-efficient processing
+    /// order, without requiring the audio thread to know the params type.
     fn collect_cables(&self, sink: &mut Vec<String>);
 }
 

--- a/crates/modular_core/src/types.rs
+++ b/crates/modular_core/src/types.rs
@@ -226,8 +226,10 @@ pub trait Sampleable: MessageHandler + Send {
     fn ensure_processed_to(&self, target: usize);
 
     /// Complete any remaining block computation. Equivalent to
-    /// `ensure_processed_to(block_size)`. Called on every module after the
-    /// sink pull so disconnected modules also advance their state.
+    /// `ensure_processed_to(block_size)`. Used by composite modules to fully
+    /// drive a nested sub-module. (The audio thread force-advances every
+    /// top-level module each block via `ensure_processed_to(end)` in
+    /// producer-before-consumer order, so disconnected modules still run.)
     fn ensure_processed(&self);
 
     /// Read the value of port `port`, channel `ch`, at sample slot `index`

--- a/crates/modular_core/tests/dsp_fresh_tests.rs
+++ b/crates/modular_core/tests/dsp_fresh_tests.rs
@@ -30,8 +30,8 @@ const DEFAULT_PORT: &str = "output";
 /// Note: cycle classification (`Block` vs `Sample`) is the caller's
 /// responsibility in `Patch::from_graph`; the tests below pass an empty
 /// `mode_map`, which defaults every module to `Block`. Cycle-aware tests
-/// would build the map via `modular::graph_analysis::classify_modules`
-/// first, but the patches here are acyclic.
+/// would build the map via `modular::graph_analysis::analyze` first, but the
+/// patches here are acyclic.
 const TEST_BLOCK_SIZE: usize = 1;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Modules were processed lazily — pulled on demand from the root output and scopes — so any module not transitively connected to a sink never ran. Modules with internal state (LFOs, sequencers, envelopes) froze when disconnected, which is hard to reason about while live-coding.

This makes **every module process every block**, regardless of connectivity, in a **cache-efficient producer-before-consumer order**.

## How

- **`graph_analysis::analyze`** — one Tarjan SCC pass returns both the `ProcessingMode` map *and* a producer-before-consumer processing order (replaces `classify_modules`). Cycle members are grouped; SCCs are emitted producers-first.
- **`PatchUpdate.process_order_ids`** — computed on the main thread in `apply_patch`; the audio thread resolves it to a contiguous `Vec<ProcessHandle>` (a `NonNull<dyn Sampleable>` `Send`-wrapper, mirroring the existing cable `cached_source_ptr` pattern). Rebuilt after every structural patch change (`apply_patch_update`, `SingleModuleUpdate`), cleared on `ClearPatch`.
- **`process_all_modules_to(end)`** — the callback drives every module to `end` before the per-sample output drain, gated on the running state so **stop still freezes** the patch. Root/scope reads become pure cache hits.

## Correctness

Processing order is semantically free here: the module wrapper is memoized and its reentrancy guard preserves the documented 1-sample feedback delay regardless of which cycle member is entered first. The only observable changes are (a) cache locality and (b) which branch of a *multi-node* feedback cycle carries the 1-sample delay (now deterministic — alphabetically-first SCC member).

## Trade-off (intentional)

Disconnected modules now consume CPU continuously while the patch runs. This is the goal: keeping stateful modules (LFOs, sequencers, envelopes) advancing even when unplugged makes patches far easier to reason about during live-coding.

## Tests / review

- New unit tests: processing-order analysis (producers-first, diamonds, cycles, isolated nodes) and the audio-thread drive (disconnected module driven, dangling ids skipped, pointer repointed after `SingleModuleUpdate`, cleared on `ClearPatch`).
- `cargo test`: 75 (`modular`) + 553 (`modular_core`) passing; clean build; `index.d.ts` (N-API surface) unchanged.
- Ran a 4-lens adversarial review (RT-safety, cycle correctness, stopped-state/triggers, completeness): no functional defects; one doc-comment precision fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)