### PR TITLE
Hard sync for oscillators (PolyBLEP band-limited)

### DIFF
--- a/crates/modular/schemas.json
+++ b/crates/modular/schemas.json
@@ -2113,6 +2113,17 @@
         "freq": {
           "description": "pitch in V/Oct (0V = C4)",
           "$ref": "#/$defs/PolySignal"
+        },
+        "sync": {
+          "description": "hard sync source — rising edges reset the oscillator phase",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PolySignal"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "required": [
@@ -2224,6 +2235,14 @@
         "defaultValue": 0.0,
         "minValue": -5.0,
         "maxValue": 5.0
+      },
+      {
+        "name": "sync",
+        "description": "hard sync source — rising edges reset the oscillator phase",
+        "signalType": "control",
+        "defaultValue": 0.0,
+        "minValue": -5.0,
+        "maxValue": 5.0
       }
     ],
     "positionalArgs": [
@@ -2262,6 +2281,17 @@
         },
         "shape": {
           "description": "waveform shape: 0=saw, 2.5=triangle, 5=ramp",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PolySignal"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sync": {
+          "description": "hard sync source — rising edges reset the oscillator phase",
           "anyOf": [
             {
               "$ref": "#/$defs/PolySignal"
@@ -2389,6 +2419,14 @@
         "defaultValue": 0.0,
         "minValue": -5.0,
         "maxValue": 5.0
+      },
+      {
+        "name": "sync",
+        "description": "hard sync source — rising edges reset the oscillator phase",
+        "signalType": "control",
+        "defaultValue": 0.0,
+        "minValue": -5.0,
+        "maxValue": 5.0
       }
     ],
     "positionalArgs": [
@@ -2427,6 +2465,17 @@
         },
         "pwm": {
           "description": "pulse width modulation CV — added to the width parameter",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PolySignal"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sync": {
+          "description": "hard sync source — rising edges reset the oscillator phase",
           "anyOf": [
             {
               "$ref": "#/$defs/PolySignal"
@@ -2569,6 +2618,14 @@
       {
         "name": "fm",
         "description": "FM input signal (pre-scaled by user)",
+        "signalType": "control",
+        "defaultValue": 0.0,
+        "minValue": -5.0,
+        "maxValue": 5.0
+      },
+      {
+        "name": "sync",
+        "description": "hard sync source — rising edges reset the oscillator phase",
         "signalType": "control",
         "defaultValue": 0.0,
         "minValue": -5.0,
@@ -3514,6 +3571,17 @@
           "description": "pitch in V/Oct (0V = C4)",
           "$ref": "#/$defs/PolySignal"
         },
+        "sync": {
+          "description": "hard sync source — rising edges reset every detuned voice's phase",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PolySignal"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "voices": {
           "description": "number of supersaw voices (1–16)",
           "type": "integer",
@@ -3639,6 +3707,14 @@
         "defaultValue": 0.0,
         "minValue": -5.0,
         "maxValue": 5.0
+      },
+      {
+        "name": "sync",
+        "description": "hard sync source — rising edges reset every detuned voice's phase",
+        "signalType": "control",
+        "defaultValue": 0.0,
+        "minValue": -5.0,
+        "maxValue": 5.0
       }
     ],
     "positionalArgs": [
@@ -3688,6 +3764,17 @@
         },
         "position": {
           "description": "Frame position as a signal. 0V maps to the first frame, 5V maps to\nthe last frame. Values are clamped to [0, 5] before being normalized.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PolySignal"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sync": {
+          "description": "hard sync source — rising edges reset the oscillator phase.",
           "anyOf": [
             {
               "$ref": "#/$defs/PolySignal"
@@ -3956,6 +4043,14 @@
       {
         "name": "fm",
         "description": "FM input signal (pre-scaled by user).",
+        "signalType": "control",
+        "defaultValue": 0.0,
+        "minValue": -5.0,
+        "maxValue": 5.0
+      },
+      {
+        "name": "sync",
+        "description": "hard sync source — rising edges reset the oscillator phase.",
         "signalType": "control",
         "defaultValue": 0.0,
         "minValue": -5.0,

--- a/crates/modular_core/src/dsp/oscillators/mod.rs
+++ b/crates/modular_core/src/dsp/oscillators/mod.rs
@@ -4,7 +4,7 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-use crate::dsp::utils::voct_to_hz;
+use crate::dsp::utils::{GATE_DETECTION_HIGH_THRESHOLD, voct_to_hz};
 use crate::params::ParamsDeserializer;
 use crate::patch::Patch;
 use crate::types::{Connect, Module, ModuleSchema, SampleableConstructor};
@@ -34,6 +34,34 @@ pub fn apply_fm(pitch: f32, fm: f32, fm_mode: FmMode) -> f32 {
         FmMode::Lin => (voct_to_hz(pitch) * (1.0 + fm)).max(0.0),
         FmMode::ThroughZero => voct_to_hz(pitch) * (1.0 + fm),
     }
+}
+
+/// Subsample position in `[0, 1)` at which a rising sync edge crossed the gate
+/// high threshold, linearly interpolated between the previous and current sync
+/// samples. Used to place the [`sync_blep`] correction within the sample.
+#[inline]
+pub fn sync_edge_fraction(prev: f32, curr: f32) -> f32 {
+    let denom = curr - prev;
+    if denom > 1.0e-12 {
+        ((GATE_DETECTION_HIGH_THRESHOLD - prev) / denom).clamp(0.0, 1.0)
+    } else {
+        0.0
+    }
+}
+
+/// Two-point PolyBLEP correction for a hard-sync phase reset.
+///
+/// The reset is a step of size `jump` (the naive output *after* the reset minus
+/// the value *before* it) located `frac` of a sample into the upcoming sample
+/// interval. Returns `(this_sample, next_sample)`: residuals to add to the
+/// naive output now and to carry into the following sample. Calibrated to match
+/// the ±1-normalized PolyBLEP used for the oscillators' natural edges, so the
+/// synced sample lands on the band-limited midpoint when `frac == 0`.
+#[inline]
+pub fn sync_blep(jump: f32, frac: f32) -> (f32, f32) {
+    let half = 0.5 * jump;
+    let before = 1.0 - frac;
+    (half * before * before, -half * frac * frac)
 }
 
 pub mod noise;
@@ -87,4 +115,37 @@ pub fn schemas() -> Vec<ModuleSchema> {
         supersaw::Supersaw::get_schema(),
         wavetable::WavetableOsc::get_schema(),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sync_edge_fraction_interpolates_threshold_crossing() {
+        // Crossing 1.0V on the way up from 0 to 5 happens 1/5 of the way in.
+        assert!((sync_edge_fraction(0.0, 5.0) - 0.2).abs() < 1e-6);
+        // Midway crossing.
+        assert!((sync_edge_fraction(0.5, 1.5) - 0.5).abs() < 1e-6);
+        // Already above threshold at the start → crossing at the very start.
+        assert_eq!(sync_edge_fraction(1.0, 5.0), 0.0);
+        // Non-rising / degenerate inputs fall back to 0.
+        assert_eq!(sync_edge_fraction(2.0, 1.0), 0.0);
+        assert_eq!(sync_edge_fraction(3.0, 3.0), 0.0);
+    }
+
+    #[test]
+    fn sync_blep_lands_the_discontinuity_sample_on_the_midpoint() {
+        let m = 2.0;
+        // frac == 0: the whole correction is on this sample → before + M/2.
+        let (now, carry) = sync_blep(m, 0.0);
+        assert!((now - 1.0).abs() < 1e-6);
+        assert!(carry.abs() < 1e-6);
+        // frac → 1: nothing now, the next sample carries −M/2 → after − M/2.
+        let (now, carry) = sync_blep(m, 1.0);
+        assert!(now.abs() < 1e-6);
+        assert!((carry + 1.0).abs() < 1e-6);
+        // A zero jump produces no correction at all.
+        assert_eq!(sync_blep(0.0, 0.3), (0.0, 0.0));
+    }
 }

--- a/crates/modular_core/src/dsp/oscillators/pulse.rs
+++ b/crates/modular_core/src/dsp/oscillators/pulse.rs
@@ -3,7 +3,10 @@ use schemars::JsonSchema;
 
 use crate::{
     PORT_MAX_CHANNELS,
-    dsp::oscillators::{FmMode, apply_fm},
+    dsp::{
+        oscillators::{FmMode, apply_fm, sync_blep, sync_edge_fraction},
+        utils::SchmittTrigger,
+    },
     poly::{PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
 };
@@ -30,6 +33,9 @@ struct PulseOscillatorParams {
     #[serde(default)]
     #[deserr(default)]
     fm_mode: FmMode,
+    /// hard sync source — rising edges reset the oscillator phase
+    #[deserr(default)]
+    sync: Option<PolySignal>,
 }
 
 #[derive(Outputs, JsonSchema)]
@@ -43,6 +49,12 @@ struct PulseOscillatorOutputs {
 struct PulseChannelState {
     phase: f32,
     width: Clickless,
+    /// Edge detector for the sync input.
+    sync_schmitt: SchmittTrigger,
+    /// Previous sync-input sample, for subsample edge interpolation.
+    sync_prev: f32,
+    /// PolyBLEP residual carried into the next sample from a sync reset.
+    blep_carry: f32,
 }
 
 /// State for the PulseOscillator module.
@@ -96,15 +108,15 @@ impl PulseOscillator {
             // Wrap phase (rem_euclid supports negative increments from through-zero FM)
             state.phase = state.phase.rem_euclid(1.0);
 
-            // Naive pulse wave
-            let mut naive_pulse = if state.phase < pulse_width { 1.0 } else { -1.0 };
+            let naive_pulse = |p: f32| if p < pulse_width { 1.0 } else { -1.0 };
 
-            // Apply PolyBLEP at the rising edge (phase = 0)
+            // Naive pulse plus PolyBLEP at its own rising (phase 0) and falling
+            // (phase = width) edges. The sync reset lands in the upcoming
+            // interval, so these operate on the real, pre-reset phase.
             let abs_phase_inc = phase_increment.abs();
-            naive_pulse += poly_blep_pulse(state.phase, abs_phase_inc);
-
-            // Apply PolyBLEP at the falling edge (phase = pulse_width)
-            naive_pulse -= poly_blep_pulse(
+            let mut body = naive_pulse(state.phase);
+            body += poly_blep_pulse(state.phase, abs_phase_inc);
+            body -= poly_blep_pulse(
                 if state.phase >= pulse_width {
                     state.phase - pulse_width
                 } else {
@@ -113,7 +125,28 @@ impl PulseOscillator {
                 abs_phase_inc,
             );
 
-            self.outputs.sample.set(ch, naive_pulse * 5.0);
+            let pending = state.blep_carry;
+            state.blep_carry = 0.0;
+
+            // Hard sync: a rising edge resets the phase, with a PolyBLEP placed
+            // at the subsample crossing to band-limit the reset discontinuity.
+            // (The jump is zero when the pulse was already high at the reset.)
+            let mut now = 0.0;
+            if let Some(sync) = &self.params.sync {
+                let v = sync.get_value(ch);
+                if state.sync_schmitt.process(v) {
+                    let frac = sync_edge_fraction(state.sync_prev, v);
+                    let before = naive_pulse(state.phase);
+                    state.phase = 0.0;
+                    let after = naive_pulse(0.0);
+                    let (n, carry) = sync_blep(after - before, frac);
+                    now = n;
+                    state.blep_carry = carry;
+                }
+                state.sync_prev = v;
+            }
+
+            self.outputs.sample.set(ch, (body + pending + now) * 5.0);
         }
     }
 }

--- a/crates/modular_core/src/dsp/oscillators/saw.rs
+++ b/crates/modular_core/src/dsp/oscillators/saw.rs
@@ -2,7 +2,10 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::{
-    dsp::oscillators::{FmMode, apply_fm},
+    dsp::{
+        oscillators::{FmMode, apply_fm, sync_blep, sync_edge_fraction},
+        utils::SchmittTrigger,
+    },
     poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
     types::Clickless,
 };
@@ -26,6 +29,9 @@ struct SawOscillatorParams {
     #[serde(default)]
     #[deserr(default)]
     fm_mode: FmMode,
+    /// hard sync source — rising edges reset the oscillator phase
+    #[deserr(default)]
+    sync: Option<PolySignal>,
 }
 
 #[derive(Outputs, JsonSchema)]
@@ -40,6 +46,12 @@ struct SawOscillatorOutputs {
 struct ChannelState {
     phase: f32,
     shape: Clickless,
+    /// Edge detector for the sync input.
+    sync_schmitt: SchmittTrigger,
+    /// Previous sync-input sample, for subsample edge interpolation.
+    sync_prev: f32,
+    /// PolyBLEP residual carried into the next sample from a sync reset.
+    blep_carry: f32,
 }
 
 /// State for the SawOscillator module.
@@ -101,17 +113,38 @@ impl SawOscillator {
             state.phase += phase_increment;
             state.phase = state.phase.rem_euclid(1.0);
 
-            // DPW: compute integral at new phase, differentiate
-            let integral_new = triangle_integral(state.phase, s);
-
-            let raw_output = if phase_increment.abs() > 1.0e-7 {
+            // DPW body for this sample. The sync reset (below) lands in the
+            // upcoming interval, so the phase advanced normally here and the DPW
+            // differentiation stays valid; the reset is band-limited separately.
+            let body = if phase_increment.abs() > 1.0e-7 {
+                let integral_new = triangle_integral(state.phase, s);
                 (integral_new - integral_old) / phase_increment
             } else {
                 // Near-DC fallback: use naive waveform (no aliasing at low freq)
                 naive_triangle(state.phase, s)
             };
 
-            self.outputs.sample.set(ch, raw_output * 5.0);
+            let pending = state.blep_carry;
+            state.blep_carry = 0.0;
+
+            // Hard sync: a rising edge resets the phase, with a PolyBLEP placed
+            // at the subsample crossing to band-limit the reset discontinuity.
+            let mut now = 0.0;
+            if let Some(sync) = &self.params.sync {
+                let v = sync.get_value(ch);
+                if state.sync_schmitt.process(v) {
+                    let frac = sync_edge_fraction(state.sync_prev, v);
+                    let before = naive_triangle(state.phase, s);
+                    state.phase = 0.0;
+                    let after = naive_triangle(0.0, s);
+                    let (n, carry) = sync_blep(after - before, frac);
+                    now = n;
+                    state.blep_carry = carry;
+                }
+                state.sync_prev = v;
+            }
+
+            self.outputs.sample.set(ch, (body + pending + now) * 5.0);
         }
     }
 }

--- a/crates/modular_core/src/dsp/oscillators/sine.rs
+++ b/crates/modular_core/src/dsp/oscillators/sine.rs
@@ -1,8 +1,8 @@
 use crate::{
     dsp::{
         consts::{LUT_SINE, LUT_SINE_SIZE},
-        oscillators::{FmMode, apply_fm},
-        utils::interpolate,
+        oscillators::{FmMode, apply_fm, sync_blep, sync_edge_fraction},
+        utils::{SchmittTrigger, interpolate},
     },
     poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
 };
@@ -24,6 +24,9 @@ struct SineOscillatorParams {
     #[serde(default)]
     #[deserr(default)]
     fm_mode: FmMode,
+    /// hard sync source — rising edges reset the oscillator phase
+    #[deserr(default)]
+    sync: Option<PolySignal>,
 }
 
 #[derive(Outputs, JsonSchema)]
@@ -37,6 +40,12 @@ struct SineOscillatorOutputs {
 #[derive(Default, Clone, Copy)]
 struct ChannelState {
     phase: f32,
+    /// Edge detector for the sync input.
+    sync_schmitt: SchmittTrigger,
+    /// Previous sync-input sample, for subsample edge interpolation.
+    sync_prev: f32,
+    /// PolyBLEP residual carried into the next sample from a sync reset.
+    blep_carry: f32,
 }
 
 /// State for the SineOscillator module.
@@ -72,8 +81,30 @@ impl SineOscillator {
             state.phase += frequency;
             // Wrap phase to [0, 1) — supports negative increments (through-zero FM)
             state.phase = state.phase.rem_euclid(1.0);
-            let sine = interpolate(LUT_SINE, state.phase, LUT_SINE_SIZE);
-            self.outputs.sample.set(ch, sine * 5.0);
+
+            // Naive sample at the (pre-reset) phase, plus any residual carried
+            // from a sync reset on the previous sample.
+            let body = interpolate(LUT_SINE, state.phase, LUT_SINE_SIZE);
+            let pending = state.blep_carry;
+            state.blep_carry = 0.0;
+
+            // Hard sync: a rising edge resets the phase, with a PolyBLEP placed
+            // at the subsample crossing to band-limit the discontinuity.
+            let mut now = 0.0;
+            if let Some(sync) = &self.params.sync {
+                let v = sync.get_value(ch);
+                if state.sync_schmitt.process(v) {
+                    let frac = sync_edge_fraction(state.sync_prev, v);
+                    state.phase = 0.0;
+                    let after = interpolate(LUT_SINE, 0.0, LUT_SINE_SIZE);
+                    let (n, carry) = sync_blep(after - body, frac);
+                    now = n;
+                    state.blep_carry = carry;
+                }
+                state.sync_prev = v;
+            }
+
+            self.outputs.sample.set(ch, (body + pending + now) * 5.0);
         }
     }
 }

--- a/crates/modular_core/src/dsp/oscillators/supersaw.rs
+++ b/crates/modular_core/src/dsp/oscillators/supersaw.rs
@@ -2,7 +2,10 @@ use deserr::Deserr;
 use schemars::JsonSchema;
 
 use crate::{
-    dsp::oscillators::{FmMode, apply_fm},
+    dsp::{
+        oscillators::{FmMode, apply_fm, sync_blep, sync_edge_fraction},
+        utils::SchmittTrigger,
+    },
     poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
 };
 
@@ -32,6 +35,9 @@ struct SupersawParams {
     #[serde(default)]
     #[deserr(default)]
     fm_mode: FmMode,
+    /// hard sync source — rising edges reset every detuned voice's phase
+    #[deserr(default)]
+    sync: Option<PolySignal>,
 }
 
 #[derive(Outputs, JsonSchema)]
@@ -87,6 +93,13 @@ struct SupersawState {
     gain: f32,
     /// Per-voice interpolation factor for symmetric detuning.
     voice_t: [f32; PORT_MAX_CHANNELS],
+    /// Per-input-channel edge detector for the sync input.
+    sync_schmitt: [SchmittTrigger; PORT_MAX_CHANNELS],
+    /// Per-input-channel previous sync sample, for subsample edge interpolation.
+    sync_prev: [f32; PORT_MAX_CHANNELS],
+    /// Per-voice PolyBLEP residual carried into the next sample from a sync
+    /// reset. Indexed like `osc_states`.
+    blep_carry: [f32; PORT_MAX_CHANNELS * PORT_MAX_CHANNELS],
 }
 
 impl Default for SupersawState {
@@ -99,6 +112,9 @@ impl Default for SupersawState {
             inv_sample_rate: 0.0,
             gain: 0.0,
             voice_t: [0.0; PORT_MAX_CHANNELS],
+            sync_schmitt: [SchmittTrigger::default(); PORT_MAX_CHANNELS],
+            sync_prev: [0.0; PORT_MAX_CHANNELS],
+            blep_carry: [0.0; PORT_MAX_CHANNELS * PORT_MAX_CHANNELS],
         }
     }
 }
@@ -187,7 +203,22 @@ impl Supersaw {
         let input_channels = self.state.input_channels;
         let inv_sample_rate = self.state.inv_sample_rate;
         let gain = self.state.gain;
-        let voice_t = &self.state.voice_t;
+
+        // Detect sync once per input channel (the master edge resets every
+        // detuned voice of that channel together) and record the subsample
+        // crossing for the PolyBLEP correction below.
+        let mut sync_edge = [false; PORT_MAX_CHANNELS];
+        let mut sync_frac = [0.0f32; PORT_MAX_CHANNELS];
+        if let Some(sync) = &self.params.sync {
+            for input_ch in 0..input_channels {
+                let v = sync.get_value(input_ch);
+                if self.state.sync_schmitt[input_ch].process(v) {
+                    sync_edge[input_ch] = true;
+                    sync_frac[input_ch] = sync_edge_fraction(self.state.sync_prev[input_ch], v);
+                }
+                self.state.sync_prev[input_ch] = v;
+            }
+        }
 
         for voice in 0..voices {
             let mut accum = 0.0f32;
@@ -197,7 +228,7 @@ impl Supersaw {
                 let detune = self.params.detune.value_or(input_ch, 0.18);
                 let offset_semitones = if voices > 1 {
                     // lerp from -detune/2 to +detune/2
-                    -detune / 2.0 + voice_t[voice] * detune
+                    -detune / 2.0 + self.state.voice_t[voice] * detune
                 } else {
                     0.0
                 };
@@ -209,18 +240,31 @@ impl Supersaw {
                 let dt = freq * inv_sample_rate;
 
                 let state_idx = input_ch * PORT_MAX_CHANNELS + voice;
-                let phase = &mut self.state.osc_states[state_idx];
 
                 // Advance phase (rem_euclid supports negative increments from through-zero FM)
-                *phase += dt;
-                *phase = phase.rem_euclid(1.0);
+                let mut phase = (self.state.osc_states[state_idx] + dt).rem_euclid(1.0);
 
-                // Naive saw: maps [0,1) to [-1,1)
-                let mut saw = 2.0 * *phase - 1.0;
+                // Naive saw + its own PolyBLEP wrap correction, then any residual
+                // carried from a sync reset on the previous sample. The reset
+                // (below) lands in the upcoming interval, so this operates on the
+                // real, pre-reset phase.
+                let mut saw = 2.0 * phase - 1.0;
+                saw -= poly_blep_saw(phase, dt.abs());
+                saw += self.state.blep_carry[state_idx];
+                self.state.blep_carry[state_idx] = 0.0;
 
-                // Apply PolyBLEP correction
-                saw -= poly_blep_saw(*phase, dt.abs());
+                // Hard sync resets this voice, band-limited with a PolyBLEP at
+                // the subsample crossing.
+                if sync_edge[input_ch] {
+                    let before = 2.0 * phase - 1.0;
+                    phase = 0.0;
+                    let after = -1.0;
+                    let (now, carry) = sync_blep(after - before, sync_frac[input_ch]);
+                    saw += now;
+                    self.state.blep_carry[state_idx] = carry;
+                }
 
+                self.state.osc_states[state_idx] = phase;
                 accum += saw;
             }
 
@@ -271,6 +315,7 @@ mod tests {
             detune: None,
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         });
         // Run several samples to get past initialization
         for _ in 0..100 {
@@ -289,6 +334,7 @@ mod tests {
             detune: None,
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         };
         assert_eq!(supersaw_derive_channel_count(&params), 7);
     }
@@ -301,6 +347,7 @@ mod tests {
             detune: None,
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         });
         for _ in 0..1000 {
             s.update(48000.0);
@@ -322,6 +369,7 @@ mod tests {
             detune: None,
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         };
         assert_eq!(supersaw_derive_channel_count(&params), 16);
 
@@ -331,6 +379,7 @@ mod tests {
             detune: None,
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         };
         assert_eq!(supersaw_derive_channel_count(&params_zero), 1);
     }
@@ -344,6 +393,7 @@ mod tests {
             detune: Some(PolySignal::mono(Signal::Volts(0.0))),
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         });
         // Force known phases (overwrite whatever init set)
         for i in 0..PORT_MAX_CHANNELS * PORT_MAX_CHANNELS {
@@ -356,6 +406,7 @@ mod tests {
             detune: Some(PolySignal::mono(Signal::Volts(2.0))),
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         });
         for i in 0..PORT_MAX_CHANNELS * PORT_MAX_CHANNELS {
             s_detune.state.osc_states[i] = 0.25;
@@ -392,6 +443,7 @@ mod tests {
             detune: Some(PolySignal::mono(Signal::Volts(0.0))),
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         });
         // Trigger phase initialization via init()
         s.init(48000.0);
@@ -412,6 +464,7 @@ mod tests {
             detune: Some(PolySignal::mono(Signal::Volts(0.0))),
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         });
         // Force known phases, zero detune -> all voices should produce identical output
         for i in 0..PORT_MAX_CHANNELS * PORT_MAX_CHANNELS {
@@ -434,6 +487,70 @@ mod tests {
     }
 
     #[test]
+    fn hard_sync_resets_all_voice_phases() {
+        let mut s = make_supersaw(SupersawParams {
+            freq: PolySignal::mono(Signal::Volts(0.0)),
+            voices: 3,
+            detune: Some(PolySignal::mono(Signal::Volts(1.0))),
+            fm: None,
+            fm_mode: FmMode::default(),
+            sync: Some(PolySignal::mono(Signal::Volts(0.0))),
+        });
+
+        // Advance so every voice phase is clearly non-zero and the sync edge
+        // detector is armed low.
+        for _ in 0..50 {
+            s.update(48000.0);
+        }
+        let advanced = (0..3)
+            .map(|v| s.state.osc_states[v])
+            .any(|p| p.abs() > 1e-3);
+        assert!(advanced, "voice phases should have advanced before sync");
+
+        // Drive a rising edge on the sync input.
+        s.params.sync = Some(PolySignal::mono(Signal::Volts(5.0)));
+        s.update(48000.0);
+
+        for voice in 0..3 {
+            let p = s.state.osc_states[voice];
+            assert!(
+                p.abs() < 1e-6,
+                "voice {voice} phase {p} should reset to 0 on hard sync"
+            );
+        }
+    }
+
+    #[test]
+    fn synced_output_stays_bounded_across_many_resets() {
+        // A fast master sync against a slower slave fires resets constantly,
+        // exercising the PolyBLEP correction + carry every few samples.
+        let mut s = make_supersaw(SupersawParams {
+            freq: PolySignal::mono(Signal::Volts(-1.0)),
+            voices: 5,
+            detune: Some(PolySignal::mono(Signal::Volts(0.3))),
+            fm: None,
+            fm_mode: FmMode::default(),
+            sync: Some(PolySignal::mono(Signal::Volts(0.0))),
+        });
+
+        // Toggle the sync input low/high every few samples to generate edges.
+        for i in 0..2000 {
+            let high = (i / 7) % 2 == 0;
+            s.params.sync = Some(PolySignal::mono(Signal::Volts(if high {
+                5.0
+            } else {
+                0.0
+            })));
+            s.update(48000.0);
+            for voice in 0..5 {
+                let v = s.outputs.sample.get(voice);
+                assert!(v.is_finite(), "output must stay finite, got {v}");
+                assert!(v.abs() <= 6.0, "output {v} should stay bounded near ±5V");
+            }
+        }
+    }
+
+    #[test]
     fn test_gain_compensation() {
         // With 4 input channels, gain should be 5.0 / sqrt(4) = 2.5
         // With 1 input channel, gain should be 5.0 / sqrt(1) = 5.0
@@ -444,6 +561,7 @@ mod tests {
             detune: Some(PolySignal::mono(Signal::Volts(0.0))),
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         });
         // Set phase to 0.75 -> naive saw = 2*0.75 - 1 = 0.5
         s1.state.osc_states[0] = 0.75;
@@ -462,6 +580,7 @@ mod tests {
             detune: Some(PolySignal::mono(Signal::Volts(0.0))),
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
         });
         // Set all 4 input channel phases identically
         for input_ch in 0..4 {

--- a/crates/modular_core/src/dsp/oscillators/wavetable.rs
+++ b/crates/modular_core/src/dsp/oscillators/wavetable.rs
@@ -18,7 +18,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{
-    dsp::oscillators::{FmMode, apply_fm, wavetable_prep::PreparedWavetable},
+    dsp::{
+        oscillators::{
+            FmMode, apply_fm, sync_blep, sync_edge_fraction, wavetable_prep::PreparedWavetable,
+        },
+        utils::SchmittTrigger,
+    },
     poly::{PORT_MAX_CHANNELS, PolyOutput, PolySignal, PolySignalExt},
     types::{Connect, Table, Wav, WavData},
 };
@@ -45,6 +50,9 @@ pub(crate) struct WavetableOscParams {
     #[serde(default)]
     #[deserr(default)]
     pub(crate) fm_mode: FmMode,
+    /// hard sync source — rising edges reset the oscillator phase.
+    #[deserr(default)]
+    pub(crate) sync: Option<PolySignal>,
     /// Optional phase-warp table applied before sampling.
     #[deserr(default)]
     pub(crate) phase: Option<Table>,
@@ -68,11 +76,22 @@ struct WavetableOscOutputs {
 struct ChannelState {
     /// Phase accumulator in `[0, 1)`.
     phase: f64,
+    /// Edge detector for the sync input.
+    sync_schmitt: SchmittTrigger,
+    /// Previous sync-input sample, for subsample edge interpolation.
+    sync_prev: f32,
+    /// PolyBLEP residual carried into the next sample from a sync reset.
+    blep_carry: f32,
 }
 
 impl Default for ChannelState {
     fn default() -> Self {
-        Self { phase: 0.0 }
+        Self {
+            phase: 0.0,
+            sync_schmitt: SchmittTrigger::default(),
+            sync_prev: 0.0,
+            blep_carry: 0.0,
+        }
     }
 }
 
@@ -89,10 +108,12 @@ pub fn wavetable_derive_channel_count(params: &WavetableOscParams) -> usize {
     let pos_ch = params.position.as_ref().map(|p| p.channels()).unwrap_or(0);
     let fm_ch = params.fm.as_ref().map(|f| f.channels()).unwrap_or(0);
     let phase_ch = params.phase.as_ref().map(|t| t.channels()).unwrap_or(0);
+    let sync_ch = params.sync.as_ref().map(|s| s.channels()).unwrap_or(0);
     pitch_ch
         .max(pos_ch)
         .max(fm_ch)
         .max(phase_ch)
+        .max(sync_ch)
         .clamp(1, PORT_MAX_CHANNELS)
 }
 
@@ -169,11 +190,12 @@ impl WavetableOsc {
             };
 
             let level = prepared.mipmap_level_for_freq(freq);
-            let sample = prepared.read_sample(level, frame_f, warped_phase);
+            let before = prepared.read_sample(level, frame_f, warped_phase);
 
-            // Output ±5V — wavetables are normalized in [-1, 1] after the
-            // FFT round-trip; scale to the synth's audio range.
-            self.outputs.sample.set(ch, sample * 5.0);
+            // Naive read plus any residual carried from a sync reset on the
+            // previous sample.
+            let mut sample = before + state.blep_carry;
+            state.blep_carry = 0.0;
 
             // Advance phase, wrap to [0, 1). rem_euclid in f64.
             let increment = freq as f64 * inv_sr;
@@ -190,6 +212,31 @@ impl WavetableOsc {
             if !next.is_finite() {
                 next = 0.0;
             }
+
+            // Hard sync: a rising edge resets the phase so the next sample reads
+            // from the table's start. A PolyBLEP at the subsample crossing
+            // band-limits the resulting step.
+            if let Some(sync) = &self.params.sync {
+                let v = sync.get_value(ch);
+                if state.sync_schmitt.process(v) {
+                    let frac = sync_edge_fraction(state.sync_prev, v);
+                    let warped_zero = match &self.params.phase {
+                        Some(table) => table.evaluate(0.0, ch),
+                        None => 0.0,
+                    };
+                    let after = prepared.read_sample(level, frame_f, warped_zero);
+                    let (now, carry) = sync_blep(after - before, frac);
+                    sample += now;
+                    state.blep_carry = carry;
+                    next = 0.0;
+                }
+                state.sync_prev = v;
+            }
+
+            // Output ±5V — wavetables are normalized in [-1, 1] after the
+            // FFT round-trip; scale to the synth's audio range.
+            self.outputs.sample.set(ch, sample * 5.0);
+
             state.phase = next;
         }
     }
@@ -256,6 +303,7 @@ mod tests {
             position: None,
             fm: None,
             fm_mode: FmMode::default(),
+            sync: None,
             phase: None,
             prepared: None,
         }


### PR DESCRIPTION
## Summary

Adds a `sync` signal input to the five internal-phase oscillators — `$sine`, `$saw`, `$pulse`, `$supersaw`, `$wavetable` — implementing **hard sync**: a rising edge on the input resets the oscillator phase, locking its pitch to a patched master.

```js
$saw('c2', { sync: $saw('c3') }).out()
$pulse('c2', { sync: $sine('c3') }).out()
```

The reset discontinuity is **band-limited with a subsample two-point PolyBLEP**, so sweeping the slave frequency gives the classic sync timbre without the aliasing of a naive phase reset.

## How it works

Three shared pieces in `oscillators/mod.rs`:

- **`sync_edge_fraction(prev, curr)`** — interpolates *where* in the sample the master crossed the gate threshold, giving a subsample position. This is what makes PolyBLEP worth doing (vs. sample-quantized detection).
- **`sync_blep(jump, frac)`** — returns `(this_sample, next_sample)` residuals for a step of size `out(0) − out(phase_at_reset)`, calibrated to match the oscillators' existing PolyBLEP. Lands the reset sample on the band-limited midpoint at `frac = 0`.
- Per-channel **`sync_prev`** (for the fraction) and **`blep_carry`** (the second half of the 2-point BLEP, applied to the next sample).

Unifying trick: the reset is modeled as landing in the **upcoming** sample interval. That keeps each oscillator's body valid on the synced sample — DPW stays differentiable, and the pulse/supersaw edge PolyBLEP keeps operating on the real pre-reset phase (no double-correction) — and the 2-point BLEP applies as current-sample + one-sample carry, so **no look-ahead/latency** is needed.

### Per oscillator
- **sine** — alias-free LUT body + BLEP on the reset jump.
- **saw** — DPW body unchanged on the synced sample; BLEP rides on top.
- **pulse** — keeps its rising/falling-edge PolyBLEP; reset jump is **0 when the pulse is already high** at reset (avoids a spurious notch).
- **supersaw** — per-input-channel edge detection; per-voice BLEP + carry (resets all detuned voices of a channel together).
- **wavetable** — mipmap body + BLEP on `read(0) − read(phase)`, folded into the output before the ±5V scale.

Not included (by design): `$pSine`/`$pSaw`/`$pPulse` (externally phase-driven — sync the upstream phasor), `$noise` (no periodic phase), `$plaits` (own engine/trigger model).

## Tests
- New unit tests for `sync_edge_fraction` (threshold interpolation) and `sync_blep` (midpoint/endpoint math).
- New supersaw boundedness test: 2000 samples with constant resets across 5 voices — asserts output stays finite and bounded (exercises the carry).
- `cargo test -p modular_core --lib` → **595 passed**; `tsc -b` clean; `yarn test:unit` → **466 passed**.

## Notes / follow-ups
- This is **PolyBLEP** (cheap, low-order) — a large improvement over a naive reset, but not as clean as minBLEP. minBLEP (à la VCV Fundamental / Eli Brandt 2001) remains a possible future upgrade.
- Verified correct/bounded in code and tests; **not yet listened to** in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)