### PR TITLE
feat: version-gated "Migrate patch to latest" command

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -28,8 +28,12 @@ yarn version patch
 # Get the new version
 VERSION=$(node -p "require('./package.json').version")
 
+# Resolve any unreleased migration markers (`sinceVersion: 'next'`) to this
+# version, so each migration records the release it actually ships in.
+RESOLVED=$(node scripts/resolveMigrationVersions.mjs "$VERSION")
+
 # Commit changes
-git add package.json
+git add package.json $RESOLVED
 git commit -m "Release v$VERSION"
 
 # Create tag

--- a/scripts/resolveMigrationVersions.mjs
+++ b/scripts/resolveMigrationVersions.mjs
@@ -5,7 +5,7 @@
  * A migration is authored with `sinceVersion: 'next'` because the author can't
  * know which release will ship it. `release.sh` runs this after bumping the
  * version so every `'next'` marker becomes the exact release version, stamping
- * each migration with the release it ships in — no manual bookkeeping.
+ * each migration with the release it ships in.
  *
  * Usage: node scripts/resolveMigrationVersions.mjs <version>
  * Prints the paths it changed (one per line) so the caller can `git add` them.

--- a/scripts/resolveMigrationVersions.mjs
+++ b/scripts/resolveMigrationVersions.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * Resolve unreleased migration markers to the version being released.
+ *
+ * A migration is authored with `sinceVersion: 'next'` because the author can't
+ * know which release will ship it. `release.sh` runs this after bumping the
+ * version so every `'next'` marker becomes the exact release version, stamping
+ * each migration with the release it ships in — no manual bookkeeping.
+ *
+ * Usage: node scripts/resolveMigrationVersions.mjs <version>
+ * Prints the paths it changed (one per line) so the caller can `git add` them.
+ */
+import { globSync, readFileSync, writeFileSync } from 'node:fs';
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+    console.error(
+        `resolveMigrationVersions: expected a semver argument, got ${JSON.stringify(version)}`,
+    );
+    process.exit(1);
+}
+
+const MARKER = /sinceVersion:\s*'next'/g;
+const changed = [];
+
+for (const file of globSync('src/renderer/dsl/**/*.ts')) {
+    const source = readFileSync(file, 'utf-8');
+    if (!MARKER.test(source)) continue;
+    writeFileSync(file, source.replace(MARKER, `sinceVersion: '${version}'`));
+    changed.push(file);
+}
+
+for (const file of changed) console.log(file);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -26,8 +26,10 @@ import type {
     UpdateAvailableInfo,
 } from '../shared/ipcTypes';
 import { IPC_CHANNELS, MENU_CHANNELS } from '../shared/ipcTypes';
+import { compareVersion } from '../shared/compareVersion';
 import {
     isStampablePath,
+    parsePatchVersionStamp,
     stampPatchVersionSource,
     stripPatchVersionStamp,
 } from '../shared/patchVersionStamp';
@@ -378,17 +380,8 @@ async function checkForUpdateAvailability(): Promise<void> {
             return;
         }
 
-        // Compare semver — only notify if latest is strictly newer
-        const [lMaj, lMin, lPat] = latestVersion.split('.').map(Number);
-        const [cMaj, cMin, cPat] = currentVersion.split('.').map(Number);
-        // NaN from non-numeric components (e.g. pre-release tags like "1.0.0-beta.1")
-        // Causes all comparisons to be false — pre-releases are silently ignored.
-        const isNewer =
-            lMaj > cMaj ||
-            (lMaj === cMaj && lMin > cMin) ||
-            (lMaj === cMaj && lMin === cMin && lPat > cPat);
-
-        if (!isNewer) {
+        // Only notify if the latest release is strictly newer.
+        if (compareVersion(latestVersion, currentVersion) <= 0) {
             return;
         }
 
@@ -974,6 +967,8 @@ function registerIPCHandler<T extends keyof typeof IPC_CHANNELS>(
 // Main process has restarted with the updated native module.
 registerIPCHandler('GET_SCHEMAS', () => schemas);
 
+registerIPCHandler('GET_APP_VERSION', () => app.getVersion());
+
 // Syphon window output (macOS): the action lives here, so the renderer's
 // operator.toggleSyphon command (palette/keymap) round-trips through IPC.
 registerIPCHandler('SYPHON_TOGGLE', () => toggleSyphonPublish());
@@ -1529,12 +1524,17 @@ registerIPCHandler('FS_READ_FILE', (relativePath) => {
     }
 
     try {
-        const content = fs.readFileSync(absolutePath, 'utf-8');
+        const raw = fs.readFileSync(absolutePath, 'utf-8');
         // Patch files carry an invisible version-stamp block at the top; strip
-        // it so the editor only ever sees the user's own source.
-        return isStampablePath(absolutePath)
-            ? stripPatchVersionStamp(content)
-            : content;
+        // it so the editor only ever sees the user's own source, but return the
+        // last-evaluated version alongside so the renderer can gate migrations.
+        if (!isStampablePath(absolutePath)) {
+            return { content: raw };
+        }
+        return {
+            content: stripPatchVersionStamp(raw),
+            ...parsePatchVersionStamp(raw),
+        };
     } catch (error) {
         console.error('Error reading file:', error);
         throw new Error(`Failed to read file: ${relativePath}`, {
@@ -1543,38 +1543,43 @@ registerIPCHandler('FS_READ_FILE', (relativePath) => {
     }
 });
 
-registerIPCHandler('FS_WRITE_FILE', (relativePath, content) => {
-    const absolutePath = validatePathInWorkspace(relativePath);
-    if (!absolutePath) {
-        return {
-            error: 'Invalid file path or no workspace selected',
-            success: false,
-        };
-    }
-
-    try {
-        // Ensure directory exists
-        const dir = path.dirname(absolutePath);
-        if (!fs.existsSync(dir)) {
-            fs.mkdirSync(dir, { recursive: true });
+registerIPCHandler(
+    'FS_WRITE_FILE',
+    (relativePath, content, evaluatedVersion) => {
+        const absolutePath = validatePathInWorkspace(relativePath);
+        if (!absolutePath) {
+            return {
+                error: 'Invalid file path or no workspace selected',
+                success: false,
+            };
         }
 
-        // Record the app version that last wrote this patch as an invisible
-        // block at the top of the file (stripped again on read).
-        const toWrite = isStampablePath(absolutePath)
-            ? stampPatchVersionSource(content, app.getVersion())
-            : content;
+        try {
+            // Ensure directory exists
+            const dir = path.dirname(absolutePath);
+            if (!fs.existsSync(dir)) {
+                fs.mkdirSync(dir, { recursive: true });
+            }
 
-        fs.writeFileSync(absolutePath, toWrite, 'utf-8');
-        return { success: true };
-    } catch (error) {
-        console.error('Error writing file:', error);
-        return {
-            error: `Failed to write file: ${relativePath}`,
-            success: false,
-        };
-    }
-});
+            // Record the version the patch last evaluated under as an invisible
+            // block at the top of the file (stripped again on read). A patch
+            // never evaluated yet carries no version, so it is written bare.
+            const toWrite =
+                isStampablePath(absolutePath) && evaluatedVersion
+                    ? stampPatchVersionSource(content, evaluatedVersion)
+                    : content;
+
+            fs.writeFileSync(absolutePath, toWrite, 'utf-8');
+            return { success: true };
+        } catch (error) {
+            console.error('Error writing file:', error);
+            return {
+                error: `Failed to write file: ${relativePath}`,
+                success: false,
+            };
+        }
+    },
+);
 
 registerIPCHandler('FS_RENAME_FILE', (oldPath, newPath) => {
     const oldAbsolutePath = validatePathInWorkspace(oldPath);
@@ -2311,34 +2316,10 @@ const createMenu = (): void => {
                         if (focusedWindow) {
                             BrowserWindow.fromId(
                                 focusedWindow.id,
-                            )?.webContents.send(MENU_CHANNELS.MIGRATE_BUFFER);
+                            )?.webContents.send(MENU_CHANNELS.MIGRATE_TO_LATEST);
                         }
                     },
-                    label: 'Migrate $cycle / $iCycle to $p / $p.s...',
-                },
-                {
-                    click: (_item, focusedWindow) => {
-                        if (focusedWindow) {
-                            BrowserWindow.fromId(
-                                focusedWindow.id,
-                            )?.webContents.send(
-                                MENU_CHANNELS.MIGRATE_WAVETABLE,
-                            );
-                        }
-                    },
-                    label: 'Migrate $wavetable to pitch-first order...',
-                },
-                {
-                    click: (_item, focusedWindow) => {
-                        if (focusedWindow) {
-                            BrowserWindow.fromId(
-                                focusedWindow.id,
-                            )?.webContents.send(
-                                MENU_CHANNELS.MIGRATE_CHEBY_BLOCK_DC,
-                            );
-                        }
-                    },
-                    label: 'Migrate $cheby to preserve pre-DC-blocker output...',
+                    label: 'Migrate patch to latest version...',
                 },
                 ...(!isMac
                     ? ([

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -41,6 +41,7 @@ export interface ElectronAPI {
 
     // Schema operations
     getSchemas: Promisify<IPCHandlers[typeof IPC_CHANNELS.GET_SCHEMAS]>;
+    getAppVersion: Promisify<IPCHandlers[typeof IPC_CHANNELS.GET_APP_VERSION]>;
 
     // DSL operations
     executeDSL: (
@@ -200,9 +201,7 @@ export interface ElectronAPI {
     onMenuOpenSettings: (callback: () => void) => () => void;
     onMenuOpenEngineHealth: (callback: () => void) => () => void;
     onMenuOpenModuleProfile: (callback: () => void) => () => void;
-    onMenuMigrateBuffer: (callback: () => void) => () => void;
-    onMenuMigrateWavetable: (callback: () => void) => () => void;
-    onMenuMigrateChebyBlockDC: (callback: () => void) => () => void;
+    onMenuMigrateToLatest: (callback: () => void) => () => void;
     // UI operations
     showContextMenu: (options: ContextMenuOptions) => Promise<void>;
     onContextMenuCommand: (
@@ -285,6 +284,7 @@ const electronAPI: ElectronAPI = {
 
     // Schema operations
     getSchemas: (...args) => invokeIPC('GET_SCHEMAS', ...args),
+    getAppVersion: (...args) => invokeIPC('GET_APP_VERSION', ...args),
 
     // DSL operations
     executeDSL: (source, sourceId, trigger) =>
@@ -467,11 +467,7 @@ const electronAPI: ElectronAPI = {
     onMenuOpenModuleProfile: menuEventHandler(
         MENU_CHANNELS.OPEN_MODULE_PROFILE,
     ),
-    onMenuMigrateBuffer: menuEventHandler(MENU_CHANNELS.MIGRATE_BUFFER),
-    onMenuMigrateWavetable: menuEventHandler(MENU_CHANNELS.MIGRATE_WAVETABLE),
-    onMenuMigrateChebyBlockDC: menuEventHandler(
-        MENU_CHANNELS.MIGRATE_CHEBY_BLOCK_DC,
-    ),
+    onMenuMigrateToLatest: menuEventHandler(MENU_CHANNELS.MIGRATE_TO_LATEST),
 
     // UI operations
     showContextMenu: (options) => invokeIPC('SHOW_CONTEXT_MENU', options),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,9 +9,8 @@ import { EngineHealth } from './components/EngineHealth';
 import { ModuleProfile } from './components/ModuleProfile';
 import { MigrationDiffModal } from './components/MigrationDiffModal';
 import type { MigrationModalSummary } from './components/MigrationDiffModal';
-import { migrateChebyBlockDC } from './dsl/migrateChebyBlockDC';
-import { migrateCycleCalls } from './dsl/migrateCycleCalls';
-import { migrateWavetableArgs } from './dsl/migrateWavetableArgs';
+import type { MigrationMeta } from './dsl/migrations/registry';
+import { migrationsNeededFor } from './dsl/migrations/registry';
 import type { UpdateNotificationState } from './components/UpdateNotification';
 import { UpdateNotification } from './components/UpdateNotification';
 import { CommandPalette } from './components/CommandPalette';
@@ -167,6 +166,9 @@ function App() {
     const [isEngineHealthOpen, setIsEngineHealthOpen] = useState(false);
     const [isPaletteOpen, setIsPaletteOpen] = useState(false);
     const [isModuleProfileOpen, setIsModuleProfileOpen] = useState(false);
+    // The migration step currently shown in the diff modal, or null when closed.
+    // A step with no automatic changes but constructs flagged for manual review
+    // still opens the modal, so the user can read them before the chain advances.
     const [migrationState, setMigrationState] = useState<{
         bufferId: string;
         original: string;
@@ -174,6 +176,13 @@ function App() {
         summary: MigrationModalSummary;
         title?: string;
         skippedLabel?: string;
+    } | null>(null);
+    // Chain context for "Migrate patch to latest": the migrations still to run,
+    // current step first. Held in a ref so the once-registered menu handler and
+    // the modal callbacks share one mutable cursor without re-subscribing.
+    const migrationRunRef = useRef<{
+        bufferId: string;
+        remaining: MigrationMeta[];
     } | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [validationErrors, setValidationErrors] = useState<
@@ -326,6 +335,7 @@ function App() {
                         await electronAPI.filesystem.writeFile(
                             buffer.filePath,
                             buffer.content,
+                            buffer.evaluatedVersion,
                         );
                     }
                 }
@@ -759,6 +769,26 @@ function App() {
                 setError(null);
                 setValidationErrors(null);
 
+                // The patch evaluated successfully: stamp the buffer with this
+                // app version so migrations that shipped after it are no longer
+                // offered. Only touch state (and mark dirty, so the new version
+                // reaches the autosave and file header) when it actually changes.
+                const evaluatedAt = appVersionRef.current;
+                if (evaluatedAt) {
+                    setBuffers((prev) =>
+                        prev.map((b) =>
+                            getBufferId(b) === activeBufferId &&
+                            b.evaluatedVersion !== evaluatedAt
+                                ? {
+                                      ...b,
+                                      dirty: true,
+                                      evaluatedVersion: evaluatedAt,
+                                  }
+                                : b,
+                        ),
+                    );
+                }
+
                 // Set interpolation resolutions in renderer for template literal highlighting
                 const interpolationMap = result.interpolationResolutions
                     ? new Map(Object.entries(result.interpolationResolutions))
@@ -871,7 +901,7 @@ function App() {
                 setValidationErrors(null);
             }
         };
-    }, [activeBufferId]);
+    }, [activeBufferId, setBuffers]);
 
     // Expose test API for E2E tests
     useEffect(() => {
@@ -937,6 +967,94 @@ function App() {
     useEffect(() => {
         activeBufferIdRef.current = activeBufferId;
     }, [activeBufferId]);
+
+    // Live view of buffers for the once-registered migrate handler.
+    const buffersRef = useRef(buffers);
+    useEffect(() => {
+        buffersRef.current = buffers;
+    }, [buffers]);
+
+    // This app's version, fetched once. Stamped onto a buffer each time it
+    // evaluates successfully so migrations can be gated on the last-evaluated
+    // version. Empty until the fetch resolves (well before any evaluation).
+    const appVersionRef = useRef('');
+    useEffect(() => {
+        electronAPI
+            .getAppVersion()
+            .then((version) => {
+                appVersionRef.current = version;
+            })
+            .catch((err) => {
+                console.error('[migrate] failed to read app version:', err);
+            });
+    }, []);
+
+    // Drive the migration chain from `source`: run each remaining migration in
+    // order, auto-clearing clean no-ops and pausing on the diff modal whenever a
+    // step changes the source or has something to flag. The modal's callbacks
+    // resume the chain. Nothing is recorded here — a successful re-evaluation
+    // after migrating advances the buffer's evaluatedVersion.
+    const advanceMigrationRun = useCallback((source: string) => {
+        const run = migrationRunRef.current;
+        if (!run) return;
+        while (run.remaining.length > 0) {
+            const meta = run.remaining[0];
+            const result = meta.run(source);
+            const hasManual = result.summary.skippedVariables.length > 0;
+            const hasError = Boolean(result.summary.error);
+            if (result.changed || hasManual || hasError) {
+                setMigrationState({
+                    bufferId: run.bufferId,
+                    original: source,
+                    migrated: result.migrated,
+                    summary: result.summary,
+                    title: meta.title,
+                    skippedLabel: meta.skippedLabel,
+                });
+                return;
+            }
+            // Clean no-op: the patch already conforms to this migration.
+            run.remaining.shift();
+        }
+        migrationRunRef.current = null;
+    }, []);
+
+    // Entry point for the "Migrate patch to latest version" command: gather the
+    // migrations the active patch still needs (by its last-evaluated version)
+    // and run them in order.
+    const startMigrateToLatest = useCallback(() => {
+        const ed = editorRef.current;
+        const activeId = activeBufferIdRef.current;
+        if (!ed || !activeId) return;
+        const buffer = buffersRef.current.find(
+            (b) => getBufferId(b) === activeId,
+        );
+        const pending = migrationsNeededFor(buffer?.evaluatedVersion);
+        if (pending.length === 0) {
+            // Nothing pending — show an informational, no-change modal.
+            setMigrationState({
+                bufferId: activeId,
+                original: '',
+                migrated: '',
+                summary: {
+                    callsChanged: 0,
+                    commentsChanged: 0,
+                    skippedVariables: [],
+                },
+                title: 'Migrate patch to latest version',
+            });
+            return;
+        }
+        migrationRunRef.current = {
+            bufferId: activeId,
+            remaining: [...pending],
+        };
+        advanceMigrationRun(ed.getValue());
+    }, [advanceMigrationRun]);
+    const startMigrateToLatestRef = useRef(startMigrateToLatest);
+    useEffect(() => {
+        startMigrateToLatestRef.current = startMigrateToLatest;
+    }, [startMigrateToLatest]);
 
     const handleCloseBufferRef = useRef(handleCloseBuffer);
     useEffect(() => {
@@ -1161,128 +1279,11 @@ function App() {
                 setIsModuleProfileOpen(true);
             },
         );
-        const cleanupMigrateBuffer = electronAPI.onMenuMigrateBuffer(() => {
-            const ed = editorRef.current;
-            // Read the live id from the ref: this listener is registered once
-            // (deps below), so closing over the `activeBufferId` state would
-            // migrate a stale buffer after the user switches buffers.
-            const activeId = activeBufferIdRef.current;
-            if (!ed || !activeId) {
-                console.warn('Migrate buffer: no editor available');
-                setMigrationState({
-                    bufferId: activeId ?? '',
-                    original: '',
-                    migrated: '',
-                    summary: {
-                        callsChanged: 0,
-                        assignmentsChanged: 0,
-                        commentsChanged: 0,
-                        skippedVariables: [],
-                        error: 'No editor available',
-                    },
-                });
-                return;
-            }
-            const original = ed.getValue();
-            const result = migrateCycleCalls(original);
-            setMigrationState({
-                bufferId: activeId,
-                original,
-                migrated: result.migrated,
-                summary: {
-                    callsChanged: result.callsChanged,
-                    assignmentsChanged: result.assignmentsChanged,
-                    commentsChanged: result.commentsChanged,
-                    skippedVariables: result.skippedVariables,
-                    error: result.error,
-                },
-            });
+        // Registered once (deps below), so it reads the live start function
+        // through a ref to avoid migrating a stale buffer after a switch.
+        const cleanupMigrateToLatest = electronAPI.onMenuMigrateToLatest(() => {
+            startMigrateToLatestRef.current();
         });
-
-        const cleanupMigrateWavetable = electronAPI.onMenuMigrateWavetable(
-            () => {
-                const ed = editorRef.current;
-                // Read the live id from the ref: this listener is registered
-                // once (deps below), so closing over the `activeBufferId` state
-                // would migrate a stale buffer after the user switches buffers.
-                const activeId = activeBufferIdRef.current;
-                const wavetableTitle =
-                    'Migrate $wavetable to pitch-first order';
-                if (!ed || !activeId) {
-                    console.warn('Migrate wavetable: no editor available');
-                    setMigrationState({
-                        bufferId: activeId ?? '',
-                        original: '',
-                        migrated: '',
-                        title: wavetableTitle,
-                        summary: {
-                            callsChanged: 0,
-                            commentsChanged: 0,
-                            skippedVariables: [],
-                            error: 'No editor available',
-                        },
-                    });
-                    return;
-                }
-                const original = ed.getValue();
-                const result = migrateWavetableArgs(original);
-                setMigrationState({
-                    bufferId: activeId,
-                    original,
-                    migrated: result.migrated,
-                    title: wavetableTitle,
-                    skippedLabel: 'Needs manual review:',
-                    summary: {
-                        callsChanged: result.callsChanged,
-                        commentsChanged: result.commentsChanged,
-                        skippedVariables: result.skipped,
-                        error: result.error,
-                    },
-                });
-            },
-        );
-
-        const cleanupMigrateChebyBlockDC =
-            electronAPI.onMenuMigrateChebyBlockDC(() => {
-                const ed = editorRef.current;
-                // Read the live id from the ref: this listener is registered
-                // once (deps below), so closing over the `activeBufferId` state
-                // would migrate a stale buffer after the user switches buffers.
-                const activeId = activeBufferIdRef.current;
-                const chebyTitle =
-                    'Migrate $cheby to preserve pre-DC-blocker output';
-                if (!ed || !activeId) {
-                    console.warn('Migrate $cheby: no editor available');
-                    setMigrationState({
-                        bufferId: activeId ?? '',
-                        original: '',
-                        migrated: '',
-                        title: chebyTitle,
-                        summary: {
-                            callsChanged: 0,
-                            commentsChanged: 0,
-                            skippedVariables: [],
-                            error: 'No editor available',
-                        },
-                    });
-                    return;
-                }
-                const original = ed.getValue();
-                const result = migrateChebyBlockDC(original);
-                setMigrationState({
-                    bufferId: activeId,
-                    original,
-                    migrated: result.migrated,
-                    title: chebyTitle,
-                    skippedLabel: 'Needs manual review:',
-                    summary: {
-                        callsChanged: result.callsChanged,
-                        commentsChanged: 0,
-                        skippedVariables: result.skipped,
-                        error: result.error,
-                    },
-                });
-            });
 
         return () => {
             cleanupNewFile();
@@ -1296,9 +1297,7 @@ function App() {
             cleanupOpenSettings();
             cleanupOpenEngineHealth();
             cleanupOpenModuleProfile();
-            cleanupMigrateBuffer();
-            cleanupMigrateWavetable();
-            cleanupMigrateChebyBlockDC();
+            cleanupMigrateToLatest();
         };
     }, [isRecording]);
 
@@ -1430,32 +1429,47 @@ function App() {
                     summary={migrationState.summary}
                     title={migrationState.title}
                     skippedLabel={migrationState.skippedLabel}
-                    onCancel={() => setMigrationState(null)}
+                    onCancel={() => {
+                        // Cancelling ends the run; steps already applied stay in
+                        // the editor, and re-evaluating advances the version.
+                        setMigrationState(null);
+                        migrationRunRef.current = null;
+                    }}
                     onApply={() => {
                         const ed = editorRef.current;
                         const model = ed?.getModel();
-                        if (!ed || !model) {
-                            setMigrationState(null);
+                        const run = migrationRunRef.current;
+                        setMigrationState(null);
+                        if (!ed || !model || !run) {
+                            migrationRunRef.current = null;
                             return;
                         }
                         if (migrationState.bufferId !== activeBufferId) {
                             console.warn(
                                 'Migrate apply: active buffer changed since modal opened; aborting',
                             );
-                            setMigrationState(null);
+                            migrationRunRef.current = null;
                             return;
                         }
-                        model.pushEditOperations(
-                            [],
-                            [
-                                {
-                                    range: model.getFullModelRange(),
-                                    text: migrationState.migrated,
-                                },
-                            ],
-                            () => null,
-                        );
-                        setMigrationState(null);
+                        // A flagged-only step leaves the source unchanged; skip
+                        // the no-op write so it adds no undo stop.
+                        if (
+                            migrationState.migrated !== migrationState.original
+                        ) {
+                            model.pushEditOperations(
+                                [],
+                                [
+                                    {
+                                        range: model.getFullModelRange(),
+                                        text: migrationState.migrated,
+                                    },
+                                ],
+                                () => null,
+                            );
+                        }
+                        // Advance the chain on the migrated source.
+                        run.remaining.shift();
+                        advanceMigrationRun(migrationState.migrated);
                     }}
                 />
             )}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -183,6 +183,10 @@ function App() {
     const migrationRunRef = useRef<{
         bufferId: string;
         remaining: MigrationMeta[];
+        // Whether any step in this run has opened the modal. When the run drains
+        // without one, every pending migration was a no-op and the user gets the
+        // "nothing to do" modal instead of silence.
+        shownAny: boolean;
     } | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [validationErrors, setValidationErrors] = useState<
@@ -990,10 +994,13 @@ function App() {
     }, []);
 
     // Drive the migration chain from `source`: run each remaining migration in
-    // order, auto-clearing clean no-ops and pausing on the diff modal whenever a
-    // step changes the source or has something to flag. The modal's callbacks
-    // resume the chain. Nothing is recorded here — a successful re-evaluation
-    // after migrating advances the buffer's evaluatedVersion.
+    // order and pause on the diff modal for any step that changes the source or
+    // raises an alert (manual-review items or a parse error). A step that would
+    // do neither is dropped from the group. If every step is dropped the patch
+    // already conforms, so a no-change modal reports there was nothing to do.
+    // The modal's callbacks resume the chain. Nothing is recorded here — a
+    // successful re-evaluation after migrating advances the buffer's
+    // evaluatedVersion.
     const advanceMigrationRun = useCallback((source: string) => {
         const run = migrationRunRef.current;
         if (!run) return;
@@ -1003,6 +1010,7 @@ function App() {
             const hasManual = result.summary.skippedVariables.length > 0;
             const hasError = Boolean(result.summary.error);
             if (result.changed || hasManual || hasError) {
+                run.shownAny = true;
                 setMigrationState({
                     bufferId: run.bufferId,
                     original: source,
@@ -1013,27 +1021,13 @@ function App() {
                 });
                 return;
             }
-            // Clean no-op: the patch already conforms to this migration.
+            // Clean no-op: the patch already conforms, so drop it from the group.
             run.remaining.shift();
         }
         migrationRunRef.current = null;
-    }, []);
-
-    // Entry point for the "Migrate patch to latest version" command: gather the
-    // migrations the active patch still needs (by its last-evaluated version)
-    // and run them in order.
-    const startMigrateToLatest = useCallback(() => {
-        const ed = editorRef.current;
-        const activeId = activeBufferIdRef.current;
-        if (!ed || !activeId) return;
-        const buffer = buffersRef.current.find(
-            (b) => getBufferId(b) === activeId,
-        );
-        const pending = migrationsNeededFor(buffer?.evaluatedVersion);
-        if (pending.length === 0) {
-            // Nothing pending — show an informational, no-change modal.
+        if (!run.shownAny) {
             setMigrationState({
-                bufferId: activeId,
+                bufferId: run.bufferId,
                 original: '',
                 migrated: '',
                 summary: {
@@ -1043,11 +1037,23 @@ function App() {
                 },
                 title: 'Migrate patch to latest version',
             });
-            return;
         }
+    }, []);
+
+    // Entry point for the "Migrate patch to latest version" command: gather the
+    // migrations the active patch still needs (by its last-evaluated version)
+    // and run them in order, dropping any that turn out to be no-ops.
+    const startMigrateToLatest = useCallback(() => {
+        const ed = editorRef.current;
+        const activeId = activeBufferIdRef.current;
+        if (!ed || !activeId) return;
+        const buffer = buffersRef.current.find(
+            (b) => getBufferId(b) === activeId,
+        );
         migrationRunRef.current = {
             bufferId: activeId,
-            remaining: [...pending],
+            remaining: migrationsNeededFor(buffer?.evaluatedVersion),
+            shownAny: false,
         };
         advanceMigrationRun(ed.getValue());
     }, [advanceMigrationRun]);

--- a/src/renderer/app/buffers.ts
+++ b/src/renderer/app/buffers.ts
@@ -26,6 +26,7 @@ export const readUnsavedBuffers = (): EditorBuffer[] => {
                     filePath: snapshot.filePath,
                     id: snapshot.id,
                     kind: 'file',
+                    evaluatedVersion: snapshot.evaluatedVersion,
                 };
             }
             return {
@@ -33,6 +34,7 @@ export const readUnsavedBuffers = (): EditorBuffer[] => {
                 dirty: true,
                 id: snapshot.id,
                 kind: 'untitled',
+                evaluatedVersion: snapshot.evaluatedVersion,
             };
         });
     } catch (error) {
@@ -56,12 +58,14 @@ export const saveUnsavedBuffers = (buffers: EditorBuffer[]) => {
                         filePath: buffer.filePath,
                         id: buffer.filePath,
                         kind: 'file',
+                        evaluatedVersion: buffer.evaluatedVersion,
                     };
                 }
                 return {
                     content: buffer.content,
                     id: buffer.id,
                     kind: 'untitled',
+                    evaluatedVersion: buffer.evaluatedVersion,
                 };
             },
         );

--- a/src/renderer/app/hooks/useEditorBuffers.ts
+++ b/src/renderer/app/hooks/useEditorBuffers.ts
@@ -105,7 +105,8 @@ export function useEditorBuffers({
                 return;
             }
 
-            const content = await electronAPI.filesystem.readFile(absPath);
+            const { content, evaluatedVersion } =
+                await electronAPI.filesystem.readFile(absPath);
 
             setBuffers((prev) => {
                 const nextBuffers = [...prev];
@@ -127,6 +128,7 @@ export function useEditorBuffers({
                     id: v4(),
                     isPreview: options?.preview ?? false,
                     kind: 'file',
+                    evaluatedVersion,
                 };
                 return [...nextBuffers, newBuffer];
             });
@@ -147,7 +149,8 @@ export function useEditorBuffers({
                 setActiveBufferId(getBufferId(existing));
                 return;
             }
-            const content = await electronAPI.filesystem.readFile(absPath);
+            const { content, evaluatedVersion } =
+                await electronAPI.filesystem.readFile(absPath);
             const newBuffer: EditorBuffer = {
                 content,
                 dirty: false,
@@ -155,6 +158,7 @@ export function useEditorBuffers({
                 id: v4(),
                 isPreview: false,
                 kind: 'file',
+                evaluatedVersion,
             };
             setBuffers((prev) => [...prev, newBuffer]);
             setActiveBufferId(absPath);
@@ -221,6 +225,7 @@ export function useEditorBuffers({
                 const result = await electronAPI.filesystem.writeFile(
                     normalized,
                     buffer.content,
+                    buffer.evaluatedVersion,
                 );
 
                 if (result.success) {
@@ -233,6 +238,7 @@ export function useEditorBuffers({
                                       filePath: normalized,
                                       id: b.id,
                                       kind: 'file' as const,
+                                      evaluatedVersion: buffer.evaluatedVersion,
                                   }
                                 : b,
                         ),
@@ -249,6 +255,7 @@ export function useEditorBuffers({
                 const result = await electronAPI.filesystem.writeFile(
                     buffer.filePath,
                     buffer.content,
+                    buffer.evaluatedVersion,
                 );
 
                 if (result.success) {

--- a/src/renderer/components/MigrationDiffModal.tsx
+++ b/src/renderer/components/MigrationDiffModal.tsx
@@ -48,17 +48,24 @@ export function MigrationDiffModal({
         (summary.assignmentsChanged ?? 0) +
         summary.commentsChanged;
     const noChanges = totalChanges === 0;
-    const canApply = !noChanges && !summary.error;
+    const hasFlags =
+        summary.skippedVariables.length > 0 || Boolean(summary.error);
+    // The primary button moves the migration forward: it applies the diff when
+    // there is one, or steps past a flagged/errored migration so the rest of the
+    // chain still runs. It is disabled only when there is nothing to apply and
+    // nothing flagged. The label reflects which of the two it does.
+    const canProceed = !noChanges || hasFlags;
+    const applyLabel = canProceed && noChanges ? 'Continue' : 'Apply';
 
     const handleKey = useCallback(
         (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
                 onCancel();
-            } else if (e.key === 'Enter' && canApply) {
+            } else if (e.key === 'Enter' && canProceed) {
                 onApply();
             }
         },
-        [canApply, onApply, onCancel],
+        [canProceed, onApply, onCancel],
     );
 
     useEffect(() => {
@@ -92,8 +99,10 @@ export function MigrationDiffModal({
                         {summary.assignmentsChanged !== undefined && (
                             <>
                                 {summary.assignmentsChanged} assignment
-                                {summary.assignmentsChanged === 1 ? '' : 's'} ·
-                                {' '}
+                                {summary.assignmentsChanged === 1
+                                    ? ''
+                                    : 's'}{' '}
+                                ·{' '}
                             </>
                         )}
                         {summary.commentsChanged} comment
@@ -114,9 +123,11 @@ export function MigrationDiffModal({
                 <div className="migration-body">
                     {noChanges ? (
                         <div className="migration-empty">
-                            {summary.skippedVariables.length > 0
-                                ? 'No automatic changes to apply — see the flagged items above.'
-                                : 'Buffer already migrated — no changes to apply.'}
+                            {summary.error
+                                ? 'Could not migrate this step — see the error above.'
+                                : summary.skippedVariables.length > 0
+                                  ? 'No automatic changes to apply — see the flagged items above.'
+                                  : 'Buffer already migrated — no changes to apply.'}
                         </div>
                     ) : (
                         <DiffEditor
@@ -152,9 +163,9 @@ export function MigrationDiffModal({
                     <button
                         className="btn btn-primary"
                         onClick={onApply}
-                        disabled={!canApply}
+                        disabled={!canProceed}
                     >
-                        Apply
+                        {applyLabel}
                     </button>
                 </div>
             </div>

--- a/src/renderer/components/__tests__/MigrationDiffModal.test.tsx
+++ b/src/renderer/components/__tests__/MigrationDiffModal.test.tsx
@@ -196,17 +196,20 @@ describe('MigrationDiffModal', () => {
         expect((apply.props as { disabled?: boolean }).disabled).toBe(true);
     });
 
-    test('Apply button is disabled when error is set', () => {
+    test('an errored step shows an enabled Continue button and the error text', () => {
+        // A migration that fails to parse leaves the source unchanged and
+        // reports an error; the primary button steps past it so the rest of the
+        // chain still runs.
         const tree = renderModal({
             summary: {
-                callsChanged: 3,
-                assignmentsChanged: 1,
+                callsChanged: 0,
+                assignmentsChanged: 0,
                 commentsChanged: 0,
                 error: 'parse failure',
             },
         });
-        const apply = findButtonByText(tree!, 'Apply');
-        expect((apply.props as { disabled?: boolean }).disabled).toBe(true);
+        const proceed = findButtonByText(tree!, 'Continue');
+        expect((proceed.props as { disabled?: boolean }).disabled).toBe(false);
 
         // The error message should also render in the summary block.
         const texts: string[] = [];
@@ -218,6 +221,21 @@ describe('MigrationDiffModal', () => {
             if (typeof flat === 'string') texts.push(flat);
         }
         expect(texts.some((t) => t.includes('parse failure'))).toBe(true);
+    });
+
+    test('a flagged-only step shows an enabled Continue button', () => {
+        // No automatic changes, but items flagged for manual review: the
+        // primary button stays enabled so the chain can advance past it.
+        const tree = renderModal({
+            summary: {
+                callsChanged: 0,
+                assignmentsChanged: 0,
+                commentsChanged: 0,
+                skippedVariables: ['line 3: $wavetable(getWav(), 0)'],
+            },
+        });
+        const proceed = findButtonByText(tree!, 'Continue');
+        expect((proceed.props as { disabled?: boolean }).disabled).toBe(false);
     });
 
     test('Apply button is enabled when totalChanges > 0 and no error', () => {

--- a/src/renderer/dsl/__tests__/migrateAdsrDefaults.test.ts
+++ b/src/renderer/dsl/__tests__/migrateAdsrDefaults.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'vitest';
+
+import { migrateAdsrDefaults } from '../migrateAdsrDefaults';
+
+const FULL = `attack: 0.01, decay: 0.1, sustain: 5, release: 0.1, curve: 0`;
+
+describe('migrateAdsrDefaults', () => {
+    // ─── Direct calls ─────────────────────────────────────────────────────
+
+    test('appends the full default set to a bare $adsr(gate) call', () => {
+        const result = migrateAdsrDefaults(`$adsr(gate).out()`);
+        expect(result.migrated).toBe(`$adsr(gate, { ${FULL} }).out()`);
+        expect(result.callsChanged).toBe(1);
+        expect(result.skipped).toEqual([]);
+    });
+
+    test('fills an empty config object cleanly', () => {
+        const result = migrateAdsrDefaults(`$adsr(gate, {}).out()`);
+        expect(result.migrated).toBe(`$adsr(gate, { ${FULL} }).out()`);
+        expect(result.callsChanged).toBe(1);
+    });
+
+    test('injects only the missing keys, keeping explicit ones', () => {
+        const result = migrateAdsrDefaults(
+            `$adsr(gate, { attack: 0.02 }).out()`,
+        );
+        expect(result.migrated).toBe(
+            `$adsr(gate, { decay: 0.1, sustain: 5, release: 0.1, curve: 0, attack: 0.02 }).out()`,
+        );
+        expect(result.callsChanged).toBe(1);
+    });
+
+    test('pins sustain when decay is set but sustain is omitted', () => {
+        // The new engine drops sustain to 0 in this case; pinning sustain: 5
+        // restores the old full-sustain default.
+        const result = migrateAdsrDefaults(`$adsr(gate, { decay: 0.3 })`);
+        expect(result.migrated).toContain('sustain: 5');
+        expect(result.migrated).toContain('decay: 0.3');
+        expect(result.migrated).not.toContain('decay: 0.1');
+    });
+
+    // ─── Dollar-chain form ────────────────────────────────────────────────
+
+    test('injects into a .$.adsr(config) chain call', () => {
+        const result = migrateAdsrDefaults(`gate.$.adsr({ decay: 0.2 }).out()`);
+        expect(result.migrated).toBe(
+            `gate.$.adsr({ attack: 0.01, sustain: 5, release: 0.1, curve: 0, decay: 0.2 }).out()`,
+        );
+        expect(result.callsChanged).toBe(1);
+    });
+
+    test('adds config to a bare .$.adsr() chain call', () => {
+        const result = migrateAdsrDefaults(`gate.$.adsr().out()`);
+        expect(result.migrated).toBe(`gate.$.adsr({ ${FULL} }).out()`);
+        expect(result.callsChanged).toBe(1);
+    });
+
+    // ─── Mix-chain form (.$m injects a leading mix arg) ───────────────────
+
+    test('injects past the mix arg in a .$m.adsr(mix, config) call', () => {
+        const result = migrateAdsrDefaults(
+            `gate.$m.adsr(2.5, { decay: 0.2 }).out()`,
+        );
+        expect(result.migrated).toBe(
+            `gate.$m.adsr(2.5, { attack: 0.01, sustain: 5, release: 0.1, curve: 0, decay: 0.2 }).out()`,
+        );
+        expect(result.callsChanged).toBe(1);
+    });
+
+    test('adds config after the mix arg in a .$m.adsr(mix) call', () => {
+        const result = migrateAdsrDefaults(`gate.$m.adsr(2.5).out()`);
+        expect(result.migrated).toBe(`gate.$m.adsr(2.5, { ${FULL} }).out()`);
+        expect(result.callsChanged).toBe(1);
+    });
+
+    // ─── Idempotency ──────────────────────────────────────────────────────
+
+    test('is a no-op when all five keys are already set', () => {
+        const src = `$adsr(gate, { ${FULL} }).out()`;
+        const result = migrateAdsrDefaults(src);
+        expect(result.migrated).toBe(src);
+        expect(result.callsChanged).toBe(0);
+    });
+
+    test('running twice changes nothing the second time', () => {
+        const once = migrateAdsrDefaults(`$adsr(gate)`).migrated;
+        const twice = migrateAdsrDefaults(once).migrated;
+        expect(twice).toBe(once);
+    });
+
+    // ─── Conservative skips ───────────────────────────────────────────────
+
+    test('skips a config passed as a variable', () => {
+        const result = migrateAdsrDefaults(`$adsr(gate, opts).out()`);
+        expect(result.migrated).toBe(`$adsr(gate, opts).out()`);
+        expect(result.callsChanged).toBe(0);
+        expect(result.skipped).toHaveLength(1);
+    });
+
+    test('skips a config built with a spread', () => {
+        const result = migrateAdsrDefaults(
+            `$adsr(gate, { ...opts, decay: 0.2 })`,
+        );
+        expect(result.callsChanged).toBe(0);
+        expect(result.skipped).toHaveLength(1);
+    });
+
+    test('leaves an unrelated .adsr() method untouched', () => {
+        const src = `myThing.adsr({ foo: 1 })`;
+        const result = migrateAdsrDefaults(src);
+        expect(result.migrated).toBe(src);
+        expect(result.callsChanged).toBe(0);
+        expect(result.skipped).toEqual([]);
+    });
+});

--- a/src/renderer/dsl/__tests__/migrateChebyBlockDC.test.ts
+++ b/src/renderer/dsl/__tests__/migrateChebyBlockDC.test.ts
@@ -50,6 +50,26 @@ describe('migrateChebyBlockDC', () => {
         expect(result.callsChanged).toBe(1);
     });
 
+    // ─── Mix-chain form (.$m injects a leading mix arg) ───────────────────
+
+    test('appends config past the mix arg in a .$m.cheby(mix, amount) call', () => {
+        const result = migrateChebyBlockDC(`$sine('c4').$m.cheby(2.5, 3).out()`);
+        expect(result.migrated).toBe(
+            `$sine('c4').$m.cheby(2.5, 3, { blockDC: false }).out()`,
+        );
+        expect(result.callsChanged).toBe(1);
+    });
+
+    test('injects blockDC into a .$m.cheby config object', () => {
+        const result = migrateChebyBlockDC(
+            `$sine('c4').$m.cheby(2.5, 3, { freq: 'c4' })`,
+        );
+        expect(result.migrated).toBe(
+            `$sine('c4').$m.cheby(2.5, 3, { blockDC: false, freq: 'c4' })`,
+        );
+        expect(result.callsChanged).toBe(1);
+    });
+
     // ─── Idempotency ──────────────────────────────────────────────────────
 
     test('leaves a call that already sets blockDC untouched', () => {

--- a/src/renderer/dsl/migrateAdsrDefaults.ts
+++ b/src/renderer/dsl/migrateAdsrDefaults.ts
@@ -1,0 +1,293 @@
+/**
+ * Migrate existing `$adsr(...)` patches to keep their pre-0.0.102 envelope.
+ *
+ * In 0.0.102 `$adsr` got snappier defaults, a new `curve` parameter, and a
+ * retrigger input. For a patch written before then, the omitted parameters now
+ * resolve to different values, so the envelope sounds different:
+ *
+ *   - `attack`  default 0.01 → 0.001 s
+ *   - `decay`   default 0.1  → 0.05 s
+ *   - `release` default 0.1  → 0.01 s
+ *   - `sustain` default 5 V, but now drops to 0 V when `decay` is set and
+ *     `sustain` is omitted (a plucky AD shape)
+ *   - `curve`   new; the old envelope was linear, the new default is 5
+ *     (logarithmic attack, exponential decay/release)
+ *
+ * This pins every call site to the old behavior by filling in the old defaults
+ * for any of `attack`, `decay`, `sustain`, `release`, and `curve` the call does
+ * not already set. `curve: 0` restores the old linear ramps; because the new
+ * retrigger input defaults to the gate, a linear curve also makes a re-attack
+ * resume exactly as it did before, so no retrigger parameter is needed.
+ * Parameters the patch sets explicitly are left untouched.
+ *
+ * Three call forms are rewritten:
+ *   - Direct:        `$adsr(gate, config?)`        → config slot is arg 1
+ *   - Dollar-chain:  `<gate>.$.adsr(config?)`       → config slot is arg 0
+ *   - Mix-chain:     `<gate>.$m.adsr(mix, config?)` → config slot is arg 1
+ *     (`.$m` injects a leading `mix` crossfade signal, shifting the config)
+ *
+ * For each, the config (the trailing options object) gains the missing keys:
+ *   - no config object yet → append `{ … }` with the full old default set
+ *   - an inline config object → insert the missing keys as its first properties
+ *
+ * Idempotent: a call whose config already sets all five keys is left untouched.
+ *
+ * Conservatively skipped (reported for manual review, never rewritten):
+ *   - other `.adsr(...)` method forms, which can't be told apart from an
+ *     unrelated method named `adsr` by syntax alone
+ *   - a config passed as a variable or built with a spread, where injecting a
+ *     property could be overridden or is not statically safe
+ *   - calls with unexpected extra arguments
+ *
+ * Comments are not rewritten — commented-out code does not affect the running
+ * patch.
+ */
+
+import { Node, Project, SyntaxKind } from 'ts-morph';
+import type { CallExpression, Expression, SourceFile } from 'ts-morph';
+
+import type { Edit } from './migrationEdits';
+import { applyEdits } from './migrationEdits';
+import type { MigrationMeta } from './migrations/types';
+
+export interface AdsrDefaultsMigrationResult {
+    migrated: string;
+    callsChanged: number;
+    /** Human-readable descriptions of `adsr` calls that look relevant but were
+     *  not rewritten automatically, so the user can fix them by hand. */
+    skipped: string[];
+    error?: string;
+}
+
+const ZERO_COUNTS = { callsChanged: 0 } as const;
+
+/** The parameters whose pre-0.0.102 defaults must be pinned, with the old
+ *  default each resolved to, in the order they are written. */
+const LEGACY_DEFAULTS: ReadonlyArray<readonly [string, string]> = [
+    ['attack', '0.01'],
+    ['decay', '0.1'],
+    ['sustain', '5'],
+    ['release', '0.1'],
+    ['curve', '0'],
+];
+
+/** The number of leading positional arguments before the config object, per
+ *  call form, or null when the call is not an `$adsr`-creating call. */
+interface AdsrForm {
+    /** Count of positional args before the optional config object. */
+    positional: number;
+}
+
+export function migrateAdsrDefaults(
+    source: string,
+): AdsrDefaultsMigrationResult {
+    let sourceFile: SourceFile;
+    try {
+        const project = new Project({
+            compilerOptions: { allowJs: true, checkJs: false, noEmit: true },
+            useInMemoryFileSystem: true,
+        });
+        sourceFile = project.createSourceFile('migrate.ts', source);
+    } catch (err) {
+        return {
+            migrated: source,
+            ...ZERO_COUNTS,
+            skipped: [],
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+
+    const edits: Edit[] = [];
+    const skipped: string[] = [];
+    let callsChanged = 0;
+
+    sourceFile.forEachDescendant((node) => {
+        if (!Node.isCallExpression(node)) return;
+
+        const form = classifyAdsr(node);
+        if (!form) return;
+
+        const args = node.getArguments() as Expression[];
+
+        // Missing a required positional arg — not a shape we can safely touch.
+        if (args.length < form.positional) {
+            skipped.push(describeCall(node));
+            return;
+        }
+
+        // No config object yet: add one carrying the full old default set.
+        if (args.length === form.positional) {
+            const fullConfig = `{ ${LEGACY_DEFAULTS.map(
+                ([key, value]) => `${key}: ${value}`,
+            ).join(', ')} }`;
+            if (args.length > 0) {
+                const anchor = args[args.length - 1];
+                edits.push({
+                    start: anchor.getEnd(),
+                    end: anchor.getEnd(),
+                    replacement: `, ${fullConfig}`,
+                });
+            } else {
+                // Dollar-chain call with no arguments (`gate.$.adsr()`): insert
+                // the config just inside the parentheses.
+                const openParen = node.getFirstChildByKind(
+                    SyntaxKind.OpenParenToken,
+                );
+                if (!openParen) {
+                    skipped.push(describeCall(node));
+                    return;
+                }
+                edits.push({
+                    start: openParen.getEnd(),
+                    end: openParen.getEnd(),
+                    replacement: fullConfig,
+                });
+            }
+            callsChanged += 1;
+            return;
+        }
+
+        // Extra args beyond the config slot — unexpected shape.
+        if (args.length > form.positional + 1) {
+            skipped.push(describeCall(node));
+            return;
+        }
+
+        const config = args[form.positional];
+        if (!Node.isObjectLiteralExpression(config)) {
+            // Config passed as a variable / call result — can't inject safely.
+            skipped.push(describeCall(node));
+            return;
+        }
+
+        const props = config.getProperties();
+        if (props.some((p) => Node.isSpreadAssignment(p))) {
+            // A spread could override an injected value — not statically safe.
+            skipped.push(describeCall(node));
+            return;
+        }
+
+        const missing = LEGACY_DEFAULTS.filter(
+            ([key]) => !objectHasKey(props, key),
+        );
+        if (missing.length === 0) return; // already pinned — idempotent no-op
+
+        const insertion = missing
+            .map(([key, value]) => `${key}: ${value}`)
+            .join(', ');
+        if (props.length === 0) {
+            // Empty `{}` (or `{ }`) → emit a clean object with the missing keys.
+            edits.push({
+                start: config.getStart(),
+                end: config.getEnd(),
+                replacement: `{ ${insertion} }`,
+            });
+        } else {
+            // Insert before the first property, preserving brace spacing.
+            const first = props[0];
+            edits.push({
+                start: first.getStart(),
+                end: first.getStart(),
+                replacement: `${insertion}, `,
+            });
+        }
+        callsChanged += 1;
+    });
+
+    const { source: migrated, conflict } = applyEdits(source, edits);
+    if (conflict) {
+        return {
+            migrated: source,
+            ...ZERO_COUNTS,
+            skipped: [],
+            error: 'edits conflict',
+        };
+    }
+
+    return { migrated, callsChanged, skipped: dedupe(skipped) };
+}
+
+/**
+ * Recognize a call that constructs an `$adsr` node and report how many
+ * positional arguments precede its config object. Returns null for anything
+ * that isn't a rewritable `$adsr` form.
+ */
+function classifyAdsr(call: CallExpression): AdsrForm | null {
+    const expr = call.getExpression();
+
+    // Direct call: `$adsr(gate, config?)`.
+    if (Node.isIdentifier(expr)) {
+        return expr.getText() === '$adsr' ? { positional: 1 } : null;
+    }
+
+    // Method form: `<gate>.$.adsr(...)` / `<gate>.$m.adsr(...)` are the dollar
+    // chains (the gate is the receiver). `.$` adds no positional args before
+    // the config; `.$m` injects a leading `mix` signal, so the config shifts by
+    // one. Any other `.adsr(...)` is ambiguous and left to the skip path.
+    if (Node.isPropertyAccessExpression(expr) && expr.getName() === 'adsr') {
+        const obj = expr.getExpression();
+        if (Node.isPropertyAccessExpression(obj)) {
+            if (obj.getName() === '$') return { positional: 0 };
+            if (obj.getName() === '$m') return { positional: 1 };
+        }
+    }
+    return null;
+}
+
+/**
+ * Whether an object literal already keys `name`, across every form
+ * `getProperty(name)` misses: shorthand `{ name }`, string-literal
+ * `{ 'name': … }`, and computed `{ ['name']: … }`. Catching all of them keeps
+ * the migration idempotent and avoids emitting a duplicate key.
+ */
+function objectHasKey(props: Node[], name: string): boolean {
+    return props.some((prop) => {
+        if (Node.isShorthandPropertyAssignment(prop)) {
+            return prop.getName() === name;
+        }
+        if (!Node.isPropertyAssignment(prop)) return false;
+        const nameNode = prop.getNameNode();
+        if (Node.isIdentifier(nameNode)) return nameNode.getText() === name;
+        if (Node.isStringLiteral(nameNode)) {
+            return nameNode.getLiteralValue() === name;
+        }
+        if (Node.isComputedPropertyName(nameNode)) {
+            const expr = nameNode.getExpression();
+            return Node.isStringLiteral(expr) && expr.getLiteralValue() === name;
+        }
+        return false;
+    });
+}
+
+function describeCall(call: CallExpression): string {
+    const line = call.getStartLineNumber();
+    const text = call.getText().replace(/\s+/g, ' ');
+    const short = text.length > 60 ? `${text.slice(0, 57)}…` : text;
+    return `line ${line}: ${short}`;
+}
+
+function dedupe(items: string[]): string[] {
+    return Array.from(new Set(items));
+}
+
+/** Registry entry: the new $adsr defaults shipped in v0.0.102. */
+export const meta: MigrationMeta = {
+    id: 'adsr-legacy-defaults',
+    sinceVersion: '0.0.102',
+    order: 4,
+    title: 'Migrate $adsr to preserve pre-0.0.102 envelope defaults',
+    skippedLabel: 'Needs manual review:',
+    run(source) {
+        const result = migrateAdsrDefaults(source);
+        return {
+            migrated: result.migrated,
+            changed: result.migrated !== source,
+            summary: {
+                callsChanged: result.callsChanged,
+                commentsChanged: 0,
+                skippedVariables: result.skipped,
+                error: result.error,
+            },
+        };
+    },
+};

--- a/src/renderer/dsl/migrateChebyBlockDC.ts
+++ b/src/renderer/dsl/migrateChebyBlockDC.ts
@@ -8,9 +8,11 @@
  * high-pass would strip). This migration pins those call sites to the old
  * behavior by inserting `{ blockDC: false }`.
  *
- * Two call forms are rewritten:
- *   - Direct:       `$cheby(input, amount, config?)`        → config slot is arg 2
- *   - Dollar-chain: `<src>.$.cheby(amount, config?)`         → config slot is arg 1
+ * Three call forms are rewritten:
+ *   - Direct:       `$cheby(input, amount, config?)`         → config slot is arg 2
+ *   - Dollar-chain: `<src>.$.cheby(amount, config?)`          → config slot is arg 1
+ *   - Mix-chain:    `<src>.$m.cheby(mix, amount, config?)`    → config slot is arg 2
+ *     (`.$m` injects a leading `mix` crossfade signal, shifting the config)
  *
  * For each, the config (the trailing options object) gets `blockDC: false`:
  *   - no config object yet → append `{ blockDC: false }` as a new argument
@@ -39,6 +41,7 @@ import type {
 
 import type { Edit } from './migrationEdits';
 import { applyEdits } from './migrationEdits';
+import type { MigrationMeta } from './migrations/types';
 
 export interface ChebyBlockDcMigrationResult {
     migrated: string;
@@ -158,13 +161,15 @@ function classifyCheby(call: CallExpression): ChebyForm | null {
         return expr.getText() === '$cheby' ? { positional: 2 } : null;
     }
 
-    // Method form: `<recv>.$.cheby(...)` is the dollar-chain (input is the
-    // receiver, so only `amount` is positional). Any other `.cheby(...)` is
-    // ambiguous and handled by the caller's skip path.
+    // Method form: `<recv>.$.cheby(...)` / `<recv>.$m.cheby(...)` are the dollar
+    // chains (input is the receiver). `.$` leaves `amount` as the only
+    // positional; `.$m` injects a leading `mix` signal, so `amount` is preceded
+    // by it. Any other `.cheby(...)` is ambiguous and left to the skip path.
     if (Node.isPropertyAccessExpression(expr) && expr.getName() === 'cheby') {
         const obj = expr.getExpression();
-        if (Node.isPropertyAccessExpression(obj) && obj.getName() === '$') {
-            return { positional: 1 };
+        if (Node.isPropertyAccessExpression(obj)) {
+            if (obj.getName() === '$') return { positional: 1 };
+            if (obj.getName() === '$m') return { positional: 2 };
         }
     }
     return null;
@@ -234,3 +239,25 @@ function describeCall(call: CallExpression): string {
 function dedupe(items: string[]): string[] {
     return Array.from(new Set(items));
 }
+
+/** Registry entry: the DC-blocker default shipped in v0.0.102. */
+export const meta: MigrationMeta = {
+    id: 'cheby-block-dc',
+    sinceVersion: '0.0.102',
+    order: 3,
+    title: 'Migrate $cheby to preserve pre-DC-blocker output',
+    skippedLabel: 'Needs manual review:',
+    run(source) {
+        const result = migrateChebyBlockDC(source);
+        return {
+            migrated: result.migrated,
+            changed: result.migrated !== source,
+            summary: {
+                callsChanged: result.callsChanged,
+                commentsChanged: 0,
+                skippedVariables: result.skipped,
+                error: result.error,
+            },
+        };
+    },
+};

--- a/src/renderer/dsl/migrateCycleCalls.ts
+++ b/src/renderer/dsl/migrateCycleCalls.ts
@@ -38,6 +38,7 @@ import { collectCommentEdits } from './migrateCycleCalls.comments';
 import type { Edit } from './migrateCycleCalls.shared';
 import { buildSpReplacement, wrapP } from './migrateCycleCalls.shared';
 import { applyEdits } from './migrationEdits';
+import type { MigrationMeta } from './migrations/types';
 
 export interface MigrationResult {
     migrated: string;
@@ -430,3 +431,25 @@ function push(
         map.set(name, [site]);
     }
 }
+
+/** Registry entry: shipped in v0.0.68. */
+export const meta: MigrationMeta = {
+    id: 'cycle-to-pattern',
+    sinceVersion: '0.0.68',
+    order: 1,
+    title: 'Migrate $cycle / $iCycle to $p / $p.s',
+    run(source) {
+        const result = migrateCycleCalls(source);
+        return {
+            migrated: result.migrated,
+            changed: result.migrated !== source,
+            summary: {
+                callsChanged: result.callsChanged,
+                assignmentsChanged: result.assignmentsChanged,
+                commentsChanged: result.commentsChanged,
+                skippedVariables: result.skippedVariables,
+                error: result.error,
+            },
+        };
+    },
+};

--- a/src/renderer/dsl/migrateWavetableArgs.ts
+++ b/src/renderer/dsl/migrateWavetableArgs.ts
@@ -36,6 +36,7 @@ import type { CallExpression, Expression, SourceFile } from 'ts-morph';
 
 import type { Edit } from './migrationEdits';
 import { applyEdits } from './migrationEdits';
+import type { MigrationMeta } from './migrations/types';
 
 export interface WavetableMigrationResult {
     migrated: string;
@@ -470,3 +471,25 @@ function trimSpan(
 function escapeRegExp(s: string): string {
     return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+/** Registry entry: shipped in v0.0.97. */
+export const meta: MigrationMeta = {
+    id: 'wavetable-pitch-first',
+    sinceVersion: '0.0.97',
+    order: 2,
+    title: 'Migrate $wavetable to pitch-first order',
+    skippedLabel: 'Needs manual review:',
+    run(source) {
+        const result = migrateWavetableArgs(source);
+        return {
+            migrated: result.migrated,
+            changed: result.migrated !== source,
+            summary: {
+                callsChanged: result.callsChanged,
+                commentsChanged: result.commentsChanged,
+                skippedVariables: result.skipped,
+                error: result.error,
+            },
+        };
+    },
+};

--- a/src/renderer/dsl/migrations/registry.test.ts
+++ b/src/renderer/dsl/migrations/registry.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { MIGRATIONS, NEXT_VERSION, migrationsNeededFor } from './registry';
+
+const ids = (evaluatedVersion: string | undefined) =>
+    migrationsNeededFor(evaluatedVersion).map((m) => m.id);
+
+describe('migration registry', () => {
+    it('has unique ids and unique, ascending order keys', () => {
+        const idSet = new Set(MIGRATIONS.map((m) => m.id));
+        expect(idSet.size).toBe(MIGRATIONS.length);
+        const orders = MIGRATIONS.map((m) => m.order);
+        expect(new Set(orders).size).toBe(orders.length);
+        expect([...orders]).toEqual([...orders].sort((a, b) => a - b));
+    });
+
+    it('marks each sinceVersion as semver or the unreleased sentinel', () => {
+        for (const m of MIGRATIONS) {
+            expect(
+                m.sinceVersion === NEXT_VERSION ||
+                    /^\d+\.\d+\.\d+$/.test(m.sinceVersion),
+            ).toBe(true);
+        }
+    });
+});
+
+describe('migrationsNeededFor', () => {
+    it('offers every migration to a never-evaluated patch, in order', () => {
+        expect(ids(undefined)).toEqual([
+            'cycle-to-pattern',
+            'wavetable-pitch-first',
+            'cheby-block-dc',
+            'adsr-legacy-defaults',
+        ]);
+    });
+
+    it('skips migrations the patch last evaluated after', () => {
+        // 0.0.70 is past cycle (0.0.68) but before wavetable (0.0.97).
+        expect(ids('0.0.70')).toEqual([
+            'wavetable-pitch-first',
+            'cheby-block-dc',
+            'adsr-legacy-defaults',
+        ]);
+        // 0.0.97 conforms to wavetable; the two 0.0.102 changes still apply.
+        expect(ids('0.0.97')).toEqual([
+            'cheby-block-dc',
+            'adsr-legacy-defaults',
+        ]);
+    });
+
+    it('offers nothing to a patch evaluated at or after the newest change', () => {
+        expect(ids('0.0.102')).toEqual([]);
+        expect(ids('9.9.9')).toEqual([]);
+    });
+});

--- a/src/renderer/dsl/migrations/registry.ts
+++ b/src/renderer/dsl/migrations/registry.ts
@@ -1,0 +1,41 @@
+import { compareVersion } from '../../../shared/compareVersion';
+import { meta as adsrDefaultsMigration } from '../migrateAdsrDefaults';
+import { meta as chebyBlockDcMigration } from '../migrateChebyBlockDC';
+import { meta as cycleCallsMigration } from '../migrateCycleCalls';
+import { meta as wavetableArgsMigration } from '../migrateWavetableArgs';
+import type { MigrationMeta } from './types';
+import { NEXT_VERSION } from './types';
+
+export type { MigrationMeta, MigrationRunResult } from './types';
+export { NEXT_VERSION } from './types';
+
+/** Every known patch migration, in application order. New migrations register
+ *  by adding their `meta` here; the order field is the source of truth so the
+ *  array literal order does not matter. */
+export const MIGRATIONS: MigrationMeta[] = [
+    cycleCallsMigration,
+    wavetableArgsMigration,
+    chebyBlockDcMigration,
+    adsrDefaultsMigration,
+].sort((a, b) => a.order - b.order);
+
+/**
+ * The migrations a patch still needs, in application order, given the app
+ * version it was last successfully evaluated under. A migration that shipped
+ * after that version has not been applied to the patch's semantics yet:
+ *
+ * - An unreleased ({@link NEXT_VERSION}) migration is newer than any released
+ *   version, so no patch conforms to it yet — always offered.
+ * - A patch never evaluated (no stamp) is treated as eligible for any migration.
+ * - Otherwise the patch needs the migration iff it last evaluated before the
+ *   migration shipped.
+ */
+export function migrationsNeededFor(
+    evaluatedVersion: string | undefined,
+): MigrationMeta[] {
+    return MIGRATIONS.filter((migration) => {
+        if (migration.sinceVersion === NEXT_VERSION) return true;
+        if (evaluatedVersion === undefined) return true;
+        return compareVersion(evaluatedVersion, migration.sinceVersion) < 0;
+    });
+}

--- a/src/renderer/dsl/migrations/types.ts
+++ b/src/renderer/dsl/migrations/types.ts
@@ -1,0 +1,42 @@
+import type { MigrationModalSummary } from '../../components/MigrationDiffModal';
+
+/** Sentinel `sinceVersion` for a migration that has not shipped in a release
+ *  yet. `release.sh` rewrites it to the new version when cutting a release, so
+ *  the developer never has to guess the release number while authoring. Until
+ *  then it sorts as newer than any stamped version, so the migration is offered
+ *  on every patch built against the development tree. */
+export const NEXT_VERSION = 'next';
+
+/** The normalized outcome of running a migration, shared by the registry-driven
+ *  runner and the diff modal regardless of which migration produced it. */
+export interface MigrationRunResult {
+    /** The source after the migration (equal to the input when nothing or only
+     *  flagged-but-unrewritten constructs were found). */
+    migrated: string;
+    /** Whether the migration actually rewrote the source. */
+    changed: boolean;
+    /** Counts and skipped items for the diff modal. */
+    summary: MigrationModalSummary;
+}
+
+/** A migration's identity, the release it shipped in, and how to run it. One
+ *  `meta` is co-located with each migration's implementation; the registry
+ *  collects them into an ordered list. */
+export interface MigrationMeta {
+    /** Unique, stable identifier for this migration. The registry requires ids
+     *  to be distinct; it is not written into patches. */
+    id: string;
+    /** The release version the migration shipped in, or {@link NEXT_VERSION}
+     *  while unreleased. A patch last written before this version may need it. */
+    sinceVersion: string;
+    /** Application order when several migrations apply to one patch. Monotonic
+     *  and independent of `sinceVersion`, which disambiguates migrations that
+     *  ship in the same release. */
+    order: number;
+    /** Heading shown in the diff modal. */
+    title: string;
+    /** Label prefixing the modal's list of constructs left for manual review. */
+    skippedLabel?: string;
+    /** Run the migration against `source`, normalized for the runner/modal. */
+    run(source: string): MigrationRunResult;
+}

--- a/src/renderer/types/editor.ts
+++ b/src/renderer/types/editor.ts
@@ -6,6 +6,11 @@ export type EditorBuffer =
           content: string;
           dirty: boolean;
           isPreview?: boolean;
+          /** App version this buffer last evaluated successfully under. Read
+           *  from the file header on open, advanced on each successful evaluate,
+           *  and written back to the header on save. Gates which migrations the
+           *  patch still needs. Absent until the buffer first evaluates. */
+          evaluatedVersion?: string;
       }
     | {
           kind: 'untitled';
@@ -13,6 +18,7 @@ export type EditorBuffer =
           content: string;
           dirty: boolean;
           isPreview?: boolean;
+          evaluatedVersion?: string;
       };
 
 export type UnsavedBufferSnapshot =
@@ -21,11 +27,13 @@ export type UnsavedBufferSnapshot =
           id: string;
           filePath: string;
           content: string;
+          evaluatedVersion?: string;
       }
     | {
           kind: 'untitled';
           id: string;
           content: string;
+          evaluatedVersion?: string;
       };
 
 export interface ScopeView {

--- a/src/shared/compareVersion.test.ts
+++ b/src/shared/compareVersion.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { compareVersion } from './compareVersion';
+
+const sign = (n: number) => (n < 0 ? -1 : n > 0 ? 1 : 0);
+
+describe('compareVersion', () => {
+    it('orders by major, then minor, then patch', () => {
+        expect(sign(compareVersion('0.0.101', '0.0.102'))).toBe(-1);
+        expect(sign(compareVersion('0.1.0', '0.0.99'))).toBe(1);
+        expect(sign(compareVersion('1.0.0', '0.9.9'))).toBe(1);
+        expect(sign(compareVersion('0.0.68', '0.0.68'))).toBe(0);
+    });
+
+    it('treats missing components as zero', () => {
+        expect(sign(compareVersion('0.1', '0.1.0'))).toBe(0);
+        expect(sign(compareVersion('1', '1.0.0'))).toBe(0);
+        expect(sign(compareVersion('0.1', '0.1.1'))).toBe(-1);
+    });
+
+    it('does not NaN-out on a pre-release suffix (compares the core)', () => {
+        // The old inline comparator went all-false on these; the core must win.
+        expect(sign(compareVersion('1.2.0-beta.1', '1.2.0'))).toBe(0);
+        expect(sign(compareVersion('1.2.0-beta.1', '1.1.0'))).toBe(1);
+    });
+});

--- a/src/shared/compareVersion.ts
+++ b/src/shared/compareVersion.ts
@@ -1,0 +1,31 @@
+/**
+ * Compare two dotted version strings (e.g. `"0.0.101"`). Returns a negative
+ * number when `a` is older than `b`, `0` when they are equal, and a positive
+ * number when `a` is newer.
+ *
+ * Components are compared left-to-right as integers; a missing component counts
+ * as `0`, so `"0.1"` equals `"0.1.0"`. Only the numeric release core is
+ * compared — any `-suffix` (a pre-release tag) is dropped before parsing.
+ * Pre-release ordering is not modelled; the app ships plain `major.minor.patch`
+ * versions.
+ */
+export function compareVersion(a: string, b: string): number {
+    const pa = parseParts(a);
+    const pb = parseParts(b);
+    const len = Math.max(pa.length, pb.length);
+    for (let i = 0; i < len; i++) {
+        const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+        if (diff !== 0) return diff < 0 ? -1 : 1;
+    }
+    return 0;
+}
+
+function parseParts(version: string): number[] {
+    return version
+        .split('-')[0]
+        .split('.')
+        .map((part) => {
+            const n = parseInt(part, 10);
+            return Number.isFinite(n) ? n : 0;
+        });
+}

--- a/src/shared/ipcTypes.ts
+++ b/src/shared/ipcTypes.ts
@@ -22,6 +22,7 @@ import type {
 } from '@modular/core';
 import type schemas from '@modular/core/schemas.json';
 import type { SliderDefinition } from './dsl/sliderTypes';
+import type { PatchVersionStamp } from './patchVersionStamp';
 
 export type {
     PatchGraph,
@@ -231,6 +232,13 @@ export interface FSOperationResult {
     error?: string;
 }
 
+/** Result of reading a file: the editor-facing content (version stamp already
+ *  stripped) plus the version the patch last evaluated under, so the renderer
+ *  can decide which migrations the patch still needs. */
+export interface FSReadFileResult extends PatchVersionStamp {
+    content: string;
+}
+
 export interface WorkspaceFolder {
     path: string;
 }
@@ -297,6 +305,7 @@ export interface ContextMenuAction {
 export const IPC_CHANNELS = {
     // Schema operations
     GET_SCHEMAS: 'modular:get-schemas',
+    GET_APP_VERSION: 'modular:get-app-version',
 
     // DSL operations
     DSL_EXECUTE: 'modular:dsl:execute',
@@ -409,9 +418,7 @@ export const IPC_CHANNELS = {
 
 export const MENU_CHANNELS = {
     CLOSE_BUFFER: 'modular:menu:close-buffer',
-    MIGRATE_BUFFER: 'modular:menu:migrate-buffer',
-    MIGRATE_CHEBY_BLOCK_DC: 'modular:menu:migrate-cheby-block-dc',
-    MIGRATE_WAVETABLE: 'modular:menu:migrate-wavetable',
+    MIGRATE_TO_LATEST: 'modular:menu:migrate-to-latest',
     NEW_FILE: 'modular:menu:new-file',
     OPEN_ENGINE_HEALTH: 'modular:menu:open-engine-health',
     OPEN_MODULE_PROFILE: 'modular:menu:open-module-profile',
@@ -430,6 +437,7 @@ export const MENU_CHANNELS = {
 export interface IPCHandlers {
     // Schema operations
     [IPC_CHANNELS.GET_SCHEMAS]: () => typeof schemas;
+    [IPC_CHANNELS.GET_APP_VERSION]: () => string;
 
     // DSL operations
     [IPC_CHANNELS.DSL_EXECUTE]: (
@@ -519,10 +527,11 @@ export interface IPCHandlers {
     [IPC_CHANNELS.FS_SELECT_WORKSPACE]: () => WorkspaceFolder | null;
     [IPC_CHANNELS.FS_GET_WORKSPACE]: () => WorkspaceFolder | null;
     [IPC_CHANNELS.FS_LIST_FILES]: () => FileTreeEntry[];
-    [IPC_CHANNELS.FS_READ_FILE]: (filePath: string) => string;
+    [IPC_CHANNELS.FS_READ_FILE]: (filePath: string) => FSReadFileResult;
     [IPC_CHANNELS.FS_WRITE_FILE]: (
         filePath: string,
         content: string,
+        evaluatedVersion?: string,
     ) => FSOperationResult;
     [IPC_CHANNELS.FS_RENAME_FILE]: (
         oldPath: string,

--- a/src/shared/patchVersionStamp.test.ts
+++ b/src/shared/patchVersionStamp.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
     isStampablePath,
+    parsePatchVersionStamp,
     stampPatchVersionSource,
     stripPatchVersionStamp,
 } from './patchVersionStamp';
@@ -54,6 +55,33 @@ describe('stampPatchVersionSource', () => {
         const stamped = stampPatchVersionSource('', '0.0.1');
         expect(stamped).toBe(`/**\n * @operator\n * @version 0.0.1\n */\n`);
         expect(stripPatchVersionStamp(stamped)).toBe('');
+    });
+});
+
+describe('parsePatchVersionStamp', () => {
+    it('reads the last-evaluated version back out of a stamp', () => {
+        const stamped = stampPatchVersionSource(PATCH, '0.0.101');
+        expect(parsePatchVersionStamp(stamped)).toEqual({
+            evaluatedVersion: '0.0.101',
+        });
+    });
+
+    it('round-trips through a re-stamp at a newer version', () => {
+        const once = stampPatchVersionSource(PATCH, '0.0.101');
+        const twice = stampPatchVersionSource(once, '0.0.102');
+        expect(twice.match(/@version/g)).toHaveLength(1);
+        expect(parsePatchVersionStamp(twice)).toEqual({
+            evaluatedVersion: '0.0.102',
+        });
+    });
+
+    it('reports no version for an unstamped patch', () => {
+        expect(parsePatchVersionStamp(PATCH)).toEqual({});
+    });
+
+    it("ignores a user's own leading JSDoc", () => {
+        const withDoc = `/**\n * @version 9.9.9\n */\n\n${PATCH}`;
+        expect(parsePatchVersionStamp(withDoc)).toEqual({});
     });
 });
 

--- a/src/shared/patchVersionStamp.ts
+++ b/src/shared/patchVersionStamp.ts
@@ -1,8 +1,14 @@
 /**
- * Operator records the app version that last wrote a patch in a metadata block
- * at the top of the file. The block looks like a JSDoc comment whose first tag
- * is `@operator`, followed by `@version <semver>`, e.g. a block holding
- * `@operator` then `@version 0.0.101`.
+ * Operator records, in a metadata block at the top of a patch file, the app
+ * version under which the patch was last successfully evaluated. The block
+ * looks like a JSDoc comment whose first tag is `@operator`, followed by
+ * `@version <semver>`, e.g. a block holding `@operator` then `@version 0.0.101`.
+ *
+ * `@version` records the last version the patch successfully ran under, which
+ * makes it a faithful proxy for the engine semantics the patch is known to be
+ * compatible with: a migration that shipped after this version has not been
+ * applied to the patch yet, so the patch may need it (see the migration
+ * registry's selection).
  *
  * The block is written on save and stripped when the patch is loaded into the
  * editor, so it never appears to the user but always travels with the file on
@@ -13,6 +19,14 @@
  * Functions here are pure string transforms with no Electron dependency, so the
  * main-process file handlers and the unit tests share the same logic.
  */
+
+/** The metadata parsed out of a patch's leading Operator block. */
+export interface PatchVersionStamp {
+    /** The app version the patch was last successfully evaluated under, or
+     *  `undefined` when the file carries no Operator block (never evaluated, or
+     *  predating version stamping). */
+    evaluatedVersion?: string;
+}
 
 /** File extensions that carry the version stamp (Operator patch files). */
 const STAMPABLE_EXTENSIONS = ['.js', '.mjs'];
@@ -41,8 +55,33 @@ function isOperatorBlock(block: string): boolean {
     return /(^|[^\w@])@operator(?![\w-])/.test(block);
 }
 
-function buildBlock(version: string): string {
-    return ['/**', ' * @operator', ` * @version ${version}`, ' */'].join('\n');
+function buildBlock(evaluatedVersion: string): string {
+    return [
+        '/**',
+        ' * @operator',
+        ` * @version ${evaluatedVersion}`,
+        ' */',
+    ].join('\n');
+}
+
+/** Pull the value of a single `@tag` line out of an Operator block. */
+function readTag(block: string, tag: string): string | undefined {
+    const match = new RegExp(`@${tag}[^\\S\\n]+([^\\n*]+)`).exec(block);
+    return match ? match[1].trim() : undefined;
+}
+
+/**
+ * Read the version stamp from `content`. Returns the recorded
+ * last-evaluated version, or `undefined` when there is no Operator block. A
+ * leading comment that is not Operator's — a user's own header — is treated as
+ * no stamp.
+ */
+export function parsePatchVersionStamp(content: string): PatchVersionStamp {
+    const match = LEADING_BLOCK_COMMENT.exec(content);
+    if (!match || !isOperatorBlock(match[0])) {
+        return {};
+    }
+    return { evaluatedVersion: readTag(match[0], 'version') };
 }
 
 /**
@@ -59,15 +98,15 @@ export function stripPatchVersionStamp(content: string): string {
 }
 
 /**
- * Return `content` with a fresh metadata block for `version` at the top. Any
- * existing block is replaced first, so re-stamping is idempotent and always
- * reflects the version that wrote the file last.
+ * Return `content` with a fresh metadata block recording `evaluatedVersion` at
+ * the top. Any existing block is replaced first, so re-stamping is idempotent
+ * and always reflects the latest successful-evaluation version.
  */
 export function stampPatchVersionSource(
     content: string,
-    version: string,
+    evaluatedVersion: string,
 ): string {
     const body = stripPatchVersionStamp(content);
-    const block = buildBlock(version);
+    const block = buildBlock(evaluatedVersion);
     return body.length === 0 ? `${block}\n` : `${block}\n\n${body}`;
 }


### PR DESCRIPTION
## What

Replaces the three separate **Migrate \$X** menu commands with a single **Migrate patch to latest version** that runs every applicable migration in order, pausing on a per-step diff modal.

## How it works

- **Migration registry** (`src/renderer/dsl/migrations/`) — each migration co-locates a `meta` (`id`, `sinceVersion`, `order`, `run`). `migrationsNeededFor(evaluatedVersion)` returns the steps a patch still needs, gated on the app version it last successfully evaluated under.
- **Version stamping** — buffers carry an `evaluatedVersion`, read from the patch's `@version` header on open (new `GET_APP_VERSION` IPC), advanced on each successful evaluate, and written back on save. A migration that shipped *after* that version is offered; one at or before it is skipped.
- **`compareVersion`** — dotted-version comparator that drops a pre-release `-suffix` instead of producing `NaN`.
- **New `$adsr` migration** — pins the pre-0.0.102 envelope defaults (attack/decay/sustain/release/curve). The `$cheby` migration also gains the `.$m` mix-chain form.
- **Release automation** — migrations are authored with `sinceVersion: 'next'`; `release.sh` resolves every marker to the release version via `scripts/resolveMigrationVersions.mjs`, so authors never guess the release number.

## Chain flow fix

The diff modal's primary button now **advances the chain**: it applies the diff when there is one, or steps past a flagged/errored migration (labeled *Continue*) so the remaining migrations still run. Previously a mid-chain step with only manual-review items left the user with a disabled Apply and a Cancel that aborted every remaining step.

## Tests

`compareVersion`, `patchVersionStamp`, the migration registry, `$adsr`/`$cheby` migrations, and the diff modal — 70 unit tests pass. `tsc -b` clean, `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBvywuKnQVFwdggH6SkzX4