### PR TITLE
Restart clock/transport on buffer switch

### DIFF
--- a/crates/modular/index.d.ts
+++ b/crates/modular/index.d.ts
@@ -52,7 +52,7 @@ export declare class Synthesizer {
    * window the renderer maps into clip space.
    */
   getScopeXy(): Array<[ScopeXyBufferKey, Float32Array, Float32Array, ScopeXyRanges]>
-  updatePatch(patch: PatchGraph, trigger?: QueuedTrigger | undefined | null): PatchUpdateResult
+  updatePatch(patch: PatchGraph, trigger?: QueuedTrigger | undefined | null, resetClock?: boolean | undefined | null): PatchUpdateResult
   /** Load a WAV file into the cache, returning metadata about the loaded sample. */
   loadWav(path: string): WavLoadInfo
   /** Set the workspace root directory for WAV file loading. */

--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -1310,6 +1310,7 @@ impl AudioState {
     update_id: u64,
     wav_data: HashMap<String, Arc<modular_core::types::WavData>>,
     tempo_override: Option<f64>,
+    reset_clock: bool,
   ) -> Result<()> {
     let PatchGraph {
       modules,
@@ -1499,6 +1500,9 @@ impl AudioState {
     // Pass through tempo override for Link integration
     update.tempo_override = tempo_override;
 
+    // Restart the transport when applying this update (set on a buffer switch)
+    update.reset_clock = reset_clock;
+
     // Send the update to audio thread
     self.send_command(GraphCommand::QueuedPatchUpdate { update, trigger })
   }
@@ -1511,6 +1515,7 @@ impl AudioState {
     update_id: u64,
     wav_data: HashMap<String, Arc<modular_core::types::WavData>>,
     tempo_override: Option<f64>,
+    reset_clock: bool,
   ) -> Vec<ApplyPatchError> {
     // Validate patch
     let schemas = schema();
@@ -1540,6 +1545,7 @@ impl AudioState {
       update_id,
       wav_data,
       tempo_override,
+      reset_clock,
     ) {
       return vec![ApplyPatchError {
         message: format!("Failed to apply patch: {}", e),
@@ -1719,7 +1725,7 @@ impl AudioProcessor {
     // Process commands from the main thread
     while let Ok(cmd) = self.command_rx.pop() {
       match cmd {
-        GraphCommand::QueuedPatchUpdate { update, trigger } => {
+        GraphCommand::QueuedPatchUpdate { mut update, trigger } => {
           // Push tempo to Link if explicitly set via $setTempo. The
           // capture/commit call inside `set_tempo_now` is the realtime-safe
           // way to mutate session state per Ableton's docs.
@@ -1733,6 +1739,11 @@ impl AudioProcessor {
           // we treat it as "apply now" rather than re-queuing for the next
           // bar/beat.
           if let Some((old_update, _)) = self.queued_update.take() {
+            // Carry a pending transport reset forward: if the superseded update
+            // was a buffer switch that never fired, the immediate apply still
+            // lands on a different song than what's playing, so it must still
+            // restart the clock.
+            update.reset_clock |= old_update.reset_clock;
             if let Err(err) = self.garbage_tx.push(GarbageItem::PatchUpdate(old_update)) {
               println!(
                 "Failed to push old patch update to garbage queue: ${:?}",
@@ -1885,6 +1896,7 @@ impl AudioProcessor {
       wav_data,
       profile_records_seed,
       profile_shared_seed,
+      reset_clock,
       ..
     } = update;
 
@@ -2057,6 +2069,19 @@ impl AudioProcessor {
           }
         }
       });
+    }
+
+    // Restart the transport when this update switches playback to a different
+    // buffer (song). Free-run only: under Ableton Link the shared session
+    // timeline is authoritative — a local reset would be re-overridden by the
+    // next synced sample and would spuriously re-fire the bar/beat triggers.
+    // Runs after the inserts/transfer/connect above so ROOT_CLOCK's message
+    // listener is registered; the swap-site eager-fill then refills the block
+    // from phase 0.
+    if reset_clock && !self.link.is_active() {
+      let _ = self
+        .patch
+        .dispatch_message(&Message::Clock(ClockMessages::Start));
     }
   }
 
@@ -3389,6 +3414,139 @@ mod tests {
         .get_module_type(),
       "my-vca",
       "module should be at new ID"
+    );
+  }
+
+  /// Build a real running ROOT_CLOCK at 120 BPM 4/4, register it as a message
+  /// listener (as `apply_patch_update` does for inserted modules), and start it
+  /// from phase 0. Returns its module id.
+  fn insert_running_root_clock(processor: &mut AudioProcessor) -> String {
+    let id = modular_core::types::ROOT_CLOCK_ID.to_string();
+    let constructors = get_constructors();
+    let constructor = constructors.get("_clock").expect("_clock constructor");
+    let params = crate::deserialize_params(
+      "_clock",
+      serde_json::json!({ "tempo": 120.0, "numerator": 4, "denominator": 4 }),
+      true,
+    )
+    .expect("deserialize clock params");
+    let clock = constructor(
+      &id,
+      44_100.0,
+      params,
+      processor.block_size,
+      modular_core::types::ProcessingMode::Sample,
+    )
+    .expect("construct clock");
+    processor.patch.sampleables.insert(id.clone(), clock);
+    processor.patch.add_message_listeners_for_module(&id);
+    processor
+      .patch
+      .dispatch_message(&Message::Clock(ClockMessages::Start))
+      .expect("start clock");
+    id
+  }
+
+  /// Advance the clock by `samples` and return its resulting bar phase. The test
+  /// processor uses `block_size == 1`, so each block is one `update`.
+  fn advance_clock(processor: &AudioProcessor, id: &str, samples: usize) -> f32 {
+    let clock = processor.patch.sampleables.get(id).unwrap();
+    let mut phase = 0.0;
+    for _ in 0..samples {
+      clock.start_block();
+      phase = clock.get_value_at("playhead", 0, 0);
+    }
+    phase
+  }
+
+  #[test]
+  fn apply_patch_update_with_reset_clock_restarts_transport() {
+    let (_cmd_producer, mut processor) = create_test_processor();
+    let id = insert_running_root_clock(&mut processor);
+
+    // Run well into the bar so the phase is unambiguously non-zero.
+    let phase_before = advance_clock(&processor, &id, 20_000);
+    assert!(
+      phase_before > 0.1,
+      "clock should have advanced before reset, got {phase_before}"
+    );
+
+    let mut update = PatchUpdate::new(44_100.0);
+    update.reset_clock = true;
+    update.desired_ids.insert(id.clone());
+    processor.apply_patch_update(update, 0);
+
+    // Re-fill the block from the top (mirrors the swap-site eager-fill) and
+    // confirm the transport restarted near zero.
+    let phase_after = advance_clock(&processor, &id, 1);
+    assert!(
+      phase_after < 0.001,
+      "transport should restart at ~0 after reset, got {phase_after}"
+    );
+  }
+
+  #[test]
+  fn apply_patch_update_without_reset_clock_keeps_transport_running() {
+    let (_cmd_producer, mut processor) = create_test_processor();
+    let id = insert_running_root_clock(&mut processor);
+
+    let phase_before = advance_clock(&processor, &id, 20_000);
+    assert!(
+      phase_before > 0.1,
+      "clock should have advanced, got {phase_before}"
+    );
+
+    let mut update = PatchUpdate::new(44_100.0);
+    update.reset_clock = false;
+    update.desired_ids.insert(id.clone());
+    processor.apply_patch_update(update, 0);
+
+    // Without a reset the clock keeps advancing from where it was.
+    let phase_after = advance_clock(&processor, &id, 1);
+    assert!(
+      phase_after > phase_before,
+      "transport should keep running (no reset): before={phase_before} after={phase_after}"
+    );
+  }
+
+  #[test]
+  fn superseded_queued_clock_reset_is_inherited() {
+    // A buffer-switch update (reset_clock=true) queued for the next bar, then
+    // superseded by a same-buffer re-eval (reset_clock=false) before it fires,
+    // must still carry the pending transport reset into the immediate apply.
+    let (mut cmd_producer, mut processor) = create_test_processor();
+
+    let mut switch_update = PatchUpdate::new(44_100.0);
+    switch_update.reset_clock = true;
+    cmd_producer
+      .push(GraphCommand::QueuedPatchUpdate {
+        update: switch_update,
+        trigger: QueuedTrigger::NextBar,
+      })
+      .unwrap();
+
+    let mut reeval_update = PatchUpdate::new(44_100.0);
+    reeval_update.reset_clock = false;
+    cmd_producer
+      .push(GraphCommand::QueuedPatchUpdate {
+        update: reeval_update,
+        trigger: QueuedTrigger::NextBar,
+      })
+      .unwrap();
+
+    processor.process_commands();
+
+    let (queued, trigger) = processor
+      .queued_update
+      .as_ref()
+      .expect("an update should remain queued");
+    assert!(
+      queued.reset_clock,
+      "pending clock reset must survive being superseded"
+    );
+    assert!(
+      matches!(trigger, QueuedTrigger::Immediate),
+      "superseding update applies immediately"
     );
   }
 

--- a/crates/modular/src/commands.rs
+++ b/crates/modular/src/commands.rs
@@ -65,6 +65,12 @@ pub struct PatchUpdate {
   /// Whether the DSL explicitly called $setTempo (don't push default 120 to Link)
   pub tempo_override: Option<f64>,
 
+  /// When true, restart ROOT_CLOCK's transport (phase, beat, bar count) to zero
+  /// as this update is applied. Set by the main thread when the update switches
+  /// playback to a different buffer (song); a same-buffer live-coding update
+  /// leaves it false so the clock keeps running uninterrupted.
+  pub reset_clock: bool,
+
   /// Pre-allocated TLS profiler records map, one entry per id in
   /// `desired_ids`. Consumed by `profiling::swap_records` on the audio
   /// thread; the evicted map flows back via the garbage queue. Always
@@ -94,6 +100,7 @@ impl PatchUpdate {
       wav_data: HashMap::new(),
       sample_rate,
       tempo_override: None,
+      reset_clock: false,
       profile_records_seed: HashMap::new(),
       profile_shared_seed: HashMap::new(),
     }

--- a/crates/modular/src/lib.rs
+++ b/crates/modular/src/lib.rs
@@ -1129,6 +1129,7 @@ impl Synthesizer {
     &mut self,
     mut patch: PatchGraph,
     trigger: Option<QueuedTrigger>,
+    reset_clock: Option<bool>,
   ) -> PatchUpdateResult {
     // Extract MIDI device names from MIDI modules and sync connections
     self.sync_midi_devices_from_patch(&patch);
@@ -1187,6 +1188,7 @@ impl Synthesizer {
       update_id,
       wav_data_snapshot,
       tempo_override,
+      reset_clock.unwrap_or(false),
     );
 
     PatchUpdateResult {

--- a/src/main/__tests__/bufferSwitch.test.ts
+++ b/src/main/__tests__/bufferSwitch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { isBufferSwitch } from '../bufferSwitch';
+
+describe('isBufferSwitch', () => {
+    test('re-applying the same buffer is not a switch', () => {
+        expect(isBufferSwitch('song-a', 'song-a')).toBe(false);
+    });
+
+    test('the very first apply (no previous source) is not a switch', () => {
+        expect(isBufferSwitch(null, 'song-a')).toBe(false);
+    });
+
+    test('switching to a different buffer is a switch', () => {
+        expect(isBufferSwitch('song-a', 'song-b')).toBe(true);
+    });
+
+    test('a missing/empty next source id is not a switch', () => {
+        expect(isBufferSwitch('song-a', undefined)).toBe(false);
+        expect(isBufferSwitch('song-a', '')).toBe(false);
+    });
+});

--- a/src/main/bufferSwitch.ts
+++ b/src/main/bufferSwitch.ts
@@ -1,0 +1,23 @@
+/**
+ * Decide whether applying a patch update should restart the transport clock.
+ *
+ * The clock restarts only when playback switches from one buffer (song) to a
+ * different one — i.e. the source identity differs from the previously-applied
+ * source. Re-evaluating the same buffer (unchanged id) keeps the clock running
+ * so live-coding never interrupts the transport. The very first apply (no
+ * previous source) also keeps it: starting from a stopped engine already begins
+ * the transport at zero on its own.
+ *
+ * `sourceId` is a stable per-buffer identity (the editor tab's id), not a file
+ * path — so renaming or saving the playing buffer does not count as a switch.
+ */
+export function isBufferSwitch(
+    previousSourceId: string | null,
+    nextSourceId: string | null | undefined,
+): boolean {
+    return (
+        Boolean(nextSourceId) &&
+        previousSourceId !== null &&
+        nextSourceId !== previousSourceId
+    );
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -23,6 +23,7 @@ import type {
 } from '../shared/ipcTypes';
 import { IPC_CHANNELS, MENU_CHANNELS } from '../shared/ipcTypes';
 import { reconcilePatchBySimilarity } from './patchSimilarityRemap';
+import { isBufferSwitch } from './bufferSwitch';
 import { executePatchScript } from './dsl/executor';
 import { buildLibSource } from './dsl/typescriptLibGen';
 import type { WavsFolderNode } from './dsl/typescriptLibGen';
@@ -894,6 +895,10 @@ registerIPCHandler(
             const shouldReconcile =
                 Boolean(sourceId) && lastAppliedSourceId === sourceId;
 
+            // Switching playback to a different buffer (song) restarts the
+            // transport from the top, applied atomically with the patch swap.
+            const resetClock = isBufferSwitch(lastAppliedSourceId, sourceId);
+
             if (DEBUG_LOG) {
                 if (!sourceId) {
                     console.log(
@@ -945,7 +950,11 @@ registerIPCHandler(
                 }),
             );
 
-            const { errors, updateId } = synth.updatePatch(patch, trigger);
+            const { errors, updateId } = synth.updatePatch(
+                patch,
+                trigger,
+                resetClock,
+            );
 
             if (errors.length === 0) {
                 lastAppliedPatchGraph = patch;
@@ -1003,6 +1012,10 @@ registerIPCHandler('SYNTH_UPDATE_PATCH', (patch, sourceId, trigger) => {
     const shouldReconcile =
         Boolean(sourceId) && lastAppliedSourceId === sourceId;
 
+    // Switching playback to a different buffer (song) restarts the transport
+    // from the top, applied atomically with the patch swap.
+    const resetClock = isBufferSwitch(lastAppliedSourceId, sourceId);
+
     if (DEBUG_LOG) {
         if (!sourceId) {
             console.log('[patch-remap] no sourceId; reconciliation disabled');
@@ -1047,7 +1060,7 @@ registerIPCHandler('SYNTH_UPDATE_PATCH', (patch, sourceId, trigger) => {
         to,
     }));
 
-    const { errors, updateId } = synth.updatePatch(patch, trigger);
+    const { errors, updateId } = synth.updatePatch(patch, trigger, resetClock);
 
     if (errors.length === 0) {
         lastAppliedPatchGraph = patch;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MonacoPatchEditor as PatchEditor } from './components/MonacoPatchEditor';
 import { AudioControls } from './components/AudioControls';
 import { TransportDisplay } from './components/TransportDisplay';
@@ -40,6 +40,7 @@ import {
     scopeBufferKeyToString,
 } from './app/oscilloscope';
 import { useEditorBuffers } from './app/hooks/useEditorBuffers';
+import { getBufferId } from './app/buffers';
 import {
     setTransport,
     updateTransport,
@@ -481,6 +482,20 @@ function App() {
         patchCodeRef.current = patchCode;
     }, [patchCode]);
 
+    // Stable per-buffer identity (the tab's id) used as the patch source id.
+    // Unlike activeBufferId — a file's mutable path — this survives rename and
+    // save, so reconciliation/clock-reset key on the buffer, not its path.
+    const activeSourceId = useMemo(
+        () =>
+            buffers.find((b) => getBufferId(b) === activeBufferId)?.id ??
+            activeBufferId,
+        [buffers, activeBufferId],
+    );
+    const activeSourceIdRef = useRef(activeSourceId);
+    useEffect(() => {
+        activeSourceIdRef.current = activeSourceId;
+    }, [activeSourceId]);
+
     const isClockRunningRef = useRef(isClockRunning);
     useEffect(() => {
         isClockRunningRef.current = isClockRunning;
@@ -667,10 +682,12 @@ function App() {
             try {
                 const patchCodeValue = patchCodeRef.current;
 
-                // Execute DSL in main process (has direct N-API access)
+                // Execute DSL in main process (has direct N-API access).
+                // Use the stable buffer id (not activeBufferId, a file's mutable
+                // path) so reconciliation/clock-reset key on the buffer itself.
                 const result = await electronAPI.executeDSL(
                     patchCodeValue,
-                    activeBufferId,
+                    activeSourceIdRef.current,
                     trigger,
                 );
                 lastPatchResultRef.current = result;


### PR DESCRIPTION
## What

When the user switches playback from one editor buffer (song) to another, `$clock` and the transport now restart at 0. The reset is applied **atomically as part of the queued patch swap**, so the existing queue-on-beat/bar timing is unchanged. Re-evaluating the *same* buffer (live-coding) leaves the clock running.

## How

A `reset_clock` flag rides the patch update from the main process down to the audio thread:

- **`commands.rs`** — `PatchUpdate` gains `reset_clock: bool`.
- **`lib.rs` / `audio.rs`** — threaded through `update_patch → handle_set_patch → apply_patch`. `apply_patch_update` dispatches the clock's existing `Start` reset to `ROOT_CLOCK` at the swap, **free-run only** (`!link.is_active()`): under Ableton Link the shared session timeline is authoritative, so a local reset would be re-overridden and would spuriously re-fire bar/beat triggers.
- **supersede path** — a pending switch-reset is **inherited** when a queued update is superseded by an immediate one (the rapid double-submit case), so it is never silently dropped.
- **`bufferSwitch.ts` + `main.ts`** — pure `isBufferSwitch(prev, next)` decides the reset; wired into both patch-apply handlers.
- **`App.tsx`** — passes the **stable buffer id** (the editor tab's id) as the source id instead of the file path, so renaming or saving the playing buffer doesn't spuriously reset (this also makes patch reconciliation survive renames).

## Design decisions

- **Link mode skips the reset** — the transport is shared with peers; free-run (solo) is where the reset applies.
- **Buffer identity = the editor tab** — switching tabs resets; rename/save of the playing buffer does not; closing and reopening a file (a new tab) counts as a switch.

## Testing

- Full `cargo test` suite passes, including 3 new tests (reset restarts transport / no-reset keeps it running / superseded reset is inherited).
- `yarn test:unit` — 436 pass, including 4 new `bufferSwitch` tests.
- `yarn typecheck` clean; native module rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
