### PR TITLE
feat: pattern arrange + fast/slow modifiers

### DIFF
--- a/crates/modular/schemas.json
+++ b/crates/modular/schemas.json
@@ -8032,7 +8032,7 @@
               "$ref": "#/$defs/SectionCycles"
             },
             "pattern": {
-              "$ref": "#/$defs/SeqPatternSource2"
+              "$ref": "#/$defs/SeqPatternSource"
             }
           },
           "required": [
@@ -8145,7 +8145,7 @@
               "$ref": "#/$defs/FactorPayload"
             },
             "pattern": {
-              "$ref": "#/$defs/SeqPatternSource2"
+              "$ref": "#/$defs/SeqPatternSource"
             }
           },
           "required": [
@@ -9806,26 +9806,6 @@
             }
           ]
         },
-        "SeqPatternSource2": {
-          "description": "Wire-level dispatch shape: a `.fast`/`.slow` wrapper, an `$p.arrange`\npayload, a chained `$p.s` payload with multi-source highlighting, or a\nsingle `ParsedPatternPayload` (the legacy single-source path used by\n`$cycle($p(...))`).\n\nThe `__kind`-tagged variants (`Fast`/`Slow`/`Arrange`/`Sp`) are listed before\nthe untagged `Single`; each carries a distinct required `__kind` literal, so\nthe untagged enum disambiguates them unambiguously before falling back to\n`Single`.",
-          "anyOf": [
-            {
-              "$ref": "#/$defs/FastPatternPayload"
-            },
-            {
-              "$ref": "#/$defs/SlowPatternPayload"
-            },
-            {
-              "$ref": "#/$defs/ArrangePatternPayload"
-            },
-            {
-              "$ref": "#/$defs/SpPatternPayload"
-            },
-            {
-              "$ref": "#/$defs/ParsedPatternPayload"
-            }
-          ]
-        },
         "Signal": {
           "anyOf": [
             {
@@ -9889,7 +9869,7 @@
               "$ref": "#/$defs/FactorPayload"
             },
             "pattern": {
-              "$ref": "#/$defs/SeqPatternSource2"
+              "$ref": "#/$defs/SeqPatternSource"
             }
           },
           "required": [

--- a/crates/modular/schemas.json
+++ b/crates/modular/schemas.json
@@ -7997,6 +7997,49 @@
             "end"
           ]
         },
+        "ArrangeKindTag": {
+          "description": "Phantom discriminator matching the literal `\"ArrangePattern\"` string.",
+          "type": "string",
+          "enum": [
+            "ArrangePattern"
+          ]
+        },
+        "ArrangePatternPayload": {
+          "description": "JSON payload for `$cycle($p.arrange(...))`. Sections play in order, each for\nits cycle budget; the whole loops with period `Σ cycles`. A trailing section\nwith `cycles == \"Infinity\"` loops forever once reached.",
+          "type": "object",
+          "properties": {
+            "__kind": {
+              "description": "Discriminator — TS-side `$p.arrange` sets this so the `SeqPatternSource`\nuntagged enum picks the `Arrange` variant.",
+              "$ref": "#/$defs/ArrangeKindTag"
+            },
+            "sections": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/ArrangeSectionPayload"
+              }
+            }
+          },
+          "required": [
+            "__kind",
+            "sections"
+          ]
+        },
+        "ArrangeSectionPayload": {
+          "description": "One section of an `$p.arrange(...)` payload: a cycle budget plus a pattern.\n`pattern` is any [`SeqPatternSource`] (recursively), so a section may be a\n`$p`, a `$p.s`, or a nested `$p.arrange`.",
+          "type": "object",
+          "properties": {
+            "cycles": {
+              "$ref": "#/$defs/SectionCycles"
+            },
+            "pattern": {
+              "$ref": "#/$defs/SeqPatternSource2"
+            }
+          },
+          "required": [
+            "cycles",
+            "pattern"
+          ]
+        },
         "AtomValue": {
           "description": "Atomic value types produced by the `$p()` DSL parser.\n\nThe reduced set from strudel's krill grammar: `Number` covers bare\nnumeric atoms, `Hz` covers frequency-tagged numbers (`440hz`), and\n`Note` covers pitched letter-octave atoms (`c4`, `d#3`, `eb5`).\nEvery other atom form (`m60` midi shorthand, sample-name identifiers,\n`2v` voltage, module references, quoted strings) has been removed from\nthe grammar and is not representable here.",
           "oneOf": [
@@ -8067,6 +8110,55 @@
                 "Note"
               ]
             }
+          ]
+        },
+        "FactorPayload": {
+          "description": "A `.fast`/`.slow` factor. A bare number (`.fast(2)`) is a constant speed —\nnot a highlightable source. A parsed pattern (`.fast(\"2 4\")`) becomes its own\nhighlightable source, so its active value lights up in the editor as it\ndrives the speed. A factor of `0` yields silence and negatives reverse time,\nmirroring the in-string `*` operator.",
+          "anyOf": [
+            {
+              "description": "`.fast(2)` — a constant. JSON numbers match this before `Pattern`.",
+              "type": "number",
+              "format": "double"
+            },
+            {
+              "description": "`.fast(\"2 4\")` — a parsed number pattern.",
+              "$ref": "#/$defs/ParsedPatternPayload"
+            }
+          ]
+        },
+        "FastKindTag": {
+          "description": "Phantom discriminator matching the literal `\"FastPattern\"` string.",
+          "type": "string",
+          "enum": [
+            "FastPattern"
+          ]
+        },
+        "FastPatternPayload": {
+          "description": "JSON payload for `$p(...).fast(factor)`: speed `pattern` up by `factor`.\n`pattern` is any [`SeqPatternSource`] (recursively), so `.fast` chains and\nnests over `$p`, `$p.s`, `$p.arrange`, and other `.fast`/`.slow` wrappers.",
+          "type": "object",
+          "properties": {
+            "__kind": {
+              "description": "Discriminator — TS-side `.fast` sets this so the `SeqPatternSource`\nuntagged enum picks the `Fast` variant.",
+              "$ref": "#/$defs/FastKindTag"
+            },
+            "factor": {
+              "$ref": "#/$defs/FactorPayload"
+            },
+            "pattern": {
+              "$ref": "#/$defs/SeqPatternSource2"
+            }
+          },
+          "required": [
+            "__kind",
+            "pattern",
+            "factor"
+          ]
+        },
+        "InfinityTag": {
+          "description": "Phantom discriminator matching the literal `\"Infinity\"` string.",
+          "type": "string",
+          "enum": [
+            "Infinity"
           ]
         },
         "Located": {
@@ -9682,9 +9774,50 @@
             "all_spans"
           ]
         },
-        "SeqPatternSource": {
-          "description": "Wire-level dispatch shape: either a single `ParsedPatternPayload`\n(legacy single-source path used by `$cycle($p(...))`) or a chained\n`$p.s` payload with multi-source highlighting.",
+        "SectionCycles": {
+          "description": "Cycle count for an `$p.arrange(...)` section: a finite positive integer, or\nthe sentinel string `\"Infinity\"` for an infinite tail section. JSON can't\ncarry a numeric infinity, so the TS `$p.arrange` helper emits the string\n`\"Infinity\"`; any finite count arrives as a JSON number.",
           "anyOf": [
+            {
+              "type": "number",
+              "format": "double"
+            },
+            {
+              "$ref": "#/$defs/InfinityTag"
+            }
+          ]
+        },
+        "SeqPatternSource": {
+          "description": "Wire-level dispatch shape: a `.fast`/`.slow` wrapper, an `$p.arrange`\npayload, a chained `$p.s` payload with multi-source highlighting, or a\nsingle `ParsedPatternPayload` (the legacy single-source path used by\n`$cycle($p(...))`).\n\nThe `__kind`-tagged variants (`Fast`/`Slow`/`Arrange`/`Sp`) are listed before\nthe untagged `Single`; each carries a distinct required `__kind` literal, so\nthe untagged enum disambiguates them unambiguously before falling back to\n`Single`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FastPatternPayload"
+            },
+            {
+              "$ref": "#/$defs/SlowPatternPayload"
+            },
+            {
+              "$ref": "#/$defs/ArrangePatternPayload"
+            },
+            {
+              "$ref": "#/$defs/SpPatternPayload"
+            },
+            {
+              "$ref": "#/$defs/ParsedPatternPayload"
+            }
+          ]
+        },
+        "SeqPatternSource2": {
+          "description": "Wire-level dispatch shape: a `.fast`/`.slow` wrapper, an `$p.arrange`\npayload, a chained `$p.s` payload with multi-source highlighting, or a\nsingle `ParsedPatternPayload` (the legacy single-source path used by\n`$cycle($p(...))`).\n\nThe `__kind`-tagged variants (`Fast`/`Slow`/`Arrange`/`Sp`) are listed before\nthe untagged `Single`; each carries a distinct required `__kind` literal, so\nthe untagged enum disambiguates them unambiguously before falling back to\n`Single`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FastPatternPayload"
+            },
+            {
+              "$ref": "#/$defs/SlowPatternPayload"
+            },
+            {
+              "$ref": "#/$defs/ArrangePatternPayload"
+            },
             {
               "$ref": "#/$defs/SpPatternPayload"
             },
@@ -9735,6 +9868,34 @@
                 "port"
               ]
             }
+          ]
+        },
+        "SlowKindTag": {
+          "description": "Phantom discriminator matching the literal `\"SlowPattern\"` string.",
+          "type": "string",
+          "enum": [
+            "SlowPattern"
+          ]
+        },
+        "SlowPatternPayload": {
+          "description": "JSON payload for `$p(...).slow(factor)`: the time-inverse of\n[`FastPatternPayload`]. See it for `pattern`/`factor` semantics.",
+          "type": "object",
+          "properties": {
+            "__kind": {
+              "description": "Discriminator — TS-side `.slow` sets this so the `SeqPatternSource`\nuntagged enum picks the `Slow` variant.",
+              "$ref": "#/$defs/SlowKindTag"
+            },
+            "factor": {
+              "$ref": "#/$defs/FactorPayload"
+            },
+            "pattern": {
+              "$ref": "#/$defs/SeqPatternSource2"
+            }
+          },
+          "required": [
+            "__kind",
+            "pattern",
+            "factor"
           ]
         },
         "SourceSpan": {

--- a/crates/modular/schemas.json
+++ b/crates/modular/schemas.json
@@ -8113,7 +8113,7 @@
           ]
         },
         "FactorPayload": {
-          "description": "A `.fast`/`.slow` factor. A bare number (`.fast(2)`) is a constant speed —\nnot a highlightable source. A parsed pattern (`.fast(\"2 4\")`) becomes its own\nhighlightable source, so its active value lights up in the editor as it\ndrives the speed. A factor of `0` yields silence and negatives reverse time,\nmirroring the in-string `*` operator.",
+          "description": "A `.fast`/`.slow` factor. A bare number (`.fast(2)`) is a constant speed —\nnot a highlightable source. A parsed pattern (`.fast(\"2 4\")`) becomes its own\nhighlightable source, so its active value lights up in the editor as it\ndrives the speed. A non-positive factor (`0` or negative) yields silence,\nmatching how the in-string `*`/`/` operators lower the same factors.",
           "anyOf": [
             {
               "description": "`.fast(2)` — a constant. JSON numbers match this before `Pattern`.",

--- a/crates/modular_core/src/dsp/seq/cache.rs
+++ b/crates/modular_core/src/dsp/seq/cache.rs
@@ -26,7 +26,7 @@ pub(crate) const SPANS_RESERVE_PER_HAP: usize = 4;
 /// pattern strings.
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct FlatSpan {
-    pub pattern_idx: u8,
+    pub pattern_idx: u32,
     pub start: u32,
     pub end: u32,
 }

--- a/crates/modular_core/src/dsp/seq/seq_value.rs
+++ b/crates/modular_core/src/dsp/seq/seq_value.rs
@@ -422,12 +422,9 @@ impl SectionCycles {
         match self {
             SectionCycles::Infinite(_) => Ok(None),
             SectionCycles::Finite(n) => {
-                if !n.is_finite() {
-                    return Err(
-                        "$p.arrange cycle count must be a finite positive integer or Infinity"
-                            .to_string(),
-                    );
-                }
+                // Non-finite values need no explicit guard: NaN and +∞ fail the
+                // `fract` check below and -∞ fails the `<= 0` check, so each is
+                // rejected before the `n as i64` cast.
                 if n <= 0.0 {
                     return Err(format!(
                         "$p.arrange cycle count must be a positive integer, got {n}"
@@ -496,8 +493,8 @@ pub enum SlowKindTag {
 /// A `.fast`/`.slow` factor. A bare number (`.fast(2)`) is a constant speed —
 /// not a highlightable source. A parsed pattern (`.fast("2 4")`) becomes its own
 /// highlightable source, so its active value lights up in the editor as it
-/// drives the speed. A factor of `0` yields silence and negatives reverse time,
-/// mirroring the in-string `*` operator.
+/// drives the speed. A non-positive factor (`0` or negative) yields silence,
+/// matching how the in-string `*`/`/` operators lower the same factors.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum FactorPayload {
@@ -683,7 +680,7 @@ impl SeqPatternParam {
             let (mut pat, metas) = Self::lower_source(section.pattern)?;
             let offset = per_source.len();
             if offset > 0 {
-                pat = pat.offset_pattern_idx(u8::try_from(offset).unwrap_or(u8::MAX));
+                pat = pat.offset_pattern_idx(offset as u32);
             }
             per_source.extend(metas);
             sections.push((cycles, pat));
@@ -773,7 +770,7 @@ impl SeqPatternParam {
                     .fmap(|v| crate::pattern_system::Fraction::from(*v))
                     .strip_modifier_spans();
                 if offset > 0 {
-                    pattern = pattern.offset_pattern_idx(u8::try_from(offset).unwrap_or(u8::MAX));
+                    pattern = pattern.offset_pattern_idx(offset as u32);
                 }
                 let meta = SeqSourceMeta {
                     source: payload.source,
@@ -1187,7 +1184,7 @@ mod tests {
 
         param.bake(0.0, 4.0);
         let storages = param.cached_haps();
-        let pidx = |cycle: usize| -> Vec<u8> {
+        let pidx = |cycle: usize| -> Vec<u32> {
             storages[cycle]
                 .span_arena
                 .iter()
@@ -1402,6 +1399,14 @@ mod tests {
         }
     }
 
+    fn slow_const_payload(factor: f64, pattern: SeqPatternSource) -> SlowPatternPayload {
+        SlowPatternPayload {
+            kind: SlowKindTag::SlowPattern,
+            pattern: Box::new(pattern),
+            factor: FactorPayload::Const(factor),
+        }
+    }
+
     #[test]
     fn test_fast_doubles_onset_count() {
         // "c4 e4" has two onsets per cycle; fast(2) packs the pattern twice → 4.
@@ -1448,7 +1453,7 @@ mod tests {
         assert_eq!(sources, vec!["c4 e4"], "no factor source is added");
 
         param.bake(0.0, 1.0);
-        let pidxs: std::collections::BTreeSet<u8> = param.cached_haps()[0]
+        let pidxs: std::collections::BTreeSet<u32> = param.cached_haps()[0]
             .span_arena
             .iter()
             .map(|s| s.pattern_idx)
@@ -1496,6 +1501,60 @@ mod tests {
     }
 
     #[test]
+    fn test_fast_negative_factor_is_silence() {
+        // A negative factor reverses the query span, and reversed spans yield no
+        // haps — so `.fast(-2)` is silence, not reversed playback. Pins the
+        // documented non-positive-factor behavior so the docs can't drift.
+        let param =
+            SeqPatternParam::from_fast_payload(fast_const_payload(-2.0, single_source("c4 e4")))
+                .unwrap();
+        assert!(
+            cycle_voltages(&param, 0).is_empty(),
+            "fast(-2) produces no haps"
+        );
+    }
+
+    #[test]
+    fn test_slow_negative_factor_is_silence() {
+        // The slow side mirrors fast: a negative factor yields silence.
+        let param =
+            SeqPatternParam::from_slow_payload(slow_const_payload(-2.0, single_source("c4 e4")))
+                .unwrap();
+        assert!(
+            cycle_voltages(&param, 0).is_empty(),
+            "slow(-2) produces no haps"
+        );
+    }
+
+    #[test]
+    fn test_fast_pattern_negative_factor_is_silence() {
+        // The pattern-string factor path mirrors the const path: a negative
+        // factor (`.fast("-2")`) reverses the query span and yields silence,
+        // matching the const-factor and zero-factor cases.
+        let param =
+            SeqPatternParam::from_fast_payload(fast_payload("-2", single_source("c4 e4"))).unwrap();
+        assert!(
+            cycle_voltages(&param, 0).is_empty(),
+            "fast(\"-2\") produces no haps"
+        );
+    }
+
+    #[test]
+    fn test_lower_factor_rejects_non_finite_const() {
+        // The const-factor finiteness guard is unreachable over the wire (JSON
+        // cannot carry NaN/∞), so exercise it directly. `Fraction::from(f64)`
+        // maps a non-finite value to 0, so without the guard a non-finite factor
+        // would be silently accepted as factor 0 (silence); the guard rejects it
+        // with an explicit error instead.
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                SeqPatternParam::lower_factor(FactorPayload::Const(bad), 0).is_err(),
+                "non-finite const factor {bad} must be rejected"
+            );
+        }
+    }
+
+    #[test]
     fn test_fast_per_source_appends_factor_after_inner() {
         // The wrapped pattern's per_source flows through, then the factor is
         // appended as its own highlightable source: `["0", "5", "2"]`. The
@@ -1530,7 +1589,7 @@ mod tests {
         assert_eq!(sources, vec!["c4 e4", "2 4"]);
 
         param.bake(0.0, 1.0);
-        let pidxs: std::collections::BTreeSet<u8> = param.cached_haps()[0]
+        let pidxs: std::collections::BTreeSet<u32> = param.cached_haps()[0]
             .span_arena
             .iter()
             .map(|s| s.pattern_idx)

--- a/crates/modular_core/src/dsp/seq/seq_value.rs
+++ b/crates/modular_core/src/dsp/seq/seq_value.rs
@@ -594,7 +594,21 @@ impl JsonSchema for SeqPatternParam {
     fn schema_name() -> std::borrow::Cow<'static, str> {
         SeqPatternSource::schema_name()
     }
+    fn schema_id() -> std::borrow::Cow<'static, str> {
+        // schemars keys definitions by `schema_id`, not `schema_name`. Delegate
+        // the id too so this param and the real `SeqPatternSource` enum share one
+        // definition. Without this, the param's default id (the bare
+        // `"SeqPatternSource"`) differs from the derived enum's module-path-
+        // qualified id, so the recursive `pattern` fields that reference the enum
+        // (arrange sections, `.fast`/`.slow` wrappers) spawn a byte-identical
+        // duplicate definition named `SeqPatternSource2`.
+        SeqPatternSource::schema_id()
+    }
     fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // Delegate the inline content directly (not `subschema_for`): with a
+        // shared `schema_id`, a `subschema_for::<SeqPatternSource>()` here would
+        // return a `$ref` to the definition currently being built, making the
+        // definition body a self-reference.
         SeqPatternSource::json_schema(generator)
     }
 }
@@ -1103,6 +1117,25 @@ mod tests {
         SeqPatternSource::Single(ParsedPatternPayload::parse_for_test(src))
     }
 
+    /// A two-source chained `$p.s(a, scale).add(b)` — both sources are active
+    /// within every cycle (combined), so its `per_source` has two entries
+    /// highlighting at pattern_idx 0 and 1.
+    fn sp_source_2(a: &str, b: &str, scale: &str) -> SeqPatternSource {
+        SeqPatternSource::Sp(SpPatternPayload {
+            kind: SpKindTag::default(),
+            sources: vec![
+                ParsedPatternPayload::parse_for_test(a),
+                ParsedPatternPayload::parse_for_test(b),
+            ],
+            scale: scale.to_string(),
+            ops: vec![SpOp {
+                op: SpOpKind::Add,
+                mode: SpAlignmentMode::In,
+            }],
+            argument_spans: vec![],
+        })
+    }
+
     fn section(cycles: f64, pattern: SeqPatternSource) -> ArrangeSectionPayload {
         ArrangeSectionPayload {
             cycles: SectionCycles::Finite(cycles),
@@ -1599,6 +1632,38 @@ mod tests {
         assert!(
             pidxs.contains(&1),
             "factor atoms highlight at their slot idx 1, got {pidxs:?}"
+        );
+    }
+
+    #[test]
+    fn test_fast_factor_slot_equals_multi_source_inner_count() {
+        // `$p.s("0 2 4", ...).add("0 5").fast("2 4")`: the wrapped pattern is a
+        // *two-source* `$p.s`, both active within every cycle. The factor's
+        // highlightable slot must therefore be the inner source COUNT (2), not a
+        // fixed 1 — `lower_fast` passes `inner.per_source.len()` as the offset.
+        // Baking a cycle proves all three sources light up at their flat slots:
+        // the two inner sources at idx 0 and 1, and the factor "2 4" at idx 2.
+        let inner = sp_source_2("0 2 4", "0 5", "c(maj)");
+        let mut param =
+            SeqPatternParam::from_fast_payload(fast_payload("2 4", inner)).unwrap();
+
+        let sources: Vec<&str> = param
+            .per_source()
+            .iter()
+            .map(|m| m.source.as_str())
+            .collect();
+        assert_eq!(sources, vec!["0 2 4", "0 5", "2 4"]);
+
+        param.bake(0.0, 1.0);
+        let pidxs: std::collections::BTreeSet<u32> = param.cached_haps()[0]
+            .span_arena
+            .iter()
+            .map(|s| s.pattern_idx)
+            .collect();
+        assert_eq!(
+            pidxs,
+            std::collections::BTreeSet::from([0, 1, 2]),
+            "inner sources highlight at idx 0/1, factor at idx 2 (== inner count), got {pidxs:?}"
         );
     }
 

--- a/crates/modular_core/src/dsp/seq/seq_value.rs
+++ b/crates/modular_core/src/dsp/seq/seq_value.rs
@@ -393,12 +393,160 @@ pub enum SpKindTag {
     SpPattern,
 }
 
-/// Wire-level dispatch shape: either a single `ParsedPatternPayload`
-/// (legacy single-source path used by `$cycle($p(...))`) or a chained
-/// `$p.s` payload with multi-source highlighting.
+/// Cycle count for an `$p.arrange(...)` section: a finite positive integer, or
+/// the sentinel string `"Infinity"` for an infinite tail section. JSON can't
+/// carry a numeric infinity, so the TS `$p.arrange` helper emits the string
+/// `"Infinity"`; any finite count arrives as a JSON number.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum SectionCycles {
+    Finite(f64),
+    Infinite(InfinityTag),
+}
+
+/// Phantom discriminator matching the literal `"Infinity"` string.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
+pub enum InfinityTag {
+    #[serde(rename = "Infinity")]
+    Infinity,
+}
+
+/// Largest finite section length, mirroring `MAX_RIBBON_OFFSET` — keeps cycle
+/// sums well within `i64`/`f64`-exact range.
+const MAX_SECTION_CYCLES: f64 = 1_000_000.0;
+
+impl SectionCycles {
+    /// Resolve to a validated positive-integer `Fraction`, or `None` for the
+    /// infinite sentinel. Rejects non-finite, non-integer, ≤ 0, and over-cap.
+    fn to_finite_cycles(self) -> Result<Option<crate::pattern_system::Fraction>, String> {
+        match self {
+            SectionCycles::Infinite(_) => Ok(None),
+            SectionCycles::Finite(n) => {
+                if !n.is_finite() {
+                    return Err(
+                        "$p.arrange cycle count must be a finite positive integer or Infinity"
+                            .to_string(),
+                    );
+                }
+                if n <= 0.0 {
+                    return Err(format!(
+                        "$p.arrange cycle count must be a positive integer, got {n}"
+                    ));
+                }
+                if n.fract() != 0.0 {
+                    return Err(format!(
+                        "$p.arrange cycle count must be a whole number of cycles, got {n}"
+                    ));
+                }
+                if n > MAX_SECTION_CYCLES {
+                    return Err(format!(
+                        "$p.arrange cycle count must be {MAX_SECTION_CYCLES} cycles or fewer"
+                    ));
+                }
+                Ok(Some(crate::pattern_system::Fraction::from_integer(
+                    n as i64,
+                )))
+            }
+        }
+    }
+}
+
+/// Phantom discriminator matching the literal `"ArrangePattern"` string.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "PascalCase")]
+pub enum ArrangeKindTag {
+    ArrangePattern,
+}
+
+/// One section of an `$p.arrange(...)` payload: a cycle budget plus a pattern.
+/// `pattern` is any [`SeqPatternSource`] (recursively), so a section may be a
+/// `$p`, a `$p.s`, or a nested `$p.arrange`.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ArrangeSectionPayload {
+    pub cycles: SectionCycles,
+    pub pattern: SeqPatternSource,
+}
+
+/// JSON payload for `$cycle($p.arrange(...))`. Sections play in order, each for
+/// its cycle budget; the whole loops with period `Σ cycles`. A trailing section
+/// with `cycles == "Infinity"` loops forever once reached.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ArrangePatternPayload {
+    /// Discriminator — TS-side `$p.arrange` sets this so the `SeqPatternSource`
+    /// untagged enum picks the `Arrange` variant.
+    #[serde(rename = "__kind")]
+    pub kind: ArrangeKindTag,
+    pub sections: Vec<ArrangeSectionPayload>,
+}
+
+/// Phantom discriminator matching the literal `"FastPattern"` string.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "PascalCase")]
+pub enum FastKindTag {
+    FastPattern,
+}
+
+/// Phantom discriminator matching the literal `"SlowPattern"` string.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "PascalCase")]
+pub enum SlowKindTag {
+    SlowPattern,
+}
+
+/// A `.fast`/`.slow` factor. A bare number (`.fast(2)`) is a constant speed —
+/// not a highlightable source. A parsed pattern (`.fast("2 4")`) becomes its own
+/// highlightable source, so its active value lights up in the editor as it
+/// drives the speed. A factor of `0` yields silence and negatives reverse time,
+/// mirroring the in-string `*` operator.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum FactorPayload {
+    /// `.fast(2)` — a constant. JSON numbers match this before `Pattern`.
+    Const(f64),
+    /// `.fast("2 4")` — a parsed number pattern.
+    Pattern(ParsedPatternPayload),
+}
+
+/// JSON payload for `$p(...).fast(factor)`: speed `pattern` up by `factor`.
+/// `pattern` is any [`SeqPatternSource`] (recursively), so `.fast` chains and
+/// nests over `$p`, `$p.s`, `$p.arrange`, and other `.fast`/`.slow` wrappers.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct FastPatternPayload {
+    /// Discriminator — TS-side `.fast` sets this so the `SeqPatternSource`
+    /// untagged enum picks the `Fast` variant.
+    #[serde(rename = "__kind")]
+    pub kind: FastKindTag,
+    pub pattern: Box<SeqPatternSource>,
+    pub factor: FactorPayload,
+}
+
+/// JSON payload for `$p(...).slow(factor)`: the time-inverse of
+/// [`FastPatternPayload`]. See it for `pattern`/`factor` semantics.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SlowPatternPayload {
+    /// Discriminator — TS-side `.slow` sets this so the `SeqPatternSource`
+    /// untagged enum picks the `Slow` variant.
+    #[serde(rename = "__kind")]
+    pub kind: SlowKindTag,
+    pub pattern: Box<SeqPatternSource>,
+    pub factor: FactorPayload,
+}
+
+/// Wire-level dispatch shape: a `.fast`/`.slow` wrapper, an `$p.arrange`
+/// payload, a chained `$p.s` payload with multi-source highlighting, or a
+/// single `ParsedPatternPayload` (the legacy single-source path used by
+/// `$cycle($p(...))`).
+///
+/// The `__kind`-tagged variants (`Fast`/`Slow`/`Arrange`/`Sp`) are listed before
+/// the untagged `Single`; each carries a distinct required `__kind` literal, so
+/// the untagged enum disambiguates them unambiguously before falling back to
+/// `Single`.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum SeqPatternSource {
+    Fast(FastPatternPayload),
+    Slow(SlowPatternPayload),
+    Arrange(ArrangePatternPayload),
     Sp(SpPatternPayload),
     Single(ParsedPatternPayload),
 }
@@ -456,24 +604,7 @@ impl JsonSchema for SeqPatternParam {
 
 impl SeqPatternParam {
     fn from_payload(payload: ParsedPatternPayload) -> Result<Self, String> {
-        if payload.source.trim().is_empty() {
-            return Err(crate::dsp::seq::interval_value::EMPTY_PATTERN_SOURCE_ERR.to_string());
-        }
-        // Strip modifier spans so intra-pattern modifier spans (euclidean
-        // operands, patterned `*`/`/` factors) fold into the source's
-        // primary chain at pattern_idx 0. Without this they keep pattern_idx
-        // >= 1 and `Seq::get_state`'s `idx < num_sources` filter discards them
-        // for a single source, so they never highlight. Mirrors the per-source
-        // strip in `from_sp_payload`.
-        let pattern = crate::pattern_system::mini::convert::<SeqValue>(&payload.ast)
-            .map_err(|e| e.to_string())?
-            .strip_modifier_spans();
-
-        let per_source = vec![SeqSourceMeta {
-            source: payload.source,
-            all_spans: payload.all_spans,
-        }];
-
+        let (pattern, per_source) = Self::lower_single(payload)?;
         // Parse-only: leave `cached_haps` empty. `Seq`'s `validate` hook
         // bakes the ribbon window once both `pattern` and `ribbon` are known.
         Ok(Self {
@@ -484,8 +615,218 @@ impl SeqPatternParam {
         })
     }
 
+    /// Lower a single `$p(...)` payload to a runtime pattern + its one source
+    /// metadata entry. Shared by `from_payload` and `lower_source` (arrange).
+    fn lower_single(
+        payload: ParsedPatternPayload,
+    ) -> Result<(Pattern<SeqValue>, Vec<SeqSourceMeta>), String> {
+        if payload.source.trim().is_empty() {
+            return Err(crate::dsp::seq::interval_value::EMPTY_PATTERN_SOURCE_ERR.to_string());
+        }
+        // Strip modifier spans so intra-pattern modifier spans (euclidean
+        // operands, patterned `*`/`/` factors) fold into the source's
+        // primary chain at pattern_idx 0. Without this they keep pattern_idx
+        // >= 1 and `Seq::get_state`'s `idx < num_sources` filter discards them
+        // for a single source, so they never highlight. Mirrors the per-source
+        // strip in `lower_sp`.
+        let pattern = crate::pattern_system::mini::convert::<SeqValue>(&payload.ast)
+            .map_err(|e| e.to_string())?
+            .strip_modifier_spans();
+
+        let per_source = vec![SeqSourceMeta {
+            source: payload.source,
+            all_spans: payload.all_spans,
+        }];
+
+        Ok((pattern, per_source))
+    }
+
+    /// Dispatch any wire source shape to its runtime pattern + flat per-source
+    /// metadata. Recurses for nested `$p.arrange`.
+    fn lower_source(
+        source: SeqPatternSource,
+    ) -> Result<(Pattern<SeqValue>, Vec<SeqSourceMeta>), String> {
+        match source {
+            SeqPatternSource::Fast(p) => Self::lower_fast(p),
+            SeqPatternSource::Slow(p) => Self::lower_slow(p),
+            SeqPatternSource::Single(p) => Self::lower_single(p),
+            SeqPatternSource::Sp(p) => Self::lower_sp(p),
+            SeqPatternSource::Arrange(p) => Self::lower_arrange(p),
+        }
+    }
+
+    /// Lower an `$p.arrange(...)` payload: lower each section independently
+    /// (so each `$p.s` section carries its own scale), offset each section's
+    /// pattern indices to its slot in the flat `per_source` list, then stitch
+    /// the sections in time with the `arrange` combinator. Validates the cycle
+    /// counts (positive integers, or a single trailing `Infinity`).
+    fn lower_arrange(
+        payload: ArrangePatternPayload,
+    ) -> Result<(Pattern<SeqValue>, Vec<SeqSourceMeta>), String> {
+        if payload.sections.is_empty() {
+            return Err("$p.arrange requires at least one section".to_string());
+        }
+        let section_count = payload.sections.len();
+        let mut per_source: Vec<SeqSourceMeta> = Vec::new();
+        let mut sections: Vec<(Option<crate::pattern_system::Fraction>, Pattern<SeqValue>)> =
+            Vec::with_capacity(section_count);
+
+        for (i, section) in payload.sections.into_iter().enumerate() {
+            let cycles = section.cycles.to_finite_cycles()?;
+            if cycles.is_none() && i + 1 != section_count {
+                return Err(
+                    "$p.arrange: an Infinity section must be the last section (sections after it \
+                     can never play)"
+                        .to_string(),
+                );
+            }
+            let (mut pat, metas) = Self::lower_source(section.pattern)?;
+            let offset = per_source.len();
+            if offset > 0 {
+                pat = pat.offset_pattern_idx(u8::try_from(offset).unwrap_or(u8::MAX));
+            }
+            per_source.extend(metas);
+            sections.push((cycles, pat));
+        }
+
+        Ok((crate::pattern_system::arrange(sections), per_source))
+    }
+
+    /// Build a `SeqPatternParam` from an `$p.arrange(...)` payload.
+    pub fn from_arrange_payload(payload: ArrangePatternPayload) -> Result<Self, String> {
+        let (pattern, per_source) = Self::lower_arrange(payload)?;
+        Ok(Self {
+            per_source,
+            is_multi_source: true,
+            pattern: Some(pattern),
+            cached_haps: Vec::new(),
+        })
+    }
+
+    /// Lower a `.fast(...)` wrapper: lower the inner pattern, build the factor
+    /// as a `Pattern<Fraction>`, and speed the inner pattern up by it. A pattern
+    /// factor (`.fast("2 4")`) is appended to `per_source` as its own
+    /// highlightable source (its slot is `inner.per_source.len()`), so the active
+    /// factor value lights up in the editor as it drives the speed — `inner_join`
+    /// carries the factor's span context onto every output hap it covers. A
+    /// constant factor (`.fast(2)`) is span-free and adds no source.
+    fn lower_fast(
+        payload: FastPatternPayload,
+    ) -> Result<(Pattern<SeqValue>, Vec<SeqSourceMeta>), String> {
+        let (inner, mut per_source) = Self::lower_source(*payload.pattern)?;
+        let (factor, factor_meta) = Self::lower_factor(payload.factor, per_source.len())?;
+        if let Some(meta) = factor_meta {
+            per_source.push(meta);
+        }
+        Ok((inner.fast(factor), per_source))
+    }
+
+    /// Lower a `.slow(...)` wrapper — the time-inverse of [`Self::lower_fast`].
+    fn lower_slow(
+        payload: SlowPatternPayload,
+    ) -> Result<(Pattern<SeqValue>, Vec<SeqSourceMeta>), String> {
+        let (inner, mut per_source) = Self::lower_source(*payload.pattern)?;
+        let (factor, factor_meta) = Self::lower_factor(payload.factor, per_source.len())?;
+        if let Some(meta) = factor_meta {
+            per_source.push(meta);
+        }
+        Ok((inner.slow(factor), per_source))
+    }
+
+    /// Lower a `.fast`/`.slow` factor into a `Pattern<Fraction>` plus an optional
+    /// source metadata entry.
+    ///
+    /// A [`FactorPayload::Const`] becomes a span-free `pure` constant — no
+    /// highlightable source (`None`). A [`FactorPayload::Pattern`] is built with
+    /// the generic `f64` mini-notation converter; internal modifier spans are
+    /// stripped so its primary atoms sit at `pattern_idx 0` (mirroring
+    /// `lower_single`), then `offset` shifts them to the factor's slot in the flat
+    /// `per_source` list so its highlights land on the right source string.
+    fn lower_factor(
+        factor: FactorPayload,
+        offset: usize,
+    ) -> Result<
+        (
+            Pattern<crate::pattern_system::Fraction>,
+            Option<SeqSourceMeta>,
+        ),
+        String,
+    > {
+        match factor {
+            FactorPayload::Const(n) => {
+                if !n.is_finite() {
+                    return Err("fast/slow factor must be a finite number".to_string());
+                }
+                Ok((
+                    crate::pattern_system::pure(crate::pattern_system::Fraction::from(n)),
+                    None,
+                ))
+            }
+            FactorPayload::Pattern(payload) => {
+                if payload.source.trim().is_empty() {
+                    return Err(
+                        crate::dsp::seq::interval_value::EMPTY_PATTERN_SOURCE_ERR.to_string()
+                    );
+                }
+                let mut pattern = crate::pattern_system::mini::convert::<f64>(&payload.ast)
+                    .map_err(|e| e.to_string())?
+                    .fmap(|v| crate::pattern_system::Fraction::from(*v))
+                    .strip_modifier_spans();
+                if offset > 0 {
+                    pattern = pattern.offset_pattern_idx(u8::try_from(offset).unwrap_or(u8::MAX));
+                }
+                let meta = SeqSourceMeta {
+                    source: payload.source,
+                    all_spans: payload.all_spans,
+                };
+                Ok((pattern, Some(meta)))
+            }
+        }
+    }
+
+    /// Build a `SeqPatternParam` from a `.fast(...)` payload.
+    ///
+    /// `is_multi_source` is always `true` so `get_state` keys highlights by
+    /// `pattern.0`, `pattern.1`, … — the TS factory registers a `.fast`/`.slow`
+    /// wrapper's argument spans under those same keys (like `$p.s`/`$p.arrange`),
+    /// so a single-source `pattern` key would never match and the wrapped
+    /// pattern wouldn't highlight.
+    pub fn from_fast_payload(payload: FastPatternPayload) -> Result<Self, String> {
+        let (pattern, per_source) = Self::lower_fast(payload)?;
+        Ok(Self {
+            per_source,
+            is_multi_source: true,
+            pattern: Some(pattern),
+            cached_haps: Vec::new(),
+        })
+    }
+
+    /// Build a `SeqPatternParam` from a `.slow(...)` payload. `is_multi_source`
+    /// is always `true` for the highlight-key reason in [`Self::from_fast_payload`].
+    pub fn from_slow_payload(payload: SlowPatternPayload) -> Result<Self, String> {
+        let (pattern, per_source) = Self::lower_slow(payload)?;
+        Ok(Self {
+            per_source,
+            is_multi_source: true,
+            pattern: Some(pattern),
+            cached_haps: Vec::new(),
+        })
+    }
+
     #[doc(hidden)]
     pub fn from_sp_payload(payload: SpPatternPayload) -> Result<Self, String> {
+        let (pattern, per_source) = Self::lower_sp(payload)?;
+        Ok(Self {
+            per_source,
+            is_multi_source: true,
+            pattern: Some(pattern),
+            cached_haps: Vec::new(),
+        })
+    }
+
+    fn lower_sp(
+        payload: SpPatternPayload,
+    ) -> Result<(Pattern<SeqValue>, Vec<SeqSourceMeta>), String> {
         use crate::dsp::seq::interval_value::{
             IntervalValue, add_interval_values, sub_interval_values,
         };
@@ -566,13 +907,7 @@ impl SeqPatternParam {
             })
             .collect();
 
-        // Parse-only: leave `cached_haps` empty (see `from_payload`).
-        Ok(Self {
-            per_source,
-            is_multi_source: true,
-            pattern: Some(voltage_pattern),
-            cached_haps: Vec::new(),
-        })
+        Ok((voltage_pattern, per_source))
     }
 
     /// Get the parsed pattern.
@@ -661,6 +996,20 @@ impl<E: DeserializeError> Deserr<E> for SeqPatternParam {
             ))
         })?;
         match parsed {
+            SeqPatternSource::Fast(p) => Self::from_fast_payload(p).map_err(|e| {
+                deserr::take_cf_content(E::error::<V>(
+                    None,
+                    ErrorKind::Unexpected { msg: e },
+                    location,
+                ))
+            }),
+            SeqPatternSource::Slow(p) => Self::from_slow_payload(p).map_err(|e| {
+                deserr::take_cf_content(E::error::<V>(
+                    None,
+                    ErrorKind::Unexpected { msg: e },
+                    location,
+                ))
+            }),
             SeqPatternSource::Single(p) => Self::from_payload(p).map_err(|e| {
                 deserr::take_cf_content(E::error::<V>(
                     None,
@@ -669,6 +1018,13 @@ impl<E: DeserializeError> Deserr<E> for SeqPatternParam {
                 ))
             }),
             SeqPatternSource::Sp(p) => Self::from_sp_payload(p).map_err(|e| {
+                deserr::take_cf_content(E::error::<V>(
+                    None,
+                    ErrorKind::Unexpected { msg: e },
+                    location,
+                ))
+            }),
+            SeqPatternSource::Arrange(p) => Self::from_arrange_payload(p).map_err(|e| {
                 deserr::take_cf_content(E::error::<V>(
                     None,
                     ErrorKind::Unexpected { msg: e },
@@ -732,6 +1088,535 @@ mod tests {
         let v: Vec<f64> = haps.iter().map(|h| h.value.to_voltage().unwrap()).collect();
         assert!((v[0] - 2.0 / 12.0).abs() < 1e-9, "v[0]={}", v[0]);
         assert!((v[1] - 4.0 / 12.0).abs() < 1e-9, "v[1]={}", v[1]);
+    }
+
+    // ===== $p.arrange tests =====
+
+    fn sp_source(src: &str, scale: &str) -> SeqPatternSource {
+        SeqPatternSource::Sp(SpPatternPayload {
+            kind: SpKindTag::default(),
+            sources: vec![ParsedPatternPayload::parse_for_test(src)],
+            scale: scale.to_string(),
+            ops: vec![],
+            argument_spans: vec![],
+        })
+    }
+
+    fn single_source(src: &str) -> SeqPatternSource {
+        SeqPatternSource::Single(ParsedPatternPayload::parse_for_test(src))
+    }
+
+    fn section(cycles: f64, pattern: SeqPatternSource) -> ArrangeSectionPayload {
+        ArrangeSectionPayload {
+            cycles: SectionCycles::Finite(cycles),
+            pattern,
+        }
+    }
+
+    fn arrange_payload(sections: Vec<ArrangeSectionPayload>) -> ArrangePatternPayload {
+        ArrangePatternPayload {
+            kind: ArrangeKindTag::ArrangePattern,
+            sections,
+        }
+    }
+
+    fn cycle_voltages(param: &SeqPatternParam, cycle: i64) -> Vec<f64> {
+        param
+            .pattern()
+            .expect("pattern")
+            .query_arc(
+                Fraction::from_integer(cycle),
+                Fraction::from_integer(cycle + 1),
+            )
+            .into_iter()
+            .filter(|h| h.has_onset())
+            .filter_map(|h| h.value.to_voltage())
+            .collect()
+    }
+
+    fn approx_eq(a: &[f64], b: &[f64]) -> bool {
+        a.len() == b.len() && a.iter().zip(b).all(|(x, y)| (x - y).abs() < 1e-9)
+    }
+
+    #[test]
+    fn test_arrange_switches_scale_per_section() {
+        // [2, "0 2 4" @ c major], [2, "0 2 4" @ a minor] — same degrees, but each
+        // section resolves through its own scale, so the voltages differ.
+        let payload = arrange_payload(vec![
+            section(2.0, sp_source("0 2 4", "c(maj)")),
+            section(2.0, sp_source("0 2 4", "a(min)")),
+        ]);
+        let param = SeqPatternParam::from_arrange_payload(payload).unwrap();
+
+        // c major degrees 0,2,4 → 0, 4/12, 7/12 V.
+        let c_major = cycle_voltages(&param, 0);
+        assert!(
+            approx_eq(&c_major, &[0.0, 4.0 / 12.0, 7.0 / 12.0]),
+            "c major section voltages: {c_major:?}"
+        );
+        // The pattern has no slow elements, so both cycles of a section match.
+        assert!(approx_eq(&cycle_voltages(&param, 1), &c_major));
+        let a_minor = cycle_voltages(&param, 2);
+        assert!(approx_eq(&cycle_voltages(&param, 3), &a_minor));
+        // Different scales → different voltages at the section seam.
+        assert!(
+            !approx_eq(&c_major, &a_minor),
+            "expected scale switch at cycle 2, got {c_major:?} vs {a_minor:?}"
+        );
+        // Period 4: cycle 4 wraps to the c major section.
+        assert!(approx_eq(&cycle_voltages(&param, 4), &c_major));
+    }
+
+    #[test]
+    fn test_arrange_flat_per_source_and_offset_indices() {
+        // Two single-source $p.s sections; the flat per_source list is their
+        // sources in order, and each section's haps carry pattern indices
+        // offset to their slot in that flat list.
+        let payload = arrange_payload(vec![
+            section(1.0, sp_source("0", "c(maj)")),
+            section(1.0, sp_source("5", "c(maj)")),
+        ]);
+        let mut param = SeqPatternParam::from_arrange_payload(payload).unwrap();
+
+        let sources: Vec<&str> = param
+            .per_source()
+            .iter()
+            .map(|m| m.source.as_str())
+            .collect();
+        assert_eq!(sources, vec!["0", "5"], "flat per_source in section order");
+
+        param.bake(0.0, 4.0);
+        let storages = param.cached_haps();
+        let pidx = |cycle: usize| -> Vec<u8> {
+            storages[cycle]
+                .span_arena
+                .iter()
+                .map(|s| s.pattern_idx)
+                .collect()
+        };
+        assert!(
+            pidx(0).iter().all(|&p| p == 0),
+            "section 0 highlights at flat idx 0, got {:?}",
+            pidx(0)
+        );
+        assert!(
+            !pidx(1).is_empty() && pidx(1).iter().all(|&p| p == 1),
+            "section 1 highlights offset to flat idx 1, got {:?}",
+            pidx(1)
+        );
+    }
+
+    #[test]
+    fn test_arrange_baked_haps_carry_scale_switched_voltages() {
+        // The audio thread reads `cached_haps`, not the live pattern. Bake the
+        // two-scale arrangement and confirm the baked per-cycle storage (what
+        // `Seq::update` consumes) carries c major in section 0 and a minor in
+        // section 1 — i.e. the scale actually switches at the seam.
+        let payload = arrange_payload(vec![
+            section(2.0, sp_source("0 2 4", "c(maj)")),
+            section(2.0, sp_source("0 2 4", "a(min)")),
+        ]);
+        let mut param = SeqPatternParam::from_arrange_payload(payload).unwrap();
+        param.bake(0.0, 4.0);
+        let storages = param.cached_haps();
+
+        let baked_volts = |cycle: usize| -> Vec<f64> {
+            storages[cycle]
+                .haps
+                .iter()
+                .filter(|h| h.has_onset)
+                .filter_map(|h| h.value.to_voltage())
+                .collect()
+        };
+
+        let c_major = baked_volts(0);
+        assert!(
+            approx_eq(&c_major, &[0.0, 4.0 / 12.0, 7.0 / 12.0]),
+            "baked c major voltages: {c_major:?}"
+        );
+        assert!(
+            approx_eq(&baked_volts(1), &c_major),
+            "section 0 spans cycles 0..2"
+        );
+        assert!(
+            !approx_eq(&baked_volts(2), &c_major),
+            "baked storage must switch scale at the section seam"
+        );
+        assert!(
+            approx_eq(&baked_volts(3), &baked_volts(2)),
+            "section 1 spans cycles 2..4"
+        );
+    }
+
+    #[test]
+    fn test_arrange_nests() {
+        // A section may itself be an arrange. per_source flattens depth-first
+        // in section order: "0", then the nested arrange's "7" and "c4".
+        let nested = SeqPatternSource::Arrange(arrange_payload(vec![
+            section(1.0, sp_source("7", "c(maj)")),
+            section(1.0, single_source("c4")),
+        ]));
+        let payload = arrange_payload(vec![
+            section(2.0, sp_source("0", "c(maj)")),
+            section(2.0, nested),
+        ]);
+        let param = SeqPatternParam::from_arrange_payload(payload).unwrap();
+
+        let sources: Vec<&str> = param
+            .per_source()
+            .iter()
+            .map(|m| m.source.as_str())
+            .collect();
+        assert_eq!(
+            sources,
+            vec!["0", "7", "c4"],
+            "nested per_source flattens in order"
+        );
+        // Builds a queryable pattern across the whole period.
+        assert_eq!(cycle_voltages(&param, 0).len(), 1);
+    }
+
+    #[test]
+    fn test_arrange_infinity_tail_loops_last_section() {
+        // [2, "c4"], [Infinity, "e4"] — c4 for cycles 0..2, e4 forever after.
+        let payload = ArrangePatternPayload {
+            kind: ArrangeKindTag::ArrangePattern,
+            sections: vec![
+                section(2.0, single_source("c4")),
+                ArrangeSectionPayload {
+                    cycles: SectionCycles::Infinite(InfinityTag::Infinity),
+                    pattern: single_source("e4"),
+                },
+            ],
+        };
+        let param = SeqPatternParam::from_arrange_payload(payload).unwrap();
+
+        let c4 = cycle_voltages(&param, 0);
+        assert!(approx_eq(&cycle_voltages(&param, 1), &c4));
+        let e4 = cycle_voltages(&param, 2);
+        assert!(!approx_eq(&c4, &e4), "tail section differs from prefix");
+        // The tail loops forever — far-future cycles still play e4.
+        assert!(approx_eq(&cycle_voltages(&param, 5), &e4));
+        assert!(approx_eq(&cycle_voltages(&param, 100), &e4));
+    }
+
+    #[test]
+    fn test_arrange_rejects_bad_cycle_counts() {
+        // Non-integer, zero, and negative finite counts are rejected.
+        for bad in [2.5, 0.0, -1.0] {
+            let payload = arrange_payload(vec![section(bad, single_source("c4"))]);
+            assert!(
+                SeqPatternParam::from_arrange_payload(payload).is_err(),
+                "cycle count {bad} should be rejected"
+            );
+        }
+        // Empty arrangement is rejected.
+        assert!(SeqPatternParam::from_arrange_payload(arrange_payload(vec![])).is_err());
+    }
+
+    #[test]
+    fn test_arrange_rejects_infinity_not_last() {
+        let payload = ArrangePatternPayload {
+            kind: ArrangeKindTag::ArrangePattern,
+            sections: vec![
+                ArrangeSectionPayload {
+                    cycles: SectionCycles::Infinite(InfinityTag::Infinity),
+                    pattern: single_source("c4"),
+                },
+                section(2.0, single_source("e4")),
+            ],
+        };
+        assert!(
+            SeqPatternParam::from_arrange_payload(payload).is_err(),
+            "an Infinity section before the end must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_arrange_wire_json_dispatches_to_arrange_variant() {
+        // The untagged `SeqPatternSource` (the same serde dispatch the deserr
+        // path runs) must pick `Arrange` for an `__kind: "ArrangePattern"`
+        // payload, with a nested `$p.s` section and the `"Infinity"` sentinel.
+        let c4 = serde_json::to_value(ParsedPatternPayload::parse_for_test("c4")).unwrap();
+        let degrees = serde_json::to_value(ParsedPatternPayload::parse_for_test("0 2 4")).unwrap();
+        let sp = serde_json::json!({
+            "__kind": "SpPattern",
+            "sources": [degrees],
+            "scale": "a(min)",
+            "ops": []
+        });
+        let json = serde_json::json!({
+            "__kind": "ArrangePattern",
+            "sections": [
+                { "cycles": 2, "pattern": c4 },
+                { "cycles": "Infinity", "pattern": sp }
+            ]
+        });
+
+        let parsed: SeqPatternSource =
+            serde_json::from_value(json).expect("arrange wire json should parse");
+        let arrange = match parsed {
+            SeqPatternSource::Arrange(a) => a,
+            other => panic!("expected Arrange variant, got {other:?}"),
+        };
+        assert_eq!(arrange.sections.len(), 2);
+        assert!(matches!(
+            arrange.sections[0].cycles,
+            SectionCycles::Finite(n) if (n - 2.0).abs() < 1e-9
+        ));
+        assert!(matches!(
+            arrange.sections[1].cycles,
+            SectionCycles::Infinite(_)
+        ));
+        // And it lowers into a usable param.
+        let param = SeqPatternParam::from_arrange_payload(arrange).unwrap();
+        assert!(param.is_multi_source());
+        assert_eq!(param.per_source().len(), 2);
+    }
+
+    // ===== .fast / .slow tests =====
+
+    // String-factor helpers build a `Pattern` factor (a highlightable source);
+    // `*_const_payload` build a `Const` factor (no source).
+    fn fast_payload(factor: &str, pattern: SeqPatternSource) -> FastPatternPayload {
+        FastPatternPayload {
+            kind: FastKindTag::FastPattern,
+            pattern: Box::new(pattern),
+            factor: FactorPayload::Pattern(ParsedPatternPayload::parse_for_test(factor)),
+        }
+    }
+
+    fn slow_payload(factor: &str, pattern: SeqPatternSource) -> SlowPatternPayload {
+        SlowPatternPayload {
+            kind: SlowKindTag::SlowPattern,
+            pattern: Box::new(pattern),
+            factor: FactorPayload::Pattern(ParsedPatternPayload::parse_for_test(factor)),
+        }
+    }
+
+    fn fast_const_payload(factor: f64, pattern: SeqPatternSource) -> FastPatternPayload {
+        FastPatternPayload {
+            kind: FastKindTag::FastPattern,
+            pattern: Box::new(pattern),
+            factor: FactorPayload::Const(factor),
+        }
+    }
+
+    #[test]
+    fn test_fast_doubles_onset_count() {
+        // "c4 e4" has two onsets per cycle; fast(2) packs the pattern twice → 4.
+        let param =
+            SeqPatternParam::from_fast_payload(fast_payload("2", single_source("c4 e4"))).unwrap();
+        assert_eq!(cycle_voltages(&param, 0).len(), 4);
+    }
+
+    #[test]
+    fn test_fast_single_source_keys_highlights_by_pattern_index() {
+        // Highlight contract: the TS factory registers a `.fast`/`.slow` wrapper's
+        // spans under `pattern.0` (like `$p.s`/`$p.arrange`), so the param must be
+        // multi-source even when wrapping a single `$p` with a constant factor
+        // (one source) — otherwise `get_state` would key the active highlight
+        // under `pattern` and never match.
+        let fast =
+            SeqPatternParam::from_fast_payload(fast_const_payload(2.0, single_source("c4 e4")))
+                .unwrap();
+        assert_eq!(fast.per_source().len(), 1, "a const factor adds no source");
+        assert!(
+            fast.is_multi_source(),
+            "fast must key highlights by pattern.0"
+        );
+    }
+
+    #[test]
+    fn test_fast_const_factor_is_not_a_highlightable_source() {
+        // `.fast(2)` (a number) is a constant: it doubles the pattern but adds no
+        // per_source entry and contributes no span context, so only the wrapped
+        // pattern (idx 0) highlights — never the bare number.
+        let mut param =
+            SeqPatternParam::from_fast_payload(fast_const_payload(2.0, single_source("c4 e4")))
+                .unwrap();
+        assert_eq!(
+            cycle_voltages(&param, 0).len(),
+            4,
+            "const factor still doubles"
+        );
+        let sources: Vec<&str> = param
+            .per_source()
+            .iter()
+            .map(|m| m.source.as_str())
+            .collect();
+        assert_eq!(sources, vec!["c4 e4"], "no factor source is added");
+
+        param.bake(0.0, 1.0);
+        let pidxs: std::collections::BTreeSet<u8> = param.cached_haps()[0]
+            .span_arena
+            .iter()
+            .map(|s| s.pattern_idx)
+            .collect();
+        assert_eq!(
+            pidxs,
+            std::collections::BTreeSet::from([0]),
+            "only the wrapped pattern highlights (idx 0), got {pidxs:?}"
+        );
+    }
+
+    #[test]
+    fn test_slow_stretches_across_cycles() {
+        // slow(2) stretches "c4 e4" over two cycles: c4 in cycle 0, e4 in cycle 1.
+        let param =
+            SeqPatternParam::from_slow_payload(slow_payload("2", single_source("c4 e4"))).unwrap();
+        let c0 = cycle_voltages(&param, 0);
+        let c1 = cycle_voltages(&param, 1);
+        assert_eq!(c0.len(), 1, "cycle 0 holds a single onset, got {c0:?}");
+        assert_eq!(c1.len(), 1, "cycle 1 holds a single onset, got {c1:?}");
+        assert!(
+            (c0[0] - c1[0]).abs() > 1e-9,
+            "the two cycles play different notes, got {c0:?} vs {c1:?}"
+        );
+    }
+
+    #[test]
+    fn test_fast_accepts_patterned_factor() {
+        // Mirrors strudel's `pure('a').fast(sequence(1, 4))` → 3 events in cycle 0:
+        // the ×1 half contributes one, the ×4 half contributes two.
+        let param =
+            SeqPatternParam::from_fast_payload(fast_payload("1 4", single_source("c4"))).unwrap();
+        assert_eq!(cycle_voltages(&param, 0).len(), 3);
+    }
+
+    #[test]
+    fn test_fast_zero_factor_is_silence() {
+        // Lenient edge behavior (mirrors the in-string `*0`): factor 0 → silence.
+        let param =
+            SeqPatternParam::from_fast_payload(fast_payload("0", single_source("c4 e4"))).unwrap();
+        assert!(
+            cycle_voltages(&param, 0).is_empty(),
+            "fast(0) produces no haps"
+        );
+    }
+
+    #[test]
+    fn test_fast_per_source_appends_factor_after_inner() {
+        // The wrapped pattern's per_source flows through, then the factor is
+        // appended as its own highlightable source: `["0", "5", "2"]`. The
+        // factory keys these by `pattern.0` / `pattern.1` / `pattern.2`.
+        let arr = SeqPatternSource::Arrange(arrange_payload(vec![
+            section(1.0, sp_source("0", "c(maj)")),
+            section(1.0, sp_source("5", "c(maj)")),
+        ]));
+        let param = SeqPatternParam::from_fast_payload(fast_payload("2", arr)).unwrap();
+        let sources: Vec<&str> = param
+            .per_source()
+            .iter()
+            .map(|m| m.source.as_str())
+            .collect();
+        assert_eq!(sources, vec!["0", "5", "2"]);
+        assert!(param.is_multi_source());
+    }
+
+    #[test]
+    fn test_fast_factor_is_a_highlightable_source() {
+        // `$p("c4 e4").fast("2 4")`: the factor "2 4" is the last per_source
+        // entry, and baking the cycle proves the active factor atoms light up
+        // at the factor's flat slot (pattern_idx == inner source count == 1).
+        let mut param =
+            SeqPatternParam::from_fast_payload(fast_payload("2 4", single_source("c4 e4")))
+                .unwrap();
+        let sources: Vec<&str> = param
+            .per_source()
+            .iter()
+            .map(|m| m.source.as_str())
+            .collect();
+        assert_eq!(sources, vec!["c4 e4", "2 4"]);
+
+        param.bake(0.0, 1.0);
+        let pidxs: std::collections::BTreeSet<u8> = param.cached_haps()[0]
+            .span_arena
+            .iter()
+            .map(|s| s.pattern_idx)
+            .collect();
+        // Inner notes highlight at idx 0; the active factor atom at idx 1.
+        assert!(pidxs.contains(&0), "inner pattern highlights at idx 0");
+        assert!(
+            pidxs.contains(&1),
+            "factor atoms highlight at their slot idx 1, got {pidxs:?}"
+        );
+    }
+
+    #[test]
+    fn test_fast_rejects_empty_factor() {
+        let payload = fast_payload("  ", single_source("c4"));
+        assert!(SeqPatternParam::from_fast_payload(payload).is_err());
+    }
+
+    #[test]
+    fn test_fast_wire_json_dispatches_to_fast_variant() {
+        // The untagged `SeqPatternSource` must pick `Fast` for an
+        // `__kind: "FastPattern"` payload, with the inner pattern and factor
+        // embedded as parsed-pattern payloads.
+        let inner = serde_json::to_value(ParsedPatternPayload::parse_for_test("c4 e4")).unwrap();
+        let factor = serde_json::to_value(ParsedPatternPayload::parse_for_test("2")).unwrap();
+        let json = serde_json::json!({
+            "__kind": "FastPattern",
+            "pattern": inner,
+            "factor": factor,
+        });
+        let parsed: SeqPatternSource =
+            serde_json::from_value(json).expect("fast wire json should parse");
+        let fast = match parsed {
+            SeqPatternSource::Fast(f) => f,
+            other => panic!("expected Fast variant, got {other:?}"),
+        };
+        // And it lowers into a usable, doubled param.
+        let param = SeqPatternParam::from_fast_payload(fast).unwrap();
+        assert_eq!(cycle_voltages(&param, 0).len(), 4);
+    }
+
+    #[test]
+    fn test_fast_wire_numeric_factor_is_const() {
+        // A bare JSON number for `factor` deserializes as `FactorPayload::Const`
+        // (the untagged enum tries `Const(f64)` before `Pattern`), so the factor
+        // is a constant with no highlightable source.
+        let inner = serde_json::to_value(ParsedPatternPayload::parse_for_test("c4 e4")).unwrap();
+        let json = serde_json::json!({
+            "__kind": "FastPattern",
+            "pattern": inner,
+            "factor": 2,
+        });
+        let parsed: SeqPatternSource =
+            serde_json::from_value(json).expect("fast wire json should parse");
+        let fast = match parsed {
+            SeqPatternSource::Fast(f) => f,
+            other => panic!("expected Fast variant, got {other:?}"),
+        };
+        assert!(matches!(fast.factor, FactorPayload::Const(n) if (n - 2.0).abs() < 1e-9));
+        let param = SeqPatternParam::from_fast_payload(fast).unwrap();
+        assert_eq!(cycle_voltages(&param, 0).len(), 4);
+        assert_eq!(param.per_source().len(), 1, "const factor adds no source");
+    }
+
+    #[test]
+    fn test_slow_wire_json_dispatches_to_slow_variant() {
+        let inner = serde_json::to_value(ParsedPatternPayload::parse_for_test("c4")).unwrap();
+        let factor = serde_json::to_value(ParsedPatternPayload::parse_for_test("2")).unwrap();
+        let json = serde_json::json!({
+            "__kind": "SlowPattern",
+            "pattern": inner,
+            "factor": factor,
+        });
+        let parsed: SeqPatternSource =
+            serde_json::from_value(json).expect("slow wire json should parse");
+        assert!(matches!(parsed, SeqPatternSource::Slow(_)));
+    }
+
+    #[test]
+    fn test_fast_slow_chain_round_trips() {
+        // `.fast(3).slow(3)` nests a Slow around a Fast; the net onset count
+        // returns to the un-sped pattern's two onsets per cycle.
+        let inner = single_source("c4 e4");
+        let fast = SeqPatternSource::Fast(fast_payload("3", inner));
+        let param = SeqPatternParam::from_slow_payload(slow_payload("3", fast)).unwrap();
+        assert_eq!(cycle_voltages(&param, 0).len(), 2);
     }
 
     #[test]

--- a/crates/modular_core/src/pattern_system/combinators.rs
+++ b/crates/modular_core/src/pattern_system/combinators.rs
@@ -523,6 +523,73 @@ mod tests {
     }
 
     #[test]
+    fn test_arrange_single_finite_section_budget_is_noop() {
+        // A lone finite section reduces to `timecat([(n, p.fast(n))])._slow(n)`,
+        // which equals `p` exactly: the cycle budget `n` does not gate playback,
+        // so the section keeps advancing through its own cycles past cycle `n`
+        // rather than resetting at the budget.
+        let p = slowcat(vec![
+            pure("p0"),
+            pure("p1"),
+            pure("p2"),
+            pure("p3"),
+            pure("p4"),
+        ]);
+        let arr = arrange(vec![(Some(Fraction::from_integer(3)), p.clone())]);
+        for c in 0..5 {
+            assert_eq!(
+                onset_values(&arr, c),
+                onset_values(&p, c),
+                "lone finite section equals p (budget is a no-op) at cycle {c}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_arrange_drops_sections_after_infinite_tail() {
+        // `arrange` is public and takes raw cycle counts; the DSL validator
+        // rejects sections after an infinite tail upstream, but the combinator
+        // also drops them defensively (they could never play). Only the finite
+        // prefix and the tail are reachable here — the trailing section never is.
+        let a = slowcat(vec![pure("a0"), pure("a1")]);
+        let b = slowcat(vec![pure("b0"), pure("b1")]);
+        let c = slowcat(vec![pure("c0"), pure("c1")]);
+        let arr = arrange(vec![
+            (Some(Fraction::from_integer(2)), a),
+            (None, b),
+            (Some(Fraction::from_integer(3)), c),
+        ]);
+
+        // Prefix a over cycles [0, 2), then b loops forever from cycle 2.
+        assert_eq!(onset_values(&arr, 0), vec!["a0"]);
+        assert_eq!(onset_values(&arr, 1), vec!["a1"]);
+        assert_eq!(onset_values(&arr, 2), vec!["b0"]);
+        assert_eq!(onset_values(&arr, 3), vec!["b1"]);
+        assert_eq!(onset_values(&arr, 50), vec!["b0"]); // (50 - 2) mod 2 = 0
+        // The dropped section never plays at any queried cycle.
+        let played: Vec<&str> = (0..24).flat_map(|cyc| onset_values(&arr, cyc)).collect();
+        assert!(
+            !played.iter().any(|v| v.starts_with('c')),
+            "dropped trailing section must never play, got {played:?}"
+        );
+    }
+
+    #[test]
+    fn test_arrange_finite_zero_sum_is_silence() {
+        // A finite arrangement whose cycle counts sum to zero lowers to silence,
+        // guarding the subsequent `_slow(0)`. The DSL validator rejects 0-cycle
+        // sections upstream, so this is reachable only via the public combinator.
+        let p = slowcat(vec![pure("p0"), pure("p1")]);
+        let arr = arrange(vec![(Some(Fraction::from_integer(0)), p)]);
+        for c in 0..3 {
+            assert!(
+                onset_values(&arr, c).is_empty(),
+                "zero-sum arrange is silent at cycle {c}"
+            );
+        }
+    }
+
+    #[test]
     fn slowcat_alternates_non_numeric_values() {
         let first = "sig1".to_string();
         let second = "sig2".to_string();

--- a/crates/modular_core/src/pattern_system/combinators.rs
+++ b/crates/modular_core/src/pattern_system/combinators.rs
@@ -7,6 +7,7 @@
 //! - `timecat` - Concatenate patterns with explicit weights
 
 use super::{ArenaHap, Fraction, Pattern, State};
+use bumpalo::Bump;
 use bumpalo::collections::Vec as BumpVec;
 
 /// Play multiple patterns simultaneously.
@@ -136,6 +137,122 @@ pub fn timecat<T: Clone + Send + Sync + 'static>(
     }
 
     stack(compressed).with_steps(total)
+}
+
+/// Arrange patterns over multiple cycles (Strudel's `arrange`).
+///
+/// Each section is `(Some(cycles), pat)` for a finite section occupying
+/// `cycles` whole cycles, or `(None, pat)` for an **infinite tail** that loops
+/// forever once reached. A `None` section must be unique and last (the caller
+/// validates this; sections after it can never play).
+///
+/// Finite arrangement mirrors Strudel bit-for-bit:
+/// `timecat(sections.map(|(n,p)| (n, p.fast(n))))._slow(total)`, where
+/// `total = Σ cycles`. Each section plays at its native rate, progressing
+/// through its own cycles, and the whole loops with period `total`. The
+/// per-section `fast(n)` is what makes a section advance through `n` of its
+/// own cycles rather than repeating its cycle 0.
+///
+/// With an infinite tail, the finite prefix plays once over cycles
+/// `[0, Σ prefix)`, then the tail section loops forever from cycle `Σ prefix`.
+pub fn arrange<T: Clone + Send + Sync + 'static>(
+    sections: Vec<(Option<Fraction>, Pattern<T>)>,
+) -> Pattern<T> {
+    if sections.is_empty() {
+        return super::constructors::silence();
+    }
+
+    match sections.iter().position(|(cycles, _)| cycles.is_none()) {
+        Some(inf_idx) => {
+            // Split into the finite prefix and the infinite tail section.
+            // Anything after the tail is unreachable; the caller rejects it,
+            // so we simply drop it here.
+            let mut sections = sections;
+            let inf_pat = sections.remove(inf_idx).1;
+            sections.truncate(inf_idx);
+            let finite: Vec<(Fraction, Pattern<T>)> = sections
+                .into_iter()
+                .map(|(cycles, pat)| (cycles.expect("prefix sections are finite"), pat))
+                .collect();
+            let s_k = sum_fractions(finite.iter().map(|(c, _)| c));
+            let prefix = if finite.is_empty() {
+                None
+            } else {
+                Some(arrange_finite(finite))
+            };
+            arrange_with_tail(prefix, s_k, inf_pat)
+        }
+        None => {
+            let finite: Vec<(Fraction, Pattern<T>)> = sections
+                .into_iter()
+                .map(|(cycles, pat)| (cycles.expect("all sections finite"), pat))
+                .collect();
+            arrange_finite(finite)
+        }
+    }
+}
+
+fn sum_fractions<'a, I: Iterator<Item = &'a Fraction>>(iter: I) -> Fraction {
+    iter.fold(Fraction::from_integer(0), |acc, c| acc + c.clone())
+}
+
+/// Finite arrangement: `timecat([(n, p.fast(n)) …])._slow(total)`.
+fn arrange_finite<T: Clone + Send + Sync + 'static>(
+    sections: Vec<(Fraction, Pattern<T>)>,
+) -> Pattern<T> {
+    if sections.is_empty() {
+        return super::constructors::silence();
+    }
+    let total = sum_fractions(sections.iter().map(|(c, _)| c));
+    if total.is_zero() {
+        return super::constructors::silence();
+    }
+    let weighted: Vec<(Fraction, Pattern<T>)> = sections
+        .into_iter()
+        .map(|(n, pat)| (n.clone(), Pattern::new_fast_const(pat, n)))
+        .collect();
+    timecat(weighted)._slow(total)
+}
+
+/// Infinite-tail arrangement: play `prefix` (a finite arrangement) over cycles
+/// `[0, s_k)`, then `inf_pat` shifted to start at cycle `s_k` and loop forever.
+fn arrange_with_tail<T: Clone + Send + Sync + 'static>(
+    prefix: Option<Pattern<T>>,
+    s_k: Fraction,
+    inf_pat: Pattern<T>,
+) -> Pattern<T> {
+    Pattern::new_into(
+        move |state: &State, bump: &Bump, out: &mut BumpVec<'_, ArenaHap<'_, T>>| {
+            state.span.for_each_cycle_span(|sub| {
+                // Each sub-span lies within one integer cycle; route by it. The
+                // finite prefix and the infinite tail meet exactly at cycle s_k.
+                let cycle = sub.begin.floor();
+                if cycle < s_k {
+                    if let Some(prefix) = &prefix {
+                        prefix.query_into(&State::new(sub.clone()), bump, out);
+                    }
+                } else {
+                    // Query the tail at its own frame (shifted back by s_k), then
+                    // map results forward by s_k. Context passes through, so the
+                    // tail section keeps its highlight offset.
+                    let qspan = sub.with_time(|t| t - &s_k);
+                    let mut scratch: BumpVec<'_, ArenaHap<'_, T>> = BumpVec::new_in(bump);
+                    inf_pat.query_into(&State::new(qspan), bump, &mut scratch);
+                    out.reserve(scratch.len());
+                    for hap in scratch {
+                        let new_part = hap.part.with_time(|t| t + &s_k);
+                        let new_whole = hap.whole.as_ref().map(|w| w.with_time(|t| t + &s_k));
+                        out.push(ArenaHap {
+                            whole: new_whole,
+                            part: new_part,
+                            value: hap.value,
+                            context: hap.context,
+                        });
+                    }
+                }
+            });
+        },
+    )
 }
 
 // ===== Helper implementations on Pattern =====
@@ -327,6 +444,82 @@ mod tests {
             lcm(&Fraction::from_integer(6), &Fraction::from_integer(4)),
             Fraction::from_integer(12)
         );
+    }
+
+    /// Query one integer cycle and return the values of its onset haps.
+    fn onset_values(pat: &Pattern<&'static str>, cycle: i64) -> Vec<&'static str> {
+        pat.query_arc(Fraction::from_integer(cycle), Fraction::from_integer(cycle + 1))
+            .into_iter()
+            .filter(|h| h.has_onset())
+            .map(|h| h.value)
+            .collect()
+    }
+
+    #[test]
+    fn test_arrange_finite_advances_sections() {
+        // A plays one cycle per result cycle while in its window; B likewise.
+        // Crucially, after the arrangement loops (period 6), section A resumes
+        // at its cycle 4 — it advances, it does not repeat its cycle 0.
+        let a = slowcat(vec![
+            pure("a0"),
+            pure("a1"),
+            pure("a2"),
+            pure("a3"),
+            pure("a4"),
+            pure("a5"),
+        ]);
+        let b = slowcat(vec![pure("b0"), pure("b1"), pure("b2"), pure("b3")]);
+        let arr = arrange(vec![
+            (Some(Fraction::from_integer(4)), a),
+            (Some(Fraction::from_integer(2)), b),
+        ]);
+
+        assert_eq!(onset_values(&arr, 0), vec!["a0"]);
+        assert_eq!(onset_values(&arr, 1), vec!["a1"]);
+        assert_eq!(onset_values(&arr, 2), vec!["a2"]);
+        assert_eq!(onset_values(&arr, 3), vec!["a3"]);
+        assert_eq!(onset_values(&arr, 4), vec!["b0"]);
+        assert_eq!(onset_values(&arr, 5), vec!["b1"]);
+        // Loop boundary: A advances to its cycle 4, B to its cycle 2.
+        assert_eq!(onset_values(&arr, 6), vec!["a4"]);
+        assert_eq!(onset_values(&arr, 7), vec!["a5"]);
+        assert_eq!(onset_values(&arr, 10), vec!["b2"]);
+    }
+
+    #[test]
+    fn test_arrange_infinite_tail_loops_forever() {
+        let a = slowcat(vec![pure("a0"), pure("a1")]);
+        let b = slowcat(vec![
+            pure("b0"),
+            pure("b1"),
+            pure("b2"),
+            pure("b3"),
+            pure("b4"),
+        ]);
+        let arr = arrange(vec![(Some(Fraction::from_integer(2)), a), (None, b)]);
+
+        // Finite prefix plays once over cycles 0..2.
+        assert_eq!(onset_values(&arr, 0), vec!["a0"]);
+        assert_eq!(onset_values(&arr, 1), vec!["a1"]);
+        // Tail starts at cycle 2 and advances through its own cycles forever.
+        assert_eq!(onset_values(&arr, 2), vec!["b0"]);
+        assert_eq!(onset_values(&arr, 3), vec!["b1"]);
+        assert_eq!(onset_values(&arr, 6), vec!["b4"]);
+        // cycle 10 → tail cycle 8 → 8 mod 5 = 3.
+        assert_eq!(onset_values(&arr, 10), vec!["b3"]);
+    }
+
+    #[test]
+    fn test_arrange_single_infinite_is_identity() {
+        let p = slowcat(vec![pure("p0"), pure("p1")]);
+        let arr = arrange(vec![(None, p.clone())]);
+        for c in 0..5 {
+            assert_eq!(
+                onset_values(&arr, c),
+                onset_values(&p, c),
+                "arrange([Infinity, P]) must equal P at cycle {c}"
+            );
+        }
     }
 
     #[test]

--- a/crates/modular_core/src/pattern_system/hap.rs
+++ b/crates/modular_core/src/pattern_system/hap.rs
@@ -274,7 +274,7 @@ pub enum ArenaHapContext<'b> {
     /// highlights land in the right slot of the flat `per_source` list.
     /// Nests additively: `Rebased(a, Rebased(b, inner))` emits at `a + b + …`.
     Rebased {
-        base: u8,
+        base: u32,
         inner: &'b ArenaHapContext<'b>,
     },
 }
@@ -339,10 +339,10 @@ impl<'b> ArenaHapContext<'b> {
     ///
     /// A `Stripped` node folds its modifier-side spans back into the source
     /// pattern_idx for the rest of the subtree.
-    pub fn walk<F: FnMut(u8, &SourceSpan)>(&self, emit: &mut F) {
+    pub fn walk<F: FnMut(u32, &SourceSpan)>(&self, emit: &mut F) {
         // Pattern index counter — incremented when we step into a modifier
         // subtree at the root level.
-        let mut next_pattern_idx: u8 = 0;
+        let mut next_pattern_idx: u32 = 0;
         self.walk_inner(0, false, &mut next_pattern_idx, emit);
     }
 
@@ -352,10 +352,10 @@ impl<'b> ArenaHapContext<'b> {
     // `walk_inner::<closure>`).
     fn walk_inner(
         &self,
-        pattern_idx: u8,
+        pattern_idx: u32,
         stripped: bool,
-        next_pattern_idx: &mut u8,
-        emit: &mut dyn FnMut(u8, &SourceSpan),
+        next_pattern_idx: &mut u32,
+        emit: &mut dyn FnMut(u32, &SourceSpan),
     ) {
         match self {
             ArenaHapContext::Empty => {}
@@ -387,7 +387,7 @@ impl<'b> ArenaHapContext<'b> {
                 // the outer counter is advanced past `base + width` so a
                 // sibling modifier chain continues from the right slot.
                 let base = *base;
-                let mut local_next: u8 = 0;
+                let mut local_next: u32 = 0;
                 inner.walk_inner(0, stripped, &mut local_next, &mut |idx, span| {
                     emit(base.saturating_add(idx), span);
                 });

--- a/crates/modular_core/src/pattern_system/hap.rs
+++ b/crates/modular_core/src/pattern_system/hap.rs
@@ -269,6 +269,14 @@ pub enum ArenaHapContext<'b> {
     /// emitted as modifier_spans by `Combined`) appears on the source side.
     /// Used by `Pattern::strip_modifier_spans`.
     Stripped(&'b ArenaHapContext<'b>),
+    /// Shifts every pattern index emitted by `inner` up by `base`. Used by
+    /// `Pattern::offset_pattern_idx` so an arranged section's source-span
+    /// highlights land in the right slot of the flat `per_source` list.
+    /// Nests additively: `Rebased(a, Rebased(b, inner))` emits at `a + b + …`.
+    Rebased {
+        base: u8,
+        inner: &'b ArenaHapContext<'b>,
+    },
 }
 
 /// Static `Empty` context. Used by leaf constructors that emit value-only
@@ -338,12 +346,16 @@ impl<'b> ArenaHapContext<'b> {
         self.walk_inner(0, false, &mut next_pattern_idx, emit);
     }
 
-    fn walk_inner<F: FnMut(u8, &SourceSpan)>(
+    // `emit` is `dyn` rather than a generic `F` so that the `Rebased` arm,
+    // which wraps `emit` in a fresh closure, doesn't trigger unbounded
+    // monomorphisation (each nesting level would otherwise instantiate a new
+    // `walk_inner::<closure>`).
+    fn walk_inner(
         &self,
         pattern_idx: u8,
         stripped: bool,
         next_pattern_idx: &mut u8,
-        emit: &mut F,
+        emit: &mut dyn FnMut(u8, &SourceSpan),
     ) {
         match self {
             ArenaHapContext::Empty => {}
@@ -367,6 +379,22 @@ impl<'b> ArenaHapContext<'b> {
             }
             ArenaHapContext::Stripped(inner) => {
                 inner.walk_inner(pattern_idx, true, next_pattern_idx, emit);
+            }
+            ArenaHapContext::Rebased { base, inner } => {
+                // Walk `inner` in its own fresh index space, then shift every
+                // emitted index up by `base`. A fresh `local_next` keeps the
+                // inner indexing independent of the surrounding `pattern_idx`;
+                // the outer counter is advanced past `base + width` so a
+                // sibling modifier chain continues from the right slot.
+                let base = *base;
+                let mut local_next: u8 = 0;
+                inner.walk_inner(0, stripped, &mut local_next, &mut |idx, span| {
+                    emit(base.saturating_add(idx), span);
+                });
+                let top = base.saturating_add(local_next);
+                if top > *next_pattern_idx {
+                    *next_pattern_idx = top;
+                }
             }
         }
     }

--- a/crates/modular_core/src/pattern_system/mod.rs
+++ b/crates/modular_core/src/pattern_system/mod.rs
@@ -44,7 +44,7 @@ pub use hap::{ArenaHap, ArenaHapContext, DspHap, Hap, HapContext, SourceSpan};
 pub use state::State;
 pub use timespan::TimeSpan;
 
-pub use combinators::{fastcat, slowcat, stack, timecat};
+pub use combinators::{arrange, fastcat, slowcat, stack, timecat};
 pub use constructors::{pure, pure_with_span, signal, silence};
 
 // Re-export mini notation types
@@ -91,6 +91,10 @@ enum PatternImpl<T> {
     /// `strip_modifier_spans` wrapper — folds each hap's modifier-side
     /// spans back into the source side at extract time.
     StripModifierSpans(Arc<Pattern<T>>),
+    /// `offset_pattern_idx` wrapper — shifts every hap's pattern indices up
+    /// by `k` (via an `ArenaHapContext::Rebased`) so an arranged section's
+    /// highlights land in the right slot of the flat `per_source` list.
+    OffsetPatternIdx(Arc<OffsetPatternIdxData<T>>),
     /// `with_modifier_span` wrapper — combines each hap's context with a
     /// leaf context carrying the modifier span.
     WithModifierSpan(Arc<WithModifierSpanData<T>>),
@@ -129,6 +133,12 @@ pub(crate) struct CompressData<T> {
 pub(crate) struct WithModifierSpanData<T> {
     pub pat: Pattern<T>,
     pub span: SourceSpan,
+}
+
+/// Backing data for [`PatternImpl::OffsetPatternIdx`].
+pub(crate) struct OffsetPatternIdxData<T> {
+    pub pat: Pattern<T>,
+    pub k: u8,
 }
 
 /// Backing data for [`PatternImpl::FastConst`].
@@ -380,6 +390,19 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
                     hap.context = ArenaHapContext::combine_in(hap.context, leaf, bump);
                 }
             }
+            PatternImpl::OffsetPatternIdx(data) => {
+                let start = out.len();
+                data.pat.query_into(state, bump, out);
+                // Wrap each hap's context so its pattern indices shift up by k.
+                // A k of 0 is a no-op the constructor skips, so wrapping here is
+                // always meaningful.
+                for hap in &mut out[start..] {
+                    hap.context = bump.alloc(ArenaHapContext::Rebased {
+                        base: data.k,
+                        inner: hap.context,
+                    });
+                }
+            }
             PatternImpl::Compress(data) => {
                 compress_query_into(data, state, bump, out);
             }
@@ -466,6 +489,24 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
     pub fn strip_modifier_spans(&self) -> Pattern<T> {
         Pattern {
             query: PatternImpl::StripModifierSpans(Arc::new(self.clone())),
+            steps: self.steps.clone(),
+        }
+    }
+
+    /// Shift every hap's pattern indices up by `k`. Used by `arrange` so that
+    /// each section's source-span highlights land at their slot in the flat
+    /// `per_source` list (section 0's sources at `[0, …)`, section 1's after,
+    /// …). Nests additively, so an arranged section that is itself an arrange
+    /// composes correctly. `k == 0` is the identity.
+    pub fn offset_pattern_idx(&self, k: u8) -> Pattern<T> {
+        if k == 0 {
+            return self.clone();
+        }
+        Pattern {
+            query: PatternImpl::OffsetPatternIdx(Arc::new(OffsetPatternIdxData {
+                pat: self.clone(),
+                k,
+            })),
             steps: self.steps.clone(),
         }
     }
@@ -881,6 +922,73 @@ mod tests {
         assert_eq!(events[0].value, 42);
         // The hap should have an onset since it starts in this cycle
         assert!(events[0].has_onset());
+    }
+
+    #[test]
+    fn test_offset_pattern_idx_shifts_walk_indices() {
+        use crate::pattern_system::constructors::pure_with_span;
+        use crate::pattern_system::hap::SourceSpan;
+
+        // A single leaf span normally walks at pattern_idx 0; offsetting by 3
+        // shifts it to 3, and a second offset composes additively (3 + 2 = 5).
+        let base = pure_with_span(1.0f64, SourceSpan::new(0, 1));
+        let collect = |pat: &Pattern<f64>| -> Vec<(u8, (usize, usize))> {
+            let bump = bumpalo::Bump::new();
+            let mut out: bumpalo::collections::Vec<'_, ArenaHap<'_, f64>> =
+                bumpalo::collections::Vec::new_in(&bump);
+            pat.query_into(
+                &State::new(TimeSpan::new(
+                    Fraction::from_integer(0),
+                    Fraction::from_integer(1),
+                )),
+                &bump,
+                &mut out,
+            );
+            let mut spans = Vec::new();
+            for hap in &out {
+                hap.context
+                    .walk(&mut |idx, span| spans.push((idx, (span.start, span.end))));
+            }
+            spans
+        };
+
+        assert_eq!(collect(&base), vec![(0, (0, 1))]);
+        assert_eq!(collect(&base.offset_pattern_idx(3)), vec![(3, (0, 1))]);
+        assert_eq!(
+            collect(&base.offset_pattern_idx(3).offset_pattern_idx(2)),
+            vec![(5, (0, 1))],
+            "nested offsets compose additively"
+        );
+        // k == 0 is the identity.
+        assert_eq!(collect(&base.offset_pattern_idx(0)), vec![(0, (0, 1))]);
+    }
+
+    #[test]
+    fn test_offset_pattern_idx_shifts_multi_index_context() {
+        use crate::pattern_system::constructors::pure_with_span;
+        use crate::pattern_system::hap::SourceSpan;
+
+        // A combined context has spans at idx 0 (source) and idx 1 (modifier).
+        // Offsetting by 4 shifts the whole chain to 4 and 5.
+        let pat = pure_with_span(1.0f64, SourceSpan::new(0, 1))
+            .with_modifier_span(SourceSpan::new(5, 6))
+            .offset_pattern_idx(4);
+        let bump = bumpalo::Bump::new();
+        let mut out: bumpalo::collections::Vec<'_, ArenaHap<'_, f64>> =
+            bumpalo::collections::Vec::new_in(&bump);
+        pat.query_into(
+            &State::new(TimeSpan::new(
+                Fraction::from_integer(0),
+                Fraction::from_integer(1),
+            )),
+            &bump,
+            &mut out,
+        );
+        let mut spans = Vec::new();
+        out[0]
+            .context
+            .walk(&mut |idx, span| spans.push((idx, (span.start, span.end))));
+        assert_eq!(spans, vec![(4, (0, 1)), (5, (5, 6))]);
     }
 
     #[test]

--- a/crates/modular_core/src/pattern_system/mod.rs
+++ b/crates/modular_core/src/pattern_system/mod.rs
@@ -138,7 +138,7 @@ pub(crate) struct WithModifierSpanData<T> {
 /// Backing data for [`PatternImpl::OffsetPatternIdx`].
 pub(crate) struct OffsetPatternIdxData<T> {
     pub pat: Pattern<T>,
-    pub k: u8,
+    pub k: u32,
 }
 
 /// Backing data for [`PatternImpl::FastConst`].
@@ -498,7 +498,7 @@ impl<T: Clone + Send + Sync + 'static> Pattern<T> {
     /// `per_source` list (section 0's sources at `[0, …)`, section 1's after,
     /// …). Nests additively, so an arranged section that is itself an arrange
     /// composes correctly. `k == 0` is the identity.
-    pub fn offset_pattern_idx(&self, k: u8) -> Pattern<T> {
+    pub fn offset_pattern_idx(&self, k: u32) -> Pattern<T> {
         if k == 0 {
             return self.clone();
         }
@@ -932,7 +932,7 @@ mod tests {
         // A single leaf span normally walks at pattern_idx 0; offsetting by 3
         // shifts it to 3, and a second offset composes additively (3 + 2 = 5).
         let base = pure_with_span(1.0f64, SourceSpan::new(0, 1));
-        let collect = |pat: &Pattern<f64>| -> Vec<(u8, (usize, usize))> {
+        let collect = |pat: &Pattern<f64>| -> Vec<(u32, (usize, usize))> {
             let bump = bumpalo::Bump::new();
             let mut out: bumpalo::collections::Vec<'_, ArenaHap<'_, f64>> =
                 bumpalo::collections::Vec::new_in(&bump);

--- a/src/main/dsl/GraphBuilder.ts
+++ b/src/main/dsl/GraphBuilder.ts
@@ -615,7 +615,10 @@ export class GraphBuilder {
         this.schemaByName = new Map(this.schemas.map((s) => [s.name, s]));
         for (const schema of this.schemas) {
             if (qualifiesForDollarChain(schema)) {
-                this.dollarLookup.set(dollarMethodName(schema.name), schema.name);
+                this.dollarLookup.set(
+                    dollarMethodName(schema.name),
+                    schema.name,
+                );
             }
         }
     }
@@ -1708,13 +1711,21 @@ export function replaceValues(input: unknown, replacer: Replacer): unknown {
             return replaced;
         }
 
-        // Opaque payloads (ParsedPattern from $p(), SpPattern from $p.s())
-        // must be preserved verbatim — walking them would collapse the
-        // nulls in `accidental`/`octave`/weight slots to 0 via
-        // valueToSignal, producing zero-duration haps and silence.
+        // Opaque payloads (ParsedPattern from $p(), SpPattern from $p.s(),
+        // ArrangePattern from $p.arrange(), FastPattern/SlowPattern from
+        // .fast()/.slow()) must be preserved verbatim — walking them would
+        // collapse the nulls in `accidental`/`octave`/weight slots to 0 via
+        // valueToSignal, producing zero-duration haps and silence. Returning the
+        // wrapper verbatim also preserves the nested pattern payloads it carries.
         if (!Array.isArray(replaced)) {
             const kind = (replaced as { __kind?: unknown }).__kind;
-            if (kind === 'ParsedPattern' || kind === 'SpPattern') {
+            if (
+                kind === 'ParsedPattern' ||
+                kind === 'SpPattern' ||
+                kind === 'ArrangePattern' ||
+                kind === 'FastPattern' ||
+                kind === 'SlowPattern'
+            ) {
                 return replaced;
             }
         }
@@ -1784,11 +1795,18 @@ export function replaceDeferredStrings(
 
     if (typeof input === 'object' && input !== null) {
         // Opaque pattern payloads (ParsedPattern from $p(), SpPattern from
-        // $p.s()) are JSON-only data with no deferred-output strings; mirror
-        // the replaceValues short-circuit and return them verbatim instead of
-        // deep-walking their mini-notation AST sub-tree.
+        // $p.s(), ArrangePattern from $p.arrange(), FastPattern/SlowPattern from
+        // .fast()/.slow()) are JSON-only data with no deferred-output strings;
+        // mirror the replaceValues short-circuit and return them verbatim instead
+        // of deep-walking their mini-notation AST sub-tree.
         const kind = (input as { __kind?: unknown }).__kind;
-        if (kind === 'ParsedPattern' || kind === 'SpPattern') {
+        if (
+            kind === 'ParsedPattern' ||
+            kind === 'SpPattern' ||
+            kind === 'ArrangePattern' ||
+            kind === 'FastPattern' ||
+            kind === 'SlowPattern'
+        ) {
             return input;
         }
 

--- a/src/main/dsl/__tests__/executor.test.ts
+++ b/src/main/dsl/__tests__/executor.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, test } from 'vitest';
 import type { PatchGraph } from '@modular/core';
 import schemas from '@modular/core/schemas.json';
 import { type DSLExecutionResult, executePatchScript } from '../executor';
+import { isFastPattern, isParsedPattern } from '../miniNotation/index';
 
 const DEFAULT_EXECUTION_OPTIONS = {
     sampleRate: 48_000,
@@ -397,6 +398,159 @@ describe('sequencing', () => {
         expect(findModules(chained, '$cycle').length).toBe(1);
     });
 
+    test('$cycle($p.arrange(...)) builds an arrangement end-to-end', () => {
+        // Round-trips the ArrangePattern wire payload through the native
+        // deserializer (via deriveChannelCount) — a clean build proves Rust
+        // accepted it through from_arrange_payload.
+        const patch = execPatch(
+            '$cycle($p.arrange([2, $p.s("0 2 4", "C(major)")], [2, $p.s("0 2 4", "A(min)")])).out()',
+        );
+        const cycles = findModules(patch, '$cycle');
+        expect(cycles.length).toBe(1);
+        const pattern = cycles[0].params.pattern as {
+            __kind: string;
+            sections: Array<{
+                cycles: number | string;
+                pattern: { __kind: string };
+            }>;
+        };
+        expect(pattern.__kind).toBe('ArrangePattern');
+        expect(pattern.sections.length).toBe(2);
+        expect(pattern.sections[0].cycles).toBe(2);
+        expect(pattern.sections[0].pattern.__kind).toBe('SpPattern');
+    });
+
+    test('$p.arrange supports an Infinity tail and nesting', () => {
+        const inf = execPatch(
+            '$cycle($p.arrange([2, $p("c4")], [Infinity, $p.s("0 2 4", "f(lydian)")])).out()',
+        );
+        const infPattern = findModules(inf, '$cycle')[0].params.pattern as {
+            sections: Array<{ cycles: number | string }>;
+        };
+        expect(infPattern.sections[1].cycles).toBe('Infinity');
+
+        const nested = execPatch(
+            '$cycle($p.arrange([2, $p("c4")], [2, $p.arrange([1, $p("e4")], [1, $p("g4")])])).out()',
+        );
+        expect(findModules(nested, '$cycle').length).toBe(1);
+    });
+
+    test('$p.arrange surfaces a Rust validation error from a section', () => {
+        // A non-integer scale degree inside a section is rejected by the
+        // native deserializer (round-tripped via deriveChannelCount).
+        expect(() =>
+            execPatch('$cycle($p.arrange([2, $p.s("1.5", "C(major)")])).out()'),
+        ).toThrow(/IntervalValue requires integer scale degrees/);
+    });
+
+    test('$p.arrange rejects an Infinity section that is not last', () => {
+        expect(() =>
+            execPatch(
+                '$cycle($p.arrange([Infinity, $p("c4")], [2, $p("e4")])).out()',
+            ),
+        ).toThrow(/must be the last section/);
+    });
+
+    test('$cycle($p(...).fast(n)) builds end-to-end', () => {
+        // Round-trips the FastPattern wire payload through the native
+        // deserializer — a clean build proves Rust accepted it through
+        // from_fast_payload.
+        const patch = execPatch('$cycle($p("c4 e4").fast(2)).out()');
+        const cycles = findModules(patch, '$cycle');
+        expect(cycles.length).toBe(1);
+        const pattern = cycles[0].params.pattern;
+        expect(isFastPattern(pattern)).toBe(true);
+        if (!isFastPattern(pattern)) return;
+        expect(isParsedPattern(pattern.pattern)).toBe(true);
+        if (isParsedPattern(pattern.pattern)) {
+            expect(pattern.pattern.source).toBe('c4 e4');
+        }
+        // A number factor is a raw constant on the wire.
+        expect(pattern.factor).toBe(2);
+    });
+
+    test('.fast captures the factor argument span for highlighting', () => {
+        // The factor string is its own highlightable source: the analyzer
+        // registers it under `factor`, and the runtime carries it through as
+        // argument_spans[1] (argument_spans[0] is the wrapped pattern), parallel
+        // to the Rust per_source [inner, factor].
+        const source =
+            'const pat = $p("c4 e4").fast("2 4")\n' +
+            'const seq = $cycle(pat)\n' +
+            'seq.out()';
+        const patch = execPatch(source);
+        const cycles = findModules(patch, '$cycle');
+        expect(cycles.length).toBe(1);
+        const pattern = cycles[0].params.pattern;
+        expect(isFastPattern(pattern)).toBe(true);
+        if (!isFastPattern(pattern)) return;
+        const { factor } = pattern;
+        if (typeof factor === 'number') {
+            throw new Error('expected a pattern factor, got a number');
+        }
+        expect(factor.source).toBe('2 4');
+        expect(pattern.argument_spans.length).toBe(2);
+
+        // The factor span must point at the '2 4' literal, not the {0,0} fallback.
+        const factorSpan = pattern.argument_spans[1];
+        expect(factorSpan).not.toEqual({ start: 0, end: 0 });
+        expect(
+            source.slice(factorSpan.start, factorSpan.end).includes('2 4'),
+        ).toBe(true);
+        // The wrapped pattern's span is captured too (argument_spans[0]).
+        const innerSpan = pattern.argument_spans[0];
+        expect(
+            source.slice(innerSpan.start, innerSpan.end).includes('c4 e4'),
+        ).toBe(true);
+    });
+
+    test('.fast with a number factor adds no factor highlight span', () => {
+        // A bare number is a constant, not a highlightable source: the factor is
+        // carried as a raw number and only the wrapped pattern contributes a span.
+        const patch = execPatch('$cycle($p("c4 e4").fast(2)).out()');
+        const pattern = findModules(patch, '$cycle')[0].params.pattern;
+        expect(isFastPattern(pattern)).toBe(true);
+        if (!isFastPattern(pattern)) return;
+        expect(pattern.factor).toBe(2);
+        expect(pattern.argument_spans.length).toBe(1);
+    });
+
+    test('.fast / .slow accept a patterned factor and compose', () => {
+        // Patterned factor string.
+        expect(
+            findModules(
+                execPatch('$cycle($p("c4 e4").fast("2 4")).out()'),
+                '$cycle',
+            ).length,
+        ).toBe(1);
+        // .slow on a scale-degree pattern.
+        expect(
+            findModules(
+                execPatch('$cycle($p.s("0 2 4", "C(major)").slow(2)).out()'),
+                '$cycle',
+            ).length,
+        ).toBe(1);
+        // A .fast wrapping an arrangement.
+        expect(
+            findModules(
+                execPatch(
+                    '$cycle($p.arrange([2, $p("c4")], [2, $p("e4")]).fast(2)).out()',
+                ),
+                '$cycle',
+            ).length,
+        ).toBe(1);
+    });
+
+    test('$cycle($p(...).fast(0)) is accepted (lowers to silence)', () => {
+        // Lenient edge behavior: factor 0 is not rejected at the wire layer.
+        expect(
+            findModules(
+                execPatch('$cycle($p("c4 e4").fast(0)).out()'),
+                '$cycle',
+            ).length,
+        ).toBe(1);
+    });
+
     test('$p rejects dropped atom kinds', () => {
         expect(() => execPatch('$p("m60")')).toThrow();
         expect(() => execPatch('$p("bd sd")')).toThrow();
@@ -408,9 +562,9 @@ describe('sequencing', () => {
         expect(() =>
             execPatch('$cycle($p.s("1.5", "C(major)")).out()'),
         ).toThrow(/IntervalValue requires integer scale degrees, got 1\.5/);
-        expect(() =>
-            execPatch('$cycle($p.s("c4", "C(major)")).out()'),
-        ).toThrow(/IntervalValue does not accept note atoms/);
+        expect(() => execPatch('$cycle($p.s("c4", "C(major)")).out()')).toThrow(
+            /IntervalValue does not accept note atoms/,
+        );
         expect(() =>
             execPatch('$cycle($p.s("440hz", "C(major)")).out()'),
         ).toThrow(/IntervalValue does not accept Hz atoms/);
@@ -578,7 +732,10 @@ describe('sequencing', () => {
         const cycle = findModules(patch, '$cycle')[0];
         const argSpans = (
             cycle.params as {
-                __argument_spans?: Record<string, { start: number; end: number }>;
+                __argument_spans?: Record<
+                    string,
+                    { start: number; end: number }
+                >;
             }
         ).__argument_spans;
         expect(argSpans).toBeDefined();

--- a/src/main/dsl/argumentSpanAnalyzer.ts
+++ b/src/main/dsl/argumentSpanAnalyzer.ts
@@ -203,6 +203,79 @@ function chainRootIsPs(
 }
 
 /**
+ * Identify `<pattern>.fast(factor)` / `<pattern>.slow(factor)` calls, where
+ * `<pattern>` is any pattern-producing chain: `$p(...)`, `$p.s(...)`,
+ * `$p.arrange(...)`, a nested `.fast`/`.slow`/`.add`/`.sub` link, or a
+ * const-bound pattern. The factor literal is registered under `factor` so the
+ * `.fast`/`.slow` method can capture it via
+ * `captureSourceLocation()` + `lookupArgumentSpan(loc, 'factor')`.
+ */
+function isFastSlowCall(
+    call: CallExpression,
+    constInitMap: Map<string, Node>,
+): boolean {
+    const expr = call.getExpression();
+    if (!Node.isPropertyAccessExpression(expr)) return false;
+    const methodName = expr.getName();
+    if (methodName !== 'fast' && methodName !== 'slow') return false;
+    return chainRootIsPattern(expr.getExpression(), constInitMap);
+}
+
+/**
+ * Walk back through a method chain and return true when it roots in a pattern
+ * builder — `$p(...)`, `$p.s(...)`, or `$p.arrange(...)` — possibly through
+ * intermediate `.add`/`.sub`/`.fast`/`.slow`/mode links and `const` hops.
+ * Generalises [`chainRootIsPs`] beyond the `$p.s` root.
+ */
+function chainRootIsPattern(
+    node: import('ts-morph').Node,
+    constInitMap: Map<string, Node>,
+    visited = new Set<string>(),
+): boolean {
+    let n: import('ts-morph').Node = node;
+    while (true) {
+        if (Node.isCallExpression(n)) {
+            const inner = n.getExpression();
+            // `$p("…")` — a bare-identifier call to the mini-notation factory.
+            if (Node.isIdentifier(inner)) {
+                return inner.getText() === '$p';
+            }
+            if (Node.isPropertyAccessExpression(inner)) {
+                const name = inner.getName();
+                const recv = inner.getExpression();
+                // `$p.s(...)` / `$p.arrange(...)` are chain roots.
+                if (
+                    (name === 's' || name === 'arrange') &&
+                    Node.isIdentifier(recv) &&
+                    recv.getText() === '$p'
+                ) {
+                    return true;
+                }
+                // Any other chain link (.add/.sub/.fast/.slow/mode) — keep
+                // walking toward the root through its receiver.
+                n = recv;
+                continue;
+            }
+            return false;
+        }
+        if (Node.isPropertyAccessExpression(n)) {
+            n = n.getExpression();
+            continue;
+        }
+        if (Node.isIdentifier(n)) {
+            const name = n.getText();
+            if (visited.has(name)) return false;
+            const init = constInitMap.get(name);
+            if (!init) return false;
+            visited.add(name);
+            n = init;
+            continue;
+        }
+        return false;
+    }
+}
+
+/**
  * Get the full dotted path for a property access call.
  * e.g., "$p.s" for $p.s()
  */
@@ -685,6 +758,44 @@ export function analyzeArgumentSpans(
             registry.set(callKey, {
                 args: argsMap,
                 moduleType: '$p.s.chain',
+            });
+            const innerNode = getTrackableNode(pArgs[0], constNodeMap);
+            if (innerNode) {
+                const resolutions = resolveInterpolations(
+                    innerNode,
+                    constNodeMap,
+                    constMap,
+                );
+                if (resolutions) {
+                    const spanKey = `${span.start}:${span.end}`;
+                    interpolationResolutions.set(spanKey, resolutions);
+                }
+            }
+            return;
+        }
+
+        // Track `<pattern>.fast(factor)` / `.slow(factor)`: register the factor
+        // literal span under `factor` so the `.fast`/`.slow` method captures it
+        // via captureSourceLocation()+lookupArgumentSpan(loc, 'factor'). Keyed at
+        // the method name's position, like the `$p.s` chain above.
+        if (isFastSlowCall(call, constInitMap)) {
+            const pArgs = call.getArguments();
+            if (pArgs.length < 1) return;
+            const span = getTrackableSpan(pArgs[0], constMap);
+            if (!span) return;
+            const callExpr = call.getExpression();
+            const callStartPos = Node.isPropertyAccessExpression(callExpr)
+                ? callExpr.getNameNode().getStart()
+                : call.getStart();
+            const { line, column } =
+                sourceFile.getLineAndColumnAtPos(callStartPos);
+            const columnOffset = line === 1 ? firstLineColumnOffset : 0;
+            const callKey: CallSiteKey = `${line + lineOffset}:${column + columnOffset}`;
+            const argsMap = new Map<string, SourceSpan>();
+            argsMap.set('factor', span);
+            registry.set(callKey, {
+                args: argsMap,
+                moduleType: '.fast/.slow',
             });
             const innerNode = getTrackableNode(pArgs[0], constNodeMap);
             if (innerNode) {

--- a/src/main/dsl/factories.ts
+++ b/src/main/dsl/factories.ts
@@ -49,7 +49,8 @@ function isParsedPatternLike(
     return (
         typeof value === 'object' &&
         value !== null &&
-        (value as { __kind?: unknown }).__kind === 'ParsedPattern'
+        '__kind' in value &&
+        value.__kind === 'ParsedPattern'
     );
 }
 
@@ -64,8 +65,41 @@ function isSpPatternLike(
     return (
         typeof value === 'object' &&
         value !== null &&
-        (value as { __kind?: unknown }).__kind === 'SpPattern'
+        '__kind' in value &&
+        value.__kind === 'SpPattern'
     );
+}
+
+/**
+ * Structural check for an `ArrangePattern` (returned by `$p.arrange(...)`).
+ * Like `SpPattern`, it carries a flat `argument_spans[i]` list — one per source
+ * across all sections, in order — used to map runtime per-source highlights
+ * back to editor literals.
+ */
+function isArrangePatternLike(
+    value: unknown,
+): value is { argument_spans?: ReadonlyArray<SourceSpan> } {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        '__kind' in value &&
+        value.__kind === 'ArrangePattern'
+    );
+}
+
+/**
+ * Structural check for a `.fast(...)` / `.slow(...)` wrapper. Like `SpPattern`
+ * and `ArrangePattern`, it carries a flat `argument_spans[i]` list — the wrapped
+ * pattern's per-source spans — used to map runtime per-source highlights back to
+ * editor literals.
+ */
+function isFastOrSlowPatternLike(
+    value: unknown,
+): value is { argument_spans?: ReadonlyArray<SourceSpan> } {
+    if (typeof value !== 'object' || value === null || !('__kind' in value)) {
+        return false;
+    }
+    return value.__kind === 'FastPattern' || value.__kind === 'SlowPattern';
 }
 
 /**
@@ -301,7 +335,13 @@ export class DSLContext {
                 ...(argumentSpans ?? {}),
             };
             for (const [paramName, value] of Object.entries(params)) {
-                if (isSpPatternLike(value)) {
+                if (
+                    isSpPatternLike(value) ||
+                    isArrangePatternLike(value) ||
+                    isFastOrSlowPatternLike(value)
+                ) {
+                    // Both carry a flat `argument_spans[i]` list lining up with
+                    // the Rust per-source order; emit `<paramName>.<i>` keys.
                     const argSpans = value.argument_spans;
                     if (argSpans && argSpans.length > 0) {
                         argSpans.forEach((span, j) => {

--- a/src/main/dsl/miniNotation/__tests__/arrange.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/arrange.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+    $p,
+    MiniParseError,
+    isArrangePattern,
+    type ArrangePattern,
+} from '../index';
+import { replaceSignals } from '../../GraphBuilder';
+
+describe('$p.arrange builder', () => {
+    test('builds an ArrangePattern wire object from [cycles, pattern] tuples', () => {
+        const r = $p.arrange([2, $p('c4 e4')], [4, $p.s('0 2 4', 'c(major)')]);
+
+        expect(isArrangePattern(r)).toBe(true);
+        expect(r.__kind).toBe('ArrangePattern');
+        expect(r.sections).toHaveLength(2);
+
+        expect(r.sections[0].cycles).toBe(2);
+        expect(r.sections[0].pattern.__kind).toBe('ParsedPattern');
+        expect(r.sections[1].cycles).toBe(4);
+        expect(r.sections[1].pattern.__kind).toBe('SpPattern');
+
+        // Flat argument_spans: one per source across sections, in order.
+        expect(r.argument_spans).toHaveLength(2);
+    });
+
+    test('encodes Infinity as the string sentinel "Infinity"', () => {
+        const r = $p.arrange([2, $p('c4')], [Infinity, $p.s('0 2 4', 'a(min)')]);
+        expect(r.sections[0].cycles).toBe(2);
+        expect(r.sections[1].cycles).toBe('Infinity');
+    });
+
+    test('nests: an ArrangePattern is a valid section, spans flatten', () => {
+        const nested = $p.arrange([1, $p('e4')], [1, $p('g4')]);
+        expect(nested.argument_spans).toHaveLength(2);
+
+        const r = $p.arrange([2, $p('c4')], [2, nested]);
+        expect(r.sections[1].pattern.__kind).toBe('ArrangePattern');
+        // 1 (c4) + 2 (nested's two sources) = 3 flat spans.
+        expect(r.argument_spans).toHaveLength(3);
+    });
+
+    test('flattens chained $p.s argument spans across sections', () => {
+        // A chained $p.s contributes one span per source in the chain.
+        const chained = $p.s('0 2 4', 'c(maj)').add('0 5');
+        expect(chained.argument_spans).toHaveLength(2);
+
+        const r = $p.arrange([1, $p('c4')], [1, chained]);
+        // 1 (c4) + 2 (chain) = 3.
+        expect(r.argument_spans).toHaveLength(3);
+    });
+
+    test('rejects an empty arrangement', () => {
+        expect(() => ($p.arrange as () => ArrangePattern)()).toThrow(
+            MiniParseError,
+        );
+    });
+
+    test('rejects non-integer, zero, and negative cycle counts', () => {
+        for (const bad of [2.5, 0, -1]) {
+            expect(() => $p.arrange([bad, $p('c4')])).toThrow(MiniParseError);
+        }
+    });
+
+    test('rejects a non-[cycles, pattern] section', () => {
+        expect(() =>
+            $p.arrange([2] as unknown as [number, ReturnType<typeof $p>]),
+        ).toThrow(MiniParseError);
+    });
+
+    test('rejects a non-pattern section payload', () => {
+        expect(() =>
+            $p.arrange([
+                2,
+                'c4' as unknown as ReturnType<typeof $p>,
+            ]),
+        ).toThrow(MiniParseError);
+    });
+
+    test('rejects an Infinity section that is not last', () => {
+        expect(() =>
+            $p.arrange([Infinity, $p('c4')], [2, $p('e4')]),
+        ).toThrow(MiniParseError);
+    });
+
+    test('survives replaceSignals verbatim (no AST collapse)', () => {
+        const r = $p.arrange([2, $p('c4')], [2, $p.s('0 2 4', 'c(maj)')]);
+        const out = replaceSignals(r) as ArrangePattern;
+
+        expect(out.__kind).toBe('ArrangePattern');
+        expect(out.sections).toHaveLength(2);
+        // Nested mini-notation payloads must be preserved, not deep-walked
+        // (which would collapse null accidental/octave/weight slots to 0).
+        const sp = out.sections[1].pattern as { sources: { source: string }[] };
+        expect(sp.sources[0].source).toBe('0 2 4');
+    });
+});

--- a/src/main/dsl/miniNotation/__tests__/fastSlow.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/fastSlow.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+    $p,
+    MiniParseError,
+    isFastPattern,
+    isParsedPattern,
+    isSlowPattern,
+} from '../index';
+import { replaceSignals } from '../../GraphBuilder';
+
+describe('.fast / .slow builders', () => {
+    test('$p(...).fast(n) builds a FastPattern wrapping the inner pattern', () => {
+        const r = $p('c4 e4').fast(2);
+
+        expect(isFastPattern(r)).toBe(true);
+        expect(r.__kind).toBe('FastPattern');
+        expect(r.pattern.__kind).toBe('ParsedPattern');
+        // A numeric factor is a raw constant, not a parsed pattern.
+        expect(r.factor).toBe(2);
+    });
+
+    test('$p(...).slow(n) builds a SlowPattern', () => {
+        const r = $p('c4 e4').slow(2);
+        expect(isSlowPattern(r)).toBe(true);
+        expect(r.__kind).toBe('SlowPattern');
+        expect(r.pattern.__kind).toBe('ParsedPattern');
+        expect(r.factor).toBe(2);
+    });
+
+    test('a string factor is parsed as a mini-notation number pattern', () => {
+        const { factor } = $p('c4').fast('2 4');
+        if (typeof factor === 'number') {
+            throw new Error('expected a pattern factor, got a number');
+        }
+        expect(factor.source).toBe('2 4');
+        // "2 4" is a two-step sequence, not a single Pure atom.
+        expect('Sequence' in factor.ast).toBe(true);
+    });
+
+    test('.fast / .slow chain and nest', () => {
+        const r = $p('c4 e4').fast(3).slow(3);
+        expect(r.__kind).toBe('SlowPattern');
+        expect(isFastPattern(r.pattern)).toBe(true);
+        if (isFastPattern(r.pattern)) {
+            expect(r.pattern.pattern.__kind).toBe('ParsedPattern');
+        }
+    });
+
+    test('works on $p.s and $p.arrange patterns', () => {
+        const onSp = $p.s('0 2 4', 'c(maj)').fast(2);
+        expect(onSp.__kind).toBe('FastPattern');
+        expect(onSp.pattern.__kind).toBe('SpPattern');
+
+        const onArrange = $p.arrange([2, $p('c4')], [2, $p('e4')]).slow(2);
+        expect(onArrange.__kind).toBe('SlowPattern');
+        expect(onArrange.pattern.__kind).toBe('ArrangePattern');
+    });
+
+    test('a number factor adds no argument span; a string factor adds one', () => {
+        // Number factor: only the wrapped pattern's span(s). The bare number is
+        // a constant and is not highlightable.
+        expect($p('c4 e4').fast(2).argument_spans).toHaveLength(1);
+        const chainedNum = $p.s('0 2 4', 'c(maj)').add('0 5').fast(2);
+        expect(chainedNum.argument_spans).toHaveLength(2);
+        // String factor: wrapped pattern's span(s) + the factor span.
+        expect($p('c4 e4').fast('2 4').argument_spans).toHaveLength(2);
+        const chainedStr = $p.s('0 2 4', 'c(maj)').add('0 5').fast('2 4');
+        expect(chainedStr.argument_spans).toHaveLength(3);
+    });
+
+    test('a FastPattern is a valid $p.arrange section, spans flatten', () => {
+        // Number factor → the FastPattern contributes only its inner span.
+        const r = $p.arrange([2, $p('c4').fast(2)], [2, $p('e4')]);
+        expect(r.sections[0].pattern.__kind).toBe('FastPattern');
+        // 1 (fast's inner c4) + 1 (e4) = 2 flat spans.
+        expect(r.argument_spans).toHaveLength(2);
+        // String factor → the FastPattern contributes inner + factor.
+        const r2 = $p.arrange([2, $p('c4').fast('2 4')], [2, $p('e4')]);
+        // 2 (inner c4 + factor) + 1 (e4) = 3 flat spans.
+        expect(r2.argument_spans).toHaveLength(3);
+    });
+
+    test('methods are non-enumerable — only the wire shape serializes', () => {
+        const r = $p('c4').fast(2);
+        expect(Object.keys(r).sort()).toEqual([
+            '__kind',
+            'argument_spans',
+            'factor',
+            'pattern',
+        ]);
+        const json: { __kind: unknown; pattern: Record<string, unknown> } =
+            JSON.parse(JSON.stringify(r));
+        expect(json.__kind).toBe('FastPattern');
+        expect('fast' in json).toBe(false);
+        expect('slow' in json).toBe(false);
+        // The nested pattern's methods are dropped too.
+        expect('fast' in json.pattern).toBe(false);
+    });
+
+    test('survives replaceSignals verbatim (no AST collapse)', () => {
+        const out = replaceSignals($p('c4 e4').fast('2 4'));
+        expect(isFastPattern(out)).toBe(true);
+        if (!isFastPattern(out)) return;
+        expect(isParsedPattern(out.pattern)).toBe(true);
+        if (isParsedPattern(out.pattern)) {
+            expect(out.pattern.source).toBe('c4 e4');
+        }
+        const { factor } = out;
+        if (typeof factor === 'number') {
+            throw new Error('expected a pattern factor, got a number');
+        }
+        expect(factor.source).toBe('2 4');
+    });
+
+    test('a zero factor is allowed (lenient — lowers to silence in the engine)', () => {
+        const r = $p('c4 e4').fast(0);
+        expect(r.__kind).toBe('FastPattern');
+        expect(r.factor).toBe(0);
+    });
+
+    test('rejects a non-finite number factor', () => {
+        // NaN / Infinity are valid `number`s but can't cross the JSON wire.
+        expect(() => $p('c4').fast(NaN)).toThrow(MiniParseError);
+        expect(() => $p('c4').fast(Infinity)).toThrow(MiniParseError);
+        // .slow goes through the same factor builder.
+        expect(() => $p('c4').slow(NaN)).toThrow(MiniParseError);
+    });
+});

--- a/src/main/dsl/miniNotation/index.ts
+++ b/src/main/dsl/miniNotation/index.ts
@@ -421,8 +421,8 @@ const SLOW_KIND = 'SlowPattern' as const;
  * The `.fast(...)` / `.slow(...)` methods attached (non-enumerably) to every
  * pattern object, mirroring Strudel's `fast`/`slow`. The factor is a constant
  * (`2`) or a mini-notation number pattern (`"2 4"` → ×2 then ×4 across the
- * cycle). A factor of `0` yields silence and negatives reverse time, matching
- * the in-string `*` / `/` operators.
+ * cycle). A non-positive factor (`0` or negative) yields silence, matching the
+ * in-string `*` / `/` operators.
  */
 export interface TimeModifiable {
     fast(factor: number | string): FastPattern & TimeModifiable;

--- a/src/main/dsl/miniNotation/index.ts
+++ b/src/main/dsl/miniNotation/index.ts
@@ -47,7 +47,7 @@ export { MiniParseError } from './parser';
  *
  * Throws `MiniParseError` if `source` is not a string or fails to parse.
  */
-function $pImpl(source: string): ParsedPattern {
+function $pImpl(source: string): ParsedPattern & TimeModifiable {
     if (typeof source !== 'string') {
         throw new MiniParseError(
             `$p() expects a string argument, got ${typeof source}`,
@@ -66,26 +66,28 @@ function $pImpl(source: string): ParsedPattern {
     if (argument_span) {
         pattern.argument_span = argument_span;
     }
-    return pattern;
+    return attachTimeModifiers(pattern);
 }
 
 /**
  * The mini-notation factory. Callable as `$p(source)` for a plain
- * `ParsedPattern`, and carries `$p.s(source, scale)` for scale-degree
- * patterns (see `$spImpl`). `$spImpl` is hoisted, so the assignment can
- * reference it here.
+ * `ParsedPattern`, carries `$p.s(source, scale)` for scale-degree patterns
+ * (see `$spImpl`) and `$p.arrange([cycles, pattern], …)` for multi-cycle
+ * arrangements (see `$arrangeImpl`). All three are hoisted, so the assignment
+ * can reference them here.
  */
-export const $p: typeof $pImpl & { s: typeof $spImpl } = Object.assign(
-    $pImpl,
-    { s: $spImpl },
-);
+export const $p: typeof $pImpl & {
+    s: typeof $spImpl;
+    arrange: typeof $arrangeImpl;
+} = Object.assign($pImpl, { s: $spImpl, arrange: $arrangeImpl });
 
 /** Type guard for runtime `ParsedPattern` checks. */
 export function isParsedPattern(value: unknown): value is ParsedPattern {
     return (
         typeof value === 'object' &&
         value !== null &&
-        (value as { __kind?: unknown }).__kind === 'ParsedPattern'
+        '__kind' in value &&
+        value.__kind === 'ParsedPattern'
     );
 }
 
@@ -137,8 +139,8 @@ export interface ParsedPatternPayload {
 }
 
 /** Callable + method bag for chain methods. */
-export type SpCombineBuilder = ((rhs: string) => SpPattern) & {
-    [M in SpAlignmentMode]: (rhs: string) => SpPattern;
+export type SpCombineBuilder = ((rhs: string) => SpPattern & TimeModifiable) & {
+    [M in SpAlignmentMode]: (rhs: string) => SpPattern & TimeModifiable;
 };
 
 /**
@@ -181,7 +183,7 @@ export interface SpPattern {
  * `"c(0 2 4 5 7 9 11)"`, just-intonation tunings `"c(just)"` /
  * `"c(pythagorean)"`, and the bare `"chromatic"` ladder.
  */
-function $spImpl(source: string, scale: string): SpPattern {
+function $spImpl(source: string, scale: string): SpPattern & TimeModifiable {
     if (typeof source !== 'string') {
         throw new MiniParseError(
             `$p.s() expects a string source, got ${typeof source}`,
@@ -208,7 +210,8 @@ export function isSpPattern(value: unknown): value is SpPattern {
     return (
         typeof value === 'object' &&
         value !== null &&
-        (value as { __kind?: unknown }).__kind === SP_KIND
+        '__kind' in value &&
+        value.__kind === SP_KIND
     );
 }
 
@@ -223,7 +226,7 @@ function buildSpPattern(
     scale: string,
     ops: SpOp[],
     argument_spans: SourceSpan[],
-): SpPattern {
+): SpPattern & TimeModifiable {
     const pat: Record<string, unknown> = {
         __kind: SP_KIND,
         sources,
@@ -245,13 +248,11 @@ function buildSpPattern(
         configurable: true,
         get: () => makeCombineBuilder(handle, 'sub'),
     });
-    return handle;
+    // fast / slow are likewise non-enumerable; the wire shape stays clean.
+    return attachTimeModifiers(handle);
 }
 
-function makeCombineBuilder(
-    pat: SpPattern,
-    op: SpOpKind,
-): SpCombineBuilder {
+function makeCombineBuilder(pat: SpPattern, op: SpOpKind): SpCombineBuilder {
     const apply = (mode: SpAlignmentMode, rhs: string): SpPattern => {
         if (typeof rhs !== 'string') {
             throw new MiniParseError(
@@ -263,8 +264,7 @@ function makeCombineBuilder(
         // argument-span analyzer registers each chain RHS under the
         // method's source location, keyed by the param name `rhs`.
         const loc = captureSourceLocation();
-        const argSpan =
-            lookupArgumentSpan(loc, 'rhs') ?? ({ start: 0, end: 0 } as SourceSpan);
+        const argSpan = lookupArgumentSpan(loc, 'rhs') ?? { start: 0, end: 0 };
         return buildSpPattern(
             [...pat.sources, payload],
             pat.scale,
@@ -285,6 +285,309 @@ function makeCombineBuilder(
         });
     }
     return builder;
+}
+
+// ─── $p.arrange ─────────────────────────────────────────────────────────
+
+/** Discriminator string the Rust `SeqPatternSource` untagged enum matches. */
+const ARRANGE_KIND = 'ArrangePattern' as const;
+
+/** A pattern usable as an `$p.arrange` section (and as a `$cycle` argument). */
+export type SectionPattern =
+    | ParsedPattern
+    | SpPattern
+    | ArrangePattern
+    | FastPattern
+    | SlowPattern;
+
+/** One `[cycles, pattern]` tuple accepted by `$p.arrange`. */
+export type ArrangeSectionArg = readonly [number, SectionPattern];
+
+/**
+ * Wire shape for one arrange section. `cycles` is a positive integer, or the
+ * string `'Infinity'` for an infinite tail (JSON can't carry numeric infinity).
+ * `pattern` is the embedded section payload — its enumerable fields already
+ * match the Rust `SeqPatternSource` shape, so the object is embedded verbatim.
+ */
+export interface ArrangeSectionWire {
+    cycles: number | 'Infinity';
+    pattern: SectionPattern;
+}
+
+/**
+ * Wire shape for an arrangement. Recognised by the Rust `SeqPatternSource`
+ * untagged enum via `__kind === 'ArrangePattern'`. `argument_spans` is the flat
+ * per-source span list (sections in order, sources within each section in
+ * order) that `$cycle`'s factory maps to `pattern.0`, `pattern.1`, … for editor
+ * highlighting — matching the flat `per_source` order the Rust side builds.
+ *
+ * An `ArrangePattern` is itself a valid `$p.arrange` section and `$cycle`
+ * argument, so arrangements nest.
+ */
+export interface ArrangePattern {
+    __kind: typeof ARRANGE_KIND;
+    sections: Array<ArrangeSectionWire>;
+    argument_spans: Array<SourceSpan>;
+}
+
+/** Type guard for runtime `ArrangePattern` checks. */
+export function isArrangePattern(value: unknown): value is ArrangePattern {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        '__kind' in value &&
+        value.__kind === ARRANGE_KIND
+    );
+}
+
+/**
+ * Arrange multiple patterns over multiple cycles, mirroring Strudel's
+ * `arrange`. Each argument is a `[cycles, pattern]` tuple: `pattern` (a
+ * `$p(...)`, `$p.s(...)`, or nested `$p.arrange(...)`) plays for `cycles`
+ * cycles, and the sections play back-to-back, looping with period `Σ cycles`.
+ *
+ * Because each `$p.s` section is resolved through its own scale, an arrangement
+ * can switch scales between sections. Cycle counts must be positive integers,
+ * except a single trailing section may use `Infinity` to loop forever once
+ * reached (later sections would never play and are rejected).
+ *
+ * Returns an `ArrangePattern`, itself usable as a section of another
+ * `$p.arrange(...)` or as the argument to `$cycle(...)`.
+ */
+function $arrangeImpl(
+    ...sections: ArrangeSectionArg[]
+): ArrangePattern & TimeModifiable {
+    if (sections.length === 0) {
+        throw new MiniParseError(
+            '$p.arrange() requires at least one [cycles, pattern] section',
+        );
+    }
+
+    const wireSections: ArrangeSectionWire[] = [];
+    const argument_spans: SourceSpan[] = [];
+
+    sections.forEach((sectionArg, i) => {
+        if (!Array.isArray(sectionArg) || sectionArg.length !== 2) {
+            throw new MiniParseError(
+                `$p.arrange() section ${i} must be a [cycles, pattern] tuple`,
+            );
+        }
+        const [cyclesRaw, pattern] = sectionArg;
+
+        if (typeof cyclesRaw !== 'number' || Number.isNaN(cyclesRaw)) {
+            throw new MiniParseError(
+                `$p.arrange() section ${i}: cycles must be a number, got ${typeof cyclesRaw}`,
+            );
+        }
+        let cycles: number | 'Infinity';
+        if (cyclesRaw === Infinity) {
+            if (i !== sections.length - 1) {
+                throw new MiniParseError(
+                    '$p.arrange(): an Infinity section must be the last section ' +
+                        '(sections after it can never play)',
+                );
+            }
+            cycles = 'Infinity';
+        } else if (!Number.isInteger(cyclesRaw) || cyclesRaw <= 0) {
+            throw new MiniParseError(
+                `$p.arrange() section ${i}: cycles must be a positive integer or Infinity, got ${cyclesRaw}`,
+            );
+        } else {
+            cycles = cyclesRaw;
+        }
+
+        // Collect each section's flat argument spans in order so the factory can
+        // map them to `pattern.0`, `pattern.1`, … (mirroring the Rust per_source).
+        argument_spans.push(
+            ...collectPatternSpans(pattern, `$p.arrange() section ${i}`),
+        );
+        wireSections.push({ cycles, pattern });
+    });
+
+    return attachTimeModifiers({
+        __kind: ARRANGE_KIND,
+        sections: wireSections,
+        argument_spans,
+    });
+}
+
+// ─── .fast / .slow (time modifiers on every pattern) ────────────────────
+
+/** Discriminator strings the Rust `SeqPatternSource` untagged enum matches. */
+const FAST_KIND = 'FastPattern' as const;
+const SLOW_KIND = 'SlowPattern' as const;
+
+/**
+ * The `.fast(...)` / `.slow(...)` methods attached (non-enumerably) to every
+ * pattern object, mirroring Strudel's `fast`/`slow`. The factor is a constant
+ * (`2`) or a mini-notation number pattern (`"2 4"` → ×2 then ×4 across the
+ * cycle). A factor of `0` yields silence and negatives reverse time, matching
+ * the in-string `*` / `/` operators.
+ */
+export interface TimeModifiable {
+    fast(factor: number | string): FastPattern & TimeModifiable;
+    slow(factor: number | string): SlowPattern & TimeModifiable;
+}
+
+/**
+ * Wire shape for `pattern.fast(factor)`. Recognised by the Rust
+ * `SeqPatternSource` untagged enum via `__kind === 'FastPattern'`. `pattern` is
+ * the wrapped pattern (any `SectionPattern`, so wrappers chain and nest);
+ * `argument_spans` is the wrapped pattern's flat per-source span list, plus the
+ * factor's span when the factor is a pattern string. At runtime the object also
+ * carries non-enumerable `.fast`/`.slow` methods (the `& TimeModifiable` the
+ * builders return); the bare interface is the JSON wire shape.
+ */
+export interface FastPattern {
+    __kind: typeof FAST_KIND;
+    pattern: SectionPattern;
+    /**
+     * The speed factor. A bare `number` is a constant (`.fast(2)`) and is *not*
+     * highlightable. A `ParsedPatternPayload` (`.fast("2 4")`) is its own
+     * highlightable source whose active value lights up as it drives the speed.
+     */
+    factor: number | ParsedPatternPayload;
+    argument_spans: Array<SourceSpan>;
+}
+
+/** Wire shape for `pattern.slow(factor)` — the time-inverse of `FastPattern`. */
+export interface SlowPattern {
+    __kind: typeof SLOW_KIND;
+    pattern: SectionPattern;
+    /** See {@link FastPattern.factor}. */
+    factor: number | ParsedPatternPayload;
+    argument_spans: Array<SourceSpan>;
+}
+
+/** Type guard for runtime `FastPattern` checks. */
+export function isFastPattern(value: unknown): value is FastPattern {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        '__kind' in value &&
+        value.__kind === FAST_KIND
+    );
+}
+
+/** Type guard for runtime `SlowPattern` checks. */
+export function isSlowPattern(value: unknown): value is SlowPattern {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        '__kind' in value &&
+        value.__kind === SLOW_KIND
+    );
+}
+
+/**
+ * Collect a pattern's flat per-source argument spans in the same order the Rust
+ * side flattens `per_source`. Shared by `$p.arrange` (per section) and the
+ * `.fast`/`.slow` wrappers (the wrapped pattern). Throws on a non-pattern value.
+ */
+function collectPatternSpans(
+    pattern: SectionPattern,
+    context: string,
+): SourceSpan[] {
+    if (isParsedPattern(pattern)) {
+        return [pattern.argument_span ?? { start: 0, end: 0 }];
+    }
+    if (
+        isSpPattern(pattern) ||
+        isArrangePattern(pattern) ||
+        isFastPattern(pattern) ||
+        isSlowPattern(pattern)
+    ) {
+        return [...pattern.argument_spans];
+    }
+    throw new MiniParseError(
+        `${context}: pattern must be a $p(...), $p.s(...), $p.arrange(...), ` +
+            `or .fast(...)/.slow(...) value`,
+    );
+}
+
+/**
+ * Build the wire payload for a `.fast`/`.slow` factor. A number is carried as a
+ * raw constant (not a highlightable source); a string is parsed as full
+ * mini-notation (`"2 4"`, `"<1 2>"`, …) into a `ParsedPatternPayload` that the
+ * Rust side lowers to a `Pattern<Fraction>` and highlights.
+ */
+function factorPayload(arg: number | string): number | ParsedPatternPayload {
+    if (typeof arg === 'number') {
+        if (!Number.isFinite(arg)) {
+            throw new MiniParseError(
+                `fast()/slow() expects a finite number factor, got ${arg}`,
+            );
+        }
+        return arg;
+    }
+    return parsePayload(arg);
+}
+
+/** Build a `FastPattern` wrapper around `inner`. */
+function makeFast(
+    inner: SectionPattern,
+    factor: number | string,
+): FastPattern & TimeModifiable {
+    return attachTimeModifiers({
+        __kind: FAST_KIND,
+        pattern: inner,
+        factor: factorPayload(factor),
+        argument_spans: factorArgumentSpans(inner, factor, 'fast'),
+    });
+}
+
+/** Build a `SlowPattern` wrapper around `inner`. */
+function makeSlow(
+    inner: SectionPattern,
+    factor: number | string,
+): SlowPattern & TimeModifiable {
+    return attachTimeModifiers({
+        __kind: SLOW_KIND,
+        pattern: inner,
+        factor: factorPayload(factor),
+        argument_spans: factorArgumentSpans(inner, factor, 'slow'),
+    });
+}
+
+/**
+ * Build a wrapper's flat argument spans: the wrapped pattern's spans, then — for
+ * a string (pattern) factor only — the factor's own document span (matching the
+ * Rust `per_source` order). A number factor is a constant: no span, no source.
+ */
+function factorArgumentSpans(
+    inner: SectionPattern,
+    factor: number | string,
+    methodName: 'fast' | 'slow',
+): SourceSpan[] {
+    const innerSpans = collectPatternSpans(inner, `$p(...).${methodName}()`);
+    if (typeof factor !== 'string') {
+        return innerSpans;
+    }
+    const loc = captureSourceLocation();
+    const factorSpan = lookupArgumentSpan(loc, 'factor') ?? {
+        start: 0,
+        end: 0,
+    };
+    return [...innerSpans, factorSpan];
+}
+
+/**
+ * Attach `.fast(...)` / `.slow(...)` methods to a pattern object. `Object.assign`
+ * types the result; the `defineProperty` calls then flip the two methods to
+ * non-enumerable so `JSON.stringify` (the IPC clone) and `Object.keys`/`entries`
+ * skip them and only the wire-shape fields cross the boundary — the same trick
+ * `$p.s` uses for `.add`/`.sub`. The object identity is preserved.
+ */
+function attachTimeModifiers<T extends SectionPattern>(
+    pattern: T,
+): T & TimeModifiable {
+    const modifiable = Object.assign(pattern, {
+        fast: (factor: number | string) => makeFast(pattern, factor),
+        slow: (factor: number | string) => makeSlow(pattern, factor),
+    });
+    Object.defineProperty(modifiable, 'fast', { enumerable: false });
+    Object.defineProperty(modifiable, 'slow', { enumerable: false });
+    return modifiable;
 }
 
 // `Located` is re-exported for tests that hand-construct ASTs.

--- a/src/main/dsl/typescriptLibGen.ts
+++ b/src/main/dsl/typescriptLibGen.ts
@@ -357,6 +357,19 @@ type ParsedPattern = {
   readonly ast: unknown;
   readonly source: string;
   readonly all_spans: ReadonlyArray<readonly [number, number]>;
+  /**
+   * Speed this pattern up by \`factor\`, mirroring Strudel's \`fast\`. The factor
+   * is a constant (\`2\`) or a mini-notation number pattern (\`"2 4"\` → ×2 for
+   * the first half of the cycle, ×4 for the second). \`fast(0)\` is silence and
+   * negatives reverse time. Chains and nests with the other pattern builders.
+   */
+  fast(factor: number | string): FastPattern;
+  /**
+   * Slow this pattern down by \`factor\` — the time-inverse of \`fast\`.
+   * \`slow(n)\` equals \`fast(1 / n)\`. The factor may be a constant or a
+   * mini-notation number pattern.
+   */
+  slow(factor: number | string): SlowPattern;
 };
 
 /**
@@ -509,6 +522,43 @@ declare namespace $p {
  * @param scale - scale string, e.g. "c(major)", "D#3(min)", "a(just)"
  */
 function s(source: string, scale: string): SpPattern;
+
+/**
+ * Arrange patterns over multiple cycles, mirroring Strudel's \`arrange\`.
+ * Each argument is a \`[cycles, pattern]\` tuple: the \`pattern\` (a \`$p(...)\`,
+ * \`$p.s(...)\`, or nested \`$p.arrange(...)\`) plays for \`cycles\` cycles, and
+ * the sections play back-to-back, looping with period \`Σ cycles\`.
+ *
+ * Because each \`$p.s\` section resolves through its own scale, an arrangement
+ * can switch scales (or keys) between sections.
+ *
+ * \`\`\`js
+ * // 4 cycles of a C-major arp, then 2 of an A-minor arp, looping every 6
+ * $cycle($p.arrange(
+ *   [4, $p.s("0 2 4 7", "c(major)")],
+ *   [2, $p.s("0 2 4",   "a(min)")],
+ * ))
+ * \`\`\`
+ *
+ * Cycle counts must be **positive integers**, except a single **trailing**
+ * section may use \`Infinity\` to loop forever once reached (any section after
+ * an \`Infinity\` section could never play and is rejected):
+ *
+ * \`\`\`js
+ * $cycle($p.arrange(
+ *   [2, $p("c4 e4 g4")],            // intro, played once
+ *   [Infinity, $p.s("0 2 4", "f(lydian)")],  // then loops forever
+ * ))
+ * \`\`\`
+ *
+ * The result is an \`ArrangePattern\`, itself usable as a section of another
+ * \`$p.arrange(...)\` (arrangements nest) or as a \`$cycle\` argument.
+ *
+ * @param sections - \`[cycles, pattern]\` tuples, in play order
+ */
+function arrange(
+  ...sections: [number, ParsedPattern | SpPattern | ArrangePattern | FastPattern | SlowPattern][]
+): ArrangePattern;
 }
 
 /**
@@ -548,6 +598,58 @@ type SpPattern = {
   argument_spans: { start: number; end: number }[];
   add: SpCombineBuilder;
   sub: SpCombineBuilder;
+  /** Speed this pattern up by \`factor\`. See \`$p(...).fast\`. */
+  fast(factor: number | string): FastPattern;
+  /** Slow this pattern down by \`factor\`. See \`$p(...).slow\`. */
+  slow(factor: number | string): SlowPattern;
+};
+
+/**
+ * An arrangement returned by \`$p.arrange(...)\`. Pass directly to \`$cycle\`'s
+ * \`pattern\` param, or nest it as a section of another \`$p.arrange(...)\`.
+ * Opaque to user code — construct with \`$p.arrange(...)\`; never build one by
+ * hand. A \`cycles\` of \`'Infinity'\` (only the last section) loops forever.
+ */
+type ArrangePattern = {
+  __kind: 'ArrangePattern';
+  sections: { cycles: number | 'Infinity'; pattern: ParsedPattern | SpPattern | ArrangePattern | FastPattern | SlowPattern }[];
+  argument_spans: { start: number; end: number }[];
+  /** Speed this arrangement up by \`factor\`. See \`$p(...).fast\`. */
+  fast(factor: number | string): FastPattern;
+  /** Slow this arrangement down by \`factor\`. See \`$p(...).slow\`. */
+  slow(factor: number | string): SlowPattern;
+};
+
+/**
+ * A sped-up pattern returned by \`pattern.fast(factor)\` (Strudel's \`fast\`).
+ * Pass directly to \`$cycle\`'s \`pattern\` param, nest it as an \`$p.arrange(...)\`
+ * section, or chain further \`.fast\`/\`.slow\`. Opaque to user code — construct
+ * with \`.fast(...)\`; never build one by hand.
+ */
+type FastPattern = {
+  __kind: 'FastPattern';
+  pattern: ParsedPattern | SpPattern | ArrangePattern | FastPattern | SlowPattern;
+  factor: number | ParsedPattern;
+  argument_spans: { start: number; end: number }[];
+  /** Speed this pattern up further by \`factor\`. See \`$p(...).fast\`. */
+  fast(factor: number | string): FastPattern;
+  /** Slow this pattern down by \`factor\`. See \`$p(...).slow\`. */
+  slow(factor: number | string): SlowPattern;
+};
+
+/**
+ * A slowed-down pattern returned by \`pattern.slow(factor)\` (Strudel's \`slow\`).
+ * The time-inverse of \`FastPattern\`; same composition rules.
+ */
+type SlowPattern = {
+  __kind: 'SlowPattern';
+  pattern: ParsedPattern | SpPattern | ArrangePattern | FastPattern | SlowPattern;
+  factor: number | ParsedPattern;
+  argument_spans: { start: number; end: number }[];
+  /** Speed this pattern up by \`factor\`. See \`$p(...).fast\`. */
+  fast(factor: number | string): FastPattern;
+  /** Slow this pattern down further by \`factor\`. See \`$p(...).slow\`. */
+  slow(factor: number | string): SlowPattern;
 };
 
 /**
@@ -1977,23 +2079,35 @@ export function generateDSL(schemas: Schemas): string {
     );
     lines.push('');
     lines.push('/**');
-    lines.push(' * Delay with feedback. Mixes `input` with a deferred feedback signal,');
-    lines.push(' * captures the mix into a buffer of `length` seconds, and routes the');
-    lines.push(' * buffer through `feedbackCb` to produce the feedback signal.');
+    lines.push(
+        ' * Delay with feedback. Mixes `input` with a deferred feedback signal,',
+    );
+    lines.push(
+        ' * captures the mix into a buffer of `length` seconds, and routes the',
+    );
+    lines.push(
+        ' * buffer through `feedbackCb` to produce the feedback signal.',
+    );
     lines.push(' *');
-    lines.push(' * Returns the wet+dry $mix output augmented with a `buffer` property');
+    lines.push(
+        ' * Returns the wet+dry $mix output augmented with a `buffer` property',
+    );
     lines.push(' * referencing the captured buffer for further reads.');
     lines.push(' *');
     lines.push(' * @example');
     lines.push(' * ```js');
-    lines.push(" * // simple feedback delay");
-    lines.push(" * $delay($noise('white').amp($perc($pulse('1hz'))), (buf) => $delayRead(buf, 0.25).amp(4.5), 1).out()");
+    lines.push(' * // simple feedback delay');
+    lines.push(
+        " * $delay($noise('white').amp($perc($pulse('1hz'))), (buf) => $delayRead(buf, 0.25).amp(4.5), 1).out()",
+    );
     lines.push(' * ```');
     lines.push(' *');
     lines.push(' * @example');
     lines.push(' * ```ts');
     lines.push(' * // tap the buffer for an additional read');
-    lines.push(' * const d = $delay(src, (buf) => $delayRead(buf, 0.5).amp(2.0), 2)');
+    lines.push(
+        ' * const d = $delay(src, (buf) => $delayRead(buf, 0.5).amp(2.0), 2)',
+    );
     lines.push(' * $delayRead(d.buffer, 0.75).out()');
     lines.push(' * ```');
     lines.push(' */');

--- a/src/main/dsl/typescriptLibGen.ts
+++ b/src/main/dsl/typescriptLibGen.ts
@@ -360,8 +360,9 @@ type ParsedPattern = {
   /**
    * Speed this pattern up by \`factor\`, mirroring Strudel's \`fast\`. The factor
    * is a constant (\`2\`) or a mini-notation number pattern (\`"2 4"\` → ×2 for
-   * the first half of the cycle, ×4 for the second). \`fast(0)\` is silence and
-   * negatives reverse time. Chains and nests with the other pattern builders.
+   * the first half of the cycle, ×4 for the second). A non-positive factor
+   * (\`fast(0)\` or negative) is silence. Chains and nests with the other
+   * pattern builders.
    */
   fast(factor: number | string): FastPattern;
   /**

--- a/src/main/dsl/typescriptLibGen.ts
+++ b/src/main/dsl/typescriptLibGen.ts
@@ -348,15 +348,10 @@ type BufferOutputRef = {
 
 /**
  * A parsed mini-notation pattern — returned by \`$p(source)\`, passed to
- * \`$cycle\` as its pattern argument. Opaque to user code;
- * the shape is \`{ __kind, ast, source, all_spans }\`. Construct with
- * \`$p(...)\`; never build one by hand.
+ * \`$cycle\` as its pattern argument. Opaque to user code; construct with
+ * \`$p(...)\` and chain \`.fast\`/\`.slow\`. Never build one by hand.
  */
 type ParsedPattern = {
-  readonly __kind: 'ParsedPattern';
-  readonly ast: unknown;
-  readonly source: string;
-  readonly all_spans: ReadonlyArray<readonly [number, number]>;
   /**
    * Speed this pattern up by \`factor\`, mirroring Strudel's \`fast\`. The factor
    * is a constant (\`2\`) or a mini-notation number pattern (\`"2 4"\` → ×2 for
@@ -584,19 +579,10 @@ type SpCombineBuilder = ((rhs: string) => SpPattern) & {
 
 /**
  * Chainable scale-degree pattern returned by \`$p.s()\`. Pass directly to
- * \`$cycle\`'s \`pattern\` param. Each chained RHS lives in \`sources[]\`
- * and gets its own editor-highlight argument span.
- *
- * Arrays declared mutable (rather than readonly) to line up with the
- * schema-generated factory param types. Treat as immutable by
- * convention — chain methods return fresh objects.
+ * \`$cycle\`'s \`pattern\` param, or chain \`.add\`/\`.sub\`/\`.fast\`/\`.slow\`.
+ * Opaque to user code — chain methods return fresh patterns.
  */
 type SpPattern = {
-  __kind: 'SpPattern';
-  sources: ParsedPattern[];
-  scale: string;
-  ops: { op: 'add' | 'sub'; mode: SpAlignmentMode }[];
-  argument_spans: { start: number; end: number }[];
   add: SpCombineBuilder;
   sub: SpCombineBuilder;
   /** Speed this pattern up by \`factor\`. See \`$p(...).fast\`. */
@@ -612,9 +598,6 @@ type SpPattern = {
  * hand. A \`cycles\` of \`'Infinity'\` (only the last section) loops forever.
  */
 type ArrangePattern = {
-  __kind: 'ArrangePattern';
-  sections: { cycles: number | 'Infinity'; pattern: ParsedPattern | SpPattern | ArrangePattern | FastPattern | SlowPattern }[];
-  argument_spans: { start: number; end: number }[];
   /** Speed this arrangement up by \`factor\`. See \`$p(...).fast\`. */
   fast(factor: number | string): FastPattern;
   /** Slow this arrangement down by \`factor\`. See \`$p(...).slow\`. */
@@ -628,10 +611,6 @@ type ArrangePattern = {
  * with \`.fast(...)\`; never build one by hand.
  */
 type FastPattern = {
-  __kind: 'FastPattern';
-  pattern: ParsedPattern | SpPattern | ArrangePattern | FastPattern | SlowPattern;
-  factor: number | ParsedPattern;
-  argument_spans: { start: number; end: number }[];
   /** Speed this pattern up further by \`factor\`. See \`$p(...).fast\`. */
   fast(factor: number | string): FastPattern;
   /** Slow this pattern down by \`factor\`. See \`$p(...).slow\`. */
@@ -643,10 +622,6 @@ type FastPattern = {
  * The time-inverse of \`FastPattern\`; same composition rules.
  */
 type SlowPattern = {
-  __kind: 'SlowPattern';
-  pattern: ParsedPattern | SpPattern | ArrangePattern | FastPattern | SlowPattern;
-  factor: number | ParsedPattern;
-  argument_spans: { start: number; end: number }[];
   /** Speed this pattern up by \`factor\`. See \`$p(...).fast\`. */
   fast(factor: number | string): FastPattern;
   /** Slow this pattern down further by \`factor\`. See \`$p(...).slow\`. */

--- a/src/shared/dsl/schemaTypeResolver.ts
+++ b/src/shared/dsl/schemaTypeResolver.ts
@@ -65,7 +65,10 @@ export function resolveRef(
     | 'Buffer'
     | 'Table'
     | 'ParsedPattern'
-    | 'SpPattern' {
+    | 'SpPattern'
+    | 'ArrangePattern'
+    | 'FastPattern'
+    | 'SlowPattern' {
     if (ref === 'Signal') {
         return 'Signal';
     }
@@ -80,6 +83,15 @@ export function resolveRef(
     }
     if (ref === 'SpPatternPayload') {
         return 'SpPattern';
+    }
+    if (ref === 'ArrangePatternPayload') {
+        return 'ArrangePattern';
+    }
+    if (ref === 'FastPatternPayload') {
+        return 'FastPattern';
+    }
+    if (ref === 'SlowPatternPayload') {
+        return 'SlowPattern';
     }
 
     const defsPrefix = '#/$defs/';
@@ -115,6 +127,21 @@ export function resolveRef(
     if (defName === 'SpPatternPayload') {
         return 'SpPattern';
     }
+    // ArrangePatternPayload is the `$p.arrange(...)` shape; it recurses
+    // (sections carry `SeqPatternSource`), so the DSL exposes it as the named
+    // `ArrangePattern` type to break the cycle, like ParsedPattern/SpPattern.
+    if (defName === 'ArrangePatternPayload') {
+        return 'ArrangePattern';
+    }
+    // FastPatternPayload / SlowPatternPayload are the `.fast(...)` / `.slow(...)`
+    // wrappers; they recurse (the wrapped `pattern` is a `SeqPatternSource`), so
+    // the DSL exposes them as named types like the others above.
+    if (defName === 'FastPatternPayload') {
+        return 'FastPattern';
+    }
+    if (defName === 'SlowPatternPayload') {
+        return 'SlowPattern';
+    }
 
     const defs = rootSchema?.$defs;
     if (!defs || typeof defs !== 'object') {
@@ -146,6 +173,15 @@ export function resolveRef(
     }
     if (resolved?.title === 'SpPatternPayload') {
         return 'SpPattern';
+    }
+    if (resolved?.title === 'ArrangePatternPayload') {
+        return 'ArrangePattern';
+    }
+    if (resolved?.title === 'FastPatternPayload') {
+        return 'FastPattern';
+    }
+    if (resolved?.title === 'SlowPatternPayload') {
+        return 'SlowPattern';
     }
     return resolved;
 }
@@ -328,6 +364,15 @@ export function schemaToTypeExpr(
         }
         if (resolved === 'SpPattern') {
             return 'SpPattern';
+        }
+        if (resolved === 'ArrangePattern') {
+            return 'ArrangePattern';
+        }
+        if (resolved === 'FastPattern') {
+            return 'FastPattern';
+        }
+        if (resolved === 'SlowPattern') {
+            return 'SlowPattern';
         }
         return schemaToTypeExpr(resolved, rootSchema);
     }


### PR DESCRIPTION
## Summary

Adds two Strudel-style pattern features to the live-coding DSL, plus their full editor-highlighting and validation plumbing.

### `$p.arrange(...)` — multi-cycle arrangements
Play patterns back-to-back over multiple cycles, looping with period `Σ cycles`. Each section resolves through its own scale, so an arrangement can switch keys/scales between sections. A single trailing `Infinity` section loops forever once reached.

```js
$cycle($p.arrange(
  [4, $p.s("0 2 4 7", "c(major)")],
  [2, $p.s("0 2 4",   "a(min)")],
))
$cycle($p.arrange([2, $p("c4 e4 g4")], [Infinity, $p.s("0 2 4", "f(lydian)")]))
```

### `.fast()` / `.slow()` — time modifiers on every pattern
Chainable on `$p(...)`, `$p.s(...)`, `$p.arrange(...)` (and on each other). The factor is a constant **or** a mini-notation number-pattern string:

```js
$cycle($p("c4 e4 g4").fast(2))          // twice as fast
$cycle($p.s("0 2 4", "c(maj)").slow(2))
$cycle($p("c4 e4").fast("2 4"))         // patterned: ×2 first half, ×4 second
$cycle($p.arrange([2, $p("c4")], [2, $p("e4")]).fast(2))
```

Edge behavior mirrors the in-string `*`/`/` operators: factor `0` → silence, negatives reverse time.

## Implementation

- **Engine** (`pattern_system`): reuses the existing `Pattern::fast`/`slow`/`arrange` combinators; the DSL layer just lowers wire shapes to them. `FactorPayload` is a `#[serde(untagged)]` `Const(f64) | Pattern(...)` so a number factor is a span-free constant and a string factor becomes its own highlightable `per_source` entry (offset `pattern_idx`).
- **Wire shapes** (`seq_value.rs`): `FastPattern`/`SlowPattern`/`ArrangePattern` variants on the untagged `SeqPatternSource`; schema (`schemas.json`) regenerated.
- **DSL** (`miniNotation/index.ts`): `.fast`/`.slow` attached as non-enumerable methods (like `$p.s`'s `.add`/`.sub`) so the JSON wire shape stays clean.
- **Highlighting**: the argument-span analyzer recognizes `.fast`/`.slow` calls and registers the factor literal; a string factor highlights its active value as it drives the speed, while a number factor does not highlight.
- **Monaco types** (`typescriptLibGen.ts`, `schemaTypeResolver.ts`): `$cycle` accepts the new pattern kinds; `.fast`/`.slow` typed with docs.

## Tests

- Rust: arrange + fast/slow lowering, hap counts, factor-as-source vs const-factor highlight contract (`cargo test -p modular_core`).
- TS: builder unit tests (`fastSlow.test.ts`, `arrange.test.ts`) and end-to-end executor tests round-tripping through the native deserializer (`executor.test.ts`).
- Full suites green: `cargo test -p modular_core`, `yarn test:unit` (462 passing), `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
