### PR TITLE
Replace warn-on-alloc audio-thread detector with panic-on-alloc + site backtrace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,17 +104,20 @@ Examples: `supersaw` — `init` seeds phases + `inv_sample_rate` (sr-only); `on_
 
 ### Detecting audio-thread allocations (dev-only)
 
-`yarn build-native-alloc` builds the rust code with a runtime allocation detector compiled in (`--features=alloc-detector` on `crates/modular`). It installs a `#[global_allocator]` that flags any heap allocation/deallocation made on the audio thread and writes a warning to **stderr** — the `rust`-labelled stream in the `concurrently` output — naming the offending module, e.g.:
+`yarn build-native-alloc` builds the rust code with a runtime allocation detector compiled in (`--features=alloc-detector` on `crates/modular`). It installs a `#[global_allocator]` that, on the **first** heap allocation/deallocation made in the audio DSP region, captures a backtrace at the allocation site and panics with it once the region exits. The audio callback's `catch_unwind` catches that panic, so the existing audio-thread-panic path emits silence and restarts the stream; the `panic_log` file and **stderr** carry the allocation-site backtrace pointing at the offending code, e.g.:
 
 ```
-[alloc-detector] AUDIO-THREAD ALLOC in module "osc_3" — 48 bytes (×127 since last report). Move allocation out of process()/update() into init()/on_patch_update() (see CLAUDE.md lifecycle rules).
+thread '<unnamed>' panicked: audio-thread heap allocation of 48 bytes inside the no-alloc region. Move it out of process()/update() into init()/on_patch_update() (see CLAUDE.md lifecycle rules). Allocation-site backtrace:
+   ...
+   <modular_core::dsp::oscillators::...>::update
+   ...
 ```
 
 Use it to verify the "no heap allocation on the audio thread" rule above. Notes:
 
-- **Opt-in only.** Plain `yarn build-native` never compiles the detector in (zero cost, byte-identical binary). The detector installs a process-wide global allocator — never enable the feature in a shipped build.
-- **Auto-attribution.** Module profiling is force-enabled so attribution works with the editor profiler closed. Allocations on the audio thread but outside any module/scope frame report as `"<unknown>"`.
-- **Detect-and-flag, never fail.** The real `System` allocation always runs first; the detector only records. All formatting/logging happens on a background thread, never the audio thread. Dropped/dealloc events and running totals are summarized periodically on the same `[alloc-detector]` stderr stream.
+- **Opt-in only.** Plain `yarn build-native` never compiles the detector in (zero cost, byte-identical binary): `panic_on_alloc` inlines to a direct call and no global allocator is installed. The detector installs a process-wide global allocator — never enable the feature in a shipped build.
+- **Stops at the first violation.** It panics and restarts on the first audio-thread (de)allocation rather than accumulating, so a single offending alloc or dealloc (including a patch-apply dealloc such as scope teardown) trips it.
+- **Site capture is safe; the panic is deferred.** The real `System` allocation always runs first; the backtrace is captured at the site (a re-entrancy guard keeps the capture's own allocations from recursing) but the panic fires only after the no-alloc region exits, where allocating and unwinding are safe.
 
 ## Conventions
 

--- a/crates/modular/Cargo.toml
+++ b/crates/modular/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 tracy   = ["modular_core/tracy", "tracy-client", "profiling/profile-with-tracy"]
 # Dev-only audio-thread allocation detector (see src/alloc_detector.rs). Off by
 # default; enabled by `yarn start:alloc` or `build-native-alloc`. Installs a global allocator — never ship.
-alloc-detector = ["modular_core/alloc-detector"]
+alloc-detector = []
 
 [dependencies]
 aubio = { version = "0.2", features = ["builtin", "bindgen"] }

--- a/crates/modular/src/alloc_detector.rs
+++ b/crates/modular/src/alloc_detector.rs
@@ -1,345 +1,184 @@
 //! Dev-only runtime detector for heap allocation/deallocation on the audio thread.
 //!
 //! Gated behind the `alloc-detector` Cargo feature (off by default). `yarn start`
-//! never compiles it in — the default build installs no global allocator and is
-//! byte-identical. `yarn start:alloc` or `yarn build-native-alloc` builds with `--features=alloc-detector`,
-//! which installs [`AudioAllocDetector`] as the process `#[global_allocator]`.
+//! never compiles it in — the default build installs no global allocator, and
+//! [`panic_on_alloc`] is an inlined pass-through, so the binary is byte-identical.
+//! `yarn start:alloc` or `yarn build-native-alloc` builds with
+//! `--features=alloc-detector`, which installs [`AudioAllocDetector`] as the
+//! process `#[global_allocator]`.
 //!
-//! How it works: every allocation/deallocation in the native addon runs the real
-//! `std::alloc::System` call **first**, then — only while the current thread is
-//! inside an [`AudioThreadScope`] (entered at the top of the cpal callback) —
-//! records a fixed-size `Copy` event into a pre-allocated lock-free SPSC ring. A
-//! dedicated background thread drains the ring and writes rate-limited warnings to
-//! stderr, naming the offending module via the profiler's currently-running frame.
+//! How it works: [`panic_on_alloc`] runs its closure inside a no-alloc region
+//! (the audio DSP work). While that region is active, [`AudioAllocDetector`]
+//! captures a backtrace at the site of the **first** heap (de)allocation made on
+//! that thread. Once the region exits — where allocating, and therefore panicking,
+//! is safe again — `panic_on_alloc` panics with that allocation-site backtrace.
+//! The audio callback's `catch_unwind` catches the panic, which flips the
+//! poisoned-thread flag and drives the existing emit-silence-and-restart path; the
+//! `panic_log` hook and the panic payload record the backtrace pointing at the
+//! offending code.
+//!
+//! All state is thread-local, so two cpal callback threads briefly overlapping
+//! during a device/sample-rate switch each capture into their own slot with no
+//! synchronization.
 
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::cell::{Cell, UnsafeCell};
-use std::sync::Once;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(feature = "alloc-detector")]
+mod imp {
+    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::backtrace::Backtrace;
+    use std::cell::{Cell, RefCell};
 
-use rtrb::{Consumer, Producer, RingBuffer};
+    thread_local! {
+        /// Nonzero while this thread is inside a [`panic_on_alloc`] region. The
+        /// allocator only records while it is set, so only the audio DSP is policed.
+        /// `const` init keeps the TLS access allocation-free.
+        static FORBID_DEPTH: Cell<u32> = const { Cell::new(0) };
+        /// Re-entrancy backstop: set while capturing a backtrace (which itself
+        /// allocates), so the capture's own allocations are not recorded.
+        static CAPTURING: Cell<bool> = const { Cell::new(false) };
+        /// The first forbidden (de)allocation seen in the current region, captured
+        /// at its site. [`panic_on_alloc`] takes it once the region exits.
+        static CAPTURED: RefCell<Option<Captured>> = const { RefCell::new(None) };
+    }
 
-/// Capacity of the SPSC event ring. Sized to cover several logger drain intervals
-/// of a module allocating once per sample before overflow — and overflow is
-/// counted (`DROPPED_EVENTS`), not fatal.
-const RING_CAPACITY: usize = 8192;
+    /// A forbidden allocator event captured at its site.
+    struct Captured {
+        backtrace: Backtrace,
+        size: usize,
+        is_dealloc: bool,
+    }
 
-/// Max module-id bytes carried per event. Longer ids are truncated for the
-/// diagnostic line; the alloc count and size stay accurate. Must match the buffer
-/// size of [`modular_core::profiling::current_module_id_into`].
-const MODULE_ID_CAP: usize = 64;
-
-/// A fixed-size, `Copy`, `Drop`-free allocation event — safe to push to the ring
-/// and to drop on the audio thread (dropping it frees nothing).
-#[derive(Clone, Copy)]
-struct AllocEvent {
-    module_id: [u8; MODULE_ID_CAP],
-    module_id_len: u8,
-    size: u32,
-    is_dealloc: bool,
-}
-
-thread_local! {
-    /// Set while the current thread is inside the cpal audio callback. This is the
-    /// hot fast-path: a single `Cell::get` that short-circuits recording on every
-    /// non-audio thread. `const` init keeps the TLS access allocation-free.
-    static ON_AUDIO: Cell<bool> = const { Cell::new(false) };
-    /// Re-entrancy backstop: set while `record_event` runs, so an allocation made
-    /// by the recording path itself (there should be none) cannot recurse.
-    static IN_DETECTOR: Cell<bool> = const { Cell::new(false) };
-}
-
-/// Running totals of audio-thread allocator traffic, plus events dropped because
-/// the ring was full. These survive ring overflow, so the logger can always report
-/// true magnitude even when individual events were dropped.
-static AUDIO_ALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
-static AUDIO_DEALLOC_COUNT: AtomicU64 = AtomicU64::new(0);
-static AUDIO_ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
-static DROPPED_EVENTS: AtomicU64 = AtomicU64::new(0);
-
-/// Producer half of the ring. `rtrb`'s `Producer` is single-producer and not
-/// `Sync`, so all access must be exclusive. Exclusivity is enforced at runtime by
-/// `PRODUCER_BUSY` (below), *not* by assuming a single audio thread: during a
-/// device or sample-rate switch the new cpal output stream starts before the old
-/// one is dropped, so two callback threads (both with `ON_AUDIO` set) can be
-/// briefly live at once. Wrapped in `UnsafeCell` so it can live in a `static`.
-struct ProducerCell(UnsafeCell<Option<Producer<AllocEvent>>>);
-
-// SAFETY: the inner `Producer` is written once during `init_detector` (before any
-// `ON_AUDIO` is set) and thereafter accessed only by the thread that wins the
-// `PRODUCER_BUSY` claim, so there is exactly one accessor at a time. The
-// Acquire/Release pairing on that claim publishes one accessor's writes to the
-// next, keeping the producer's non-atomic cached state coherent. No two threads
-// ever touch it concurrently, so the lack of built-in synchronization is sound.
-unsafe impl Sync for ProducerCell {}
-
-static RING_PRODUCER: ProducerCell = ProducerCell(UnsafeCell::new(None));
-
-/// Single-claim token guarding `RING_PRODUCER`. A thread must win this CAS before
-/// touching the producer; a thread that loses (another audio thread is mid-push
-/// during a stream swap) drops its event rather than racing the SPSC ring. Lock-
-/// free and non-blocking — never spins or waits on the audio thread.
-static PRODUCER_BUSY: AtomicBool = AtomicBool::new(false);
-
-/// True once the ring is built and the producer published. Until then the audio
-/// thread only bumps the totals (no ring to push to yet).
-static INITIALIZED: AtomicBool = AtomicBool::new(false);
-
-/// Guards one-time construction of the ring + logger thread.
-static INIT: Once = Once::new();
-
-/// RAII guard marking the current thread as the audio thread for the detector's
-/// duration. Entered at the top of the cpal callback; dropped when the callback
-/// returns (including on a caught unwind, since it is bound outside `catch_unwind`).
-pub struct AudioThreadScope;
-
-impl AudioThreadScope {
-    /// Mark the current thread as the audio thread. Lazily builds the ring and
-    /// spawns the logger thread on first use (a one-off cost on the first callback,
-    /// acceptable for an opt-in diagnostic build), then sets the `ON_AUDIO` flag.
+    /// Record one allocator event, called from the [`AudioAllocDetector`] methods
+    /// **after** the real `System` call. Outside a no-alloc region it is a single
+    /// `Cell::get`; the first event inside one captures a site backtrace.
     #[inline]
-    pub fn enter() -> AudioThreadScope {
-        // Runs before `ON_AUDIO` is set, so the allocations it makes (ring buffer,
-        // logger thread) are not recorded.
-        INIT.call_once(init_detector);
-        ON_AUDIO.with(|c| c.set(true));
-        AudioThreadScope
-    }
-}
-
-impl Drop for AudioThreadScope {
-    #[inline]
-    fn drop(&mut self) {
-        ON_AUDIO.with(|c| c.set(false));
-    }
-}
-
-/// One-time setup, run on the audio thread on the first callback: build the ring,
-/// publish the producer, and hand the consumer to a background logger thread.
-fn init_detector() {
-    let (producer, consumer) = RingBuffer::new(RING_CAPACITY);
-    // SAFETY: still single-threaded with respect to the producer — no audio
-    // callback is recording yet (this runs before `ON_AUDIO` is ever set), and the
-    // logger thread (which only touches the consumer) is spawned below.
-    unsafe {
-        *RING_PRODUCER.0.get() = Some(producer);
-    }
-    // Publish the producer before flipping the flag so the audio thread never sees
-    // `INITIALIZED == true` alongside a `None` producer.
-    INITIALIZED.store(true, Ordering::Release);
-    spawn_logger(consumer);
-}
-
-/// Record one allocator event. Called from the `GlobalAlloc` impl **after** the
-/// real `System` call. Returns immediately on any non-audio thread.
-#[inline]
-fn record_event(size: usize, is_dealloc: bool) {
-    // Fast path: nothing to do unless we're on the audio thread.
-    if !ON_AUDIO.with(|c| c.get()) {
-        return;
-    }
-    // Re-entrancy backstop (the body below should never allocate, but be safe).
-    if IN_DETECTOR.with(|c| c.get()) {
-        return;
-    }
-    IN_DETECTOR.with(|c| c.set(true));
-
-    if is_dealloc {
-        AUDIO_DEALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
-    } else {
-        AUDIO_ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
-        AUDIO_ALLOC_BYTES.fetch_add(size as u64, Ordering::Relaxed);
-    }
-
-    if INITIALIZED.load(Ordering::Acquire) {
-        let mut module_id = [0u8; MODULE_ID_CAP];
-        let module_id_len = modular_core::profiling::current_module_id_into(&mut module_id);
-        let event = AllocEvent {
-            module_id,
-            module_id_len,
-            size: size.min(u32::MAX as usize) as u32,
-            is_dealloc,
-        };
-        // Claim exclusive access to the single SPSC producer before touching it.
-        // Non-blocking: if another audio thread holds the claim (possible for a few
-        // callbacks during a device/sample-rate switch, when the new stream starts
-        // before the old one is dropped), drop this event rather than race the ring.
-        if PRODUCER_BUSY
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
-        {
-            // SAFETY: the CAS guarantees this thread is the only one accessing the
-            // producer for the duration of the push (see `ProducerCell`); `push`
-            // into the pre-allocated ring never allocates.
-            unsafe {
-                if let Some(producer) = (*RING_PRODUCER.0.get()).as_mut()
-                    && producer.push(event).is_err()
-                {
-                    DROPPED_EVENTS.fetch_add(1, Ordering::Relaxed);
-                }
-            }
-            PRODUCER_BUSY.store(false, Ordering::Release);
-        } else {
-            DROPPED_EVENTS.fetch_add(1, Ordering::Relaxed);
+    fn record(size: usize, is_dealloc: bool) {
+        if FORBID_DEPTH.with(|d| d.get()) == 0 {
+            return;
         }
-    }
-
-    IN_DETECTOR.with(|c| c.set(false));
-}
-
-/// Spawn the background logger thread that owns the ring consumer. It force-enables
-/// module profiling so the audio thread populates frames (and allocations can be
-/// attributed) even with the profiling UI closed.
-fn spawn_logger(consumer: Consumer<AllocEvent>) {
-    let spawned = std::thread::Builder::new()
-        .name("alloc-detector-log".to_string())
-        .spawn(move || {
-            // Force module profiling on independently of the UI enable refcount and
-            // the device-switch reset (both drive the shared `ENABLED` flag), so the
-            // audio thread always pushes frames and allocations can be attributed to
-            // the running module. `refresh_enabled` ORs this in every callback.
-            modular_core::profiling::set_force_enabled(true);
-            logger_loop(consumer);
+        if CAPTURING.with(|c| c.get()) {
+            return;
+        }
+        CAPTURING.with(|c| c.set(true));
+        CAPTURED.with(|slot| {
+            // Drop the shared borrow before `force_capture` so the capture's own
+            // (re-entrant, `CAPTURING`-skipped) allocations can never collide with
+            // the exclusive borrow taken below.
+            let empty = slot.borrow().is_none();
+            if empty {
+                let backtrace = Backtrace::force_capture();
+                *slot.borrow_mut() = Some(Captured {
+                    backtrace,
+                    size,
+                    is_dealloc,
+                });
+            }
         });
-    if spawned.is_err() {
-        eprintln!("[alloc-detector] failed to spawn logger thread; attribution disabled");
+        CAPTURING.with(|c| c.set(false));
     }
-}
 
-/// Per-offender accumulation between reports.
-#[derive(Default)]
-struct Offender {
-    /// Events seen since the last report line for this key.
-    pending: u64,
-    /// Most recent allocation size for this key (matches the plan's per-line size).
-    last_size: u32,
-}
+    /// Bumps [`FORBID_DEPTH`] for the lifetime of the no-alloc region, restoring it
+    /// on drop so a panic mid-region still exits the region cleanly.
+    struct ForbidGuard;
 
-/// Snapshot of the running totals, for change-detection on the summary line.
-#[derive(Clone, Copy, Default, PartialEq)]
-struct Totals {
-    allocs: u64,
-    deallocs: u64,
-    bytes: u64,
-    dropped: u64,
-}
-
-/// Drain → dedup/rate-limit → stderr. Runs forever on the logger thread; all heap
-/// use here (`HashMap`, `String`, `format!`) is fine because this is not the audio
-/// thread (the `ON_AUDIO` gate is false here, so these allocations are ignored).
-fn logger_loop(mut consumer: Consumer<AllocEvent>) {
-    use std::collections::HashMap;
-    use std::time::{Duration, Instant};
-
-    let drain_interval = Duration::from_millis(200);
-    let report_interval = Duration::from_millis(1000);
-
-    let mut offenders: HashMap<([u8; MODULE_ID_CAP], u8, bool), Offender> = HashMap::new();
-    let mut last_report = Instant::now();
-    let mut last_totals = Totals::default();
-
-    loop {
-        while let Ok(event) = consumer.pop() {
-            let key = (event.module_id, event.module_id_len, event.is_dealloc);
-            let offender = offenders.entry(key).or_default();
-            offender.pending += 1;
-            offender.last_size = event.size;
+    impl ForbidGuard {
+        #[inline]
+        fn enter() -> ForbidGuard {
+            FORBID_DEPTH.with(|d| d.set(d.get() + 1));
+            ForbidGuard
         }
+    }
 
-        if last_report.elapsed() >= report_interval {
-            for ((id_bytes, id_len, is_dealloc), offender) in offenders.iter_mut() {
-                if offender.pending == 0 {
-                    continue;
-                }
-                let kind = if *is_dealloc { "DEALLOC" } else { "ALLOC" };
-                if *id_len == 0 {
-                    eprintln!(
-                        "[alloc-detector] AUDIO-THREAD {kind} in module \"<unknown>\" \
-                         (no active profiler frame — allocation outside any module/scope, \
-                         or profiling not yet enabled) — {} bytes (×{} since last report).",
-                        offender.last_size, offender.pending,
-                    );
-                } else {
-                    let name = String::from_utf8_lossy(&id_bytes[..*id_len as usize]);
-                    eprintln!(
-                        "[alloc-detector] AUDIO-THREAD {kind} in module \"{name}\" — {} bytes \
-                         (×{} since last report). Move allocation out of process()/update() into \
-                         init()/on_patch_update() (see CLAUDE.md lifecycle rules).",
-                        offender.last_size, offender.pending,
-                    );
-                }
-                offender.pending = 0;
-            }
+    impl Drop for ForbidGuard {
+        #[inline]
+        fn drop(&mut self) {
+            FORBID_DEPTH.with(|d| d.set(d.get() - 1));
+        }
+    }
 
-            let totals = Totals {
-                allocs: AUDIO_ALLOC_COUNT.load(Ordering::Relaxed),
-                deallocs: AUDIO_DEALLOC_COUNT.load(Ordering::Relaxed),
-                bytes: AUDIO_ALLOC_BYTES.load(Ordering::Relaxed),
-                dropped: DROPPED_EVENTS.load(Ordering::Relaxed),
+    /// Run `f` forbidding heap (de)allocation on this thread. The first violation
+    /// is captured with a site backtrace; this then panics with it **after** the
+    /// region exits (`FORBID_DEPTH` back to 0), where allocating to format the
+    /// message and unwinding are both safe. The audio callback's `catch_unwind`
+    /// catches the panic and drives the restart path.
+    pub fn panic_on_alloc<T>(f: impl FnOnce() -> T) -> T {
+        CAPTURED.with(|slot| *slot.borrow_mut() = None);
+        let ret = {
+            let _guard = ForbidGuard::enter();
+            f()
+        };
+        if let Some(c) = CAPTURED.with(|slot| slot.borrow_mut().take()) {
+            let kind = if c.is_dealloc {
+                "deallocation"
+            } else {
+                "allocation"
             };
-            if totals != last_totals {
-                eprintln!(
-                    "[alloc-detector] totals: {} allocs / {} deallocs / {} bytes on audio thread \
-                     ({} events dropped, ring full)",
-                    totals.allocs, totals.deallocs, totals.bytes, totals.dropped,
-                );
-                last_totals = totals;
+            panic!(
+                "audio-thread heap {kind} of {n} bytes inside the no-alloc region. \
+                 Move it out of process()/update() into init()/on_patch_update() \
+                 (see CLAUDE.md lifecycle rules). Allocation-site backtrace:\n{bt}",
+                n = c.size,
+                bt = c.backtrace,
+            );
+        }
+        ret
+    }
+
+    /// The global allocator installed by the `alloc-detector` feature build. Every
+    /// method delegates to `std::alloc::System` (so allocation behavior is
+    /// unchanged) and then records the event via [`record`].
+    pub struct AudioAllocDetector;
+
+    // SAFETY: every method performs the real `System` operation first and returns
+    // its result unchanged; `record` only reads/writes thread-locals and (on the
+    // first violation in a region) captures a backtrace, never affecting the
+    // returned pointer. The detector never returns null for a successful System
+    // allocation and never frees early.
+    unsafe impl GlobalAlloc for AudioAllocDetector {
+        #[inline]
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            let ptr = unsafe { System.alloc(layout) };
+            if !ptr.is_null() {
+                record(layout.size(), false);
             }
-
-            // Drop fully-reported entries (all have pending == 0 here) so a long
-            // session with many distinct module ids can't grow the map without bound.
-            offenders.retain(|_, o| o.pending != 0);
-
-            last_report = Instant::now();
+            ptr
         }
 
-        std::thread::sleep(drain_interval);
+        #[inline]
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            unsafe { System.dealloc(ptr, layout) };
+            record(layout.size(), true);
+        }
+
+        #[inline]
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            let ptr = unsafe { System.alloc_zeroed(layout) };
+            if !ptr.is_null() {
+                record(layout.size(), false);
+            }
+            ptr
+        }
+
+        #[inline]
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            // Delegate to System's realloc (may resize in place) rather than the
+            // default alloc+copy+dealloc, so the addon's allocation behavior is
+            // unperturbed. A realloc still touches the allocator, so flag it.
+            let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+            if !new_ptr.is_null() {
+                record(new_size, false);
+            }
+            new_ptr
+        }
     }
 }
 
-/// The global allocator installed by the `alloc-detector` feature build. Every
-/// method delegates to `std::alloc::System` (so allocation behavior is unchanged)
-/// and then records the event via [`record_event`].
-pub struct AudioAllocDetector;
+#[cfg(feature = "alloc-detector")]
+pub use imp::{AudioAllocDetector, panic_on_alloc};
 
-// SAFETY: every method performs the real `System` operation first and returns its
-// result unchanged; `record_event` only reads thread-locals / atomics and pushes
-// to a pre-allocated ring, never affecting the returned pointer. The detector never
-// returns null for a successful System allocation and never frees early.
-unsafe impl GlobalAlloc for AudioAllocDetector {
-    #[inline]
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc(layout) };
-        if !ptr.is_null() {
-            record_event(layout.size(), false);
-        }
-        ptr
-    }
-
-    #[inline]
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe { System.dealloc(ptr, layout) };
-        record_event(layout.size(), true);
-    }
-
-    #[inline]
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        let ptr = unsafe { System.alloc_zeroed(layout) };
-        if !ptr.is_null() {
-            record_event(layout.size(), false);
-        }
-        ptr
-    }
-
-    #[inline]
-    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        // Delegate to System's realloc (may resize in place) rather than the
-        // default alloc+copy+dealloc, so the addon's allocation behavior is
-        // unperturbed. A realloc still touches the allocator, so flag it.
-        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
-        if !new_ptr.is_null() {
-            record_event(new_size, false);
-        }
-        new_ptr
-    }
+/// Pass-through when the detector is not compiled in: runs `f` directly, so the
+/// audio callback's wrapping is zero-cost in the default build.
+#[cfg(not(feature = "alloc-detector"))]
+#[inline(always)]
+pub fn panic_on_alloc<T>(f: impl FnOnce() -> T) -> T {
+    f()
 }

--- a/crates/modular/src/alloc_detector.rs
+++ b/crates/modular/src/alloc_detector.rs
@@ -114,8 +114,7 @@ mod imp {
             };
             panic!(
                 "audio-thread heap {kind} of {n} bytes inside the no-alloc region. \
-                 Move it out of process()/update() into init()/on_patch_update() \
-                 (see CLAUDE.md lifecycle rules). Allocation-site backtrace:\n{bt}",
+                Allocation-site backtrace:\n{bt}",
                 n = c.size,
                 bt = c.backtrace,
             );

--- a/crates/modular/src/audio.rs
+++ b/crates/modular/src/audio.rs
@@ -2109,7 +2109,11 @@ impl AudioProcessor {
         }
 
         let old_order_ids = std::mem::replace(&mut self.process_order_ids, process_order_ids);
-        if self.garbage_tx.push(GarbageItem::OrderIds(old_order_ids)).is_err() {
+        if self
+            .garbage_tx
+            .push(GarbageItem::OrderIds(old_order_ids))
+            .is_err()
+        {
             // Queue full (GARBAGE_QUEUE_CAPACITY is generous): the old order ids drop
             // here as a fallback rather than blocking the audio thread.
         }
@@ -2415,342 +2419,353 @@ where
                     }
                     return;
                 }
-                // Dev-only: mark this thread as the audio thread so the global
-                // allocation detector records (and attributes) any alloc/dealloc
-                // made below. Placed after the panicked-flag early return and
-                // outside `catch_unwind`, so the guard's `Drop` runs even on a
-                // caught unwind. Compiles to nothing without `--features=alloc-detector`.
-                #[cfg(feature = "alloc-detector")]
-                let _alloc_scope = crate::alloc_detector::AudioThreadScope::enter();
+                // Dev-only: `panic_on_alloc` forbids heap (de)allocation in the DSP
+                // region below; a violation panics with a site backtrace, caught by
+                // this `catch_unwind` so the poisoned-thread path restarts the stream.
+                // Inlined to a direct call without `--features=alloc-detector`.
                 let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    use modular_core::types::{ROOT_CLOCK_ID, ROOT_ID};
-                    profiling::scope!("audio_callback");
+                    crate::alloc_detector::panic_on_alloc(|| {
+                        use modular_core::types::{ROOT_CLOCK_ID, ROOT_ID};
+                        profiling::scope!("audio_callback");
 
-                    let callback_start = Instant::now();
+                        let callback_start = Instant::now();
 
-                    // Mirror the main-thread enable atomic into the audio thread's
-                    // profiler TLS. Cheap relaxed load once per callback.
-                    modular_core::profiling::refresh_enabled();
+                        // Mirror the main-thread enable atomic into the audio thread's
+                        // profiler TLS. Cheap relaxed load once per callback.
+                        modular_core::profiling::refresh_enabled();
 
-                    // Process any pending commands from the main thread
-                    {
-                        profiling::scope!("process_commands");
-                        audio_processor.process_commands();
-                    }
-
-                    // Capture Link session state once per buffer (before frame loop).
-                    audio_processor
-                        .link
-                        .capture_buffer_state(audio_processor.sample_rate);
-
-                    // Operator transport is decoupled from Link peer transport:
-                    // peers never start or stop Operator. The only Link-driven transport
-                    // action is releasing a locally-initiated quantized start when the
-                    // shared timeline reaches a bar boundary.
-                    if audio_processor.link.check_pending_start_release() {
-                        audio_processor
-                            .stopped
-                            .store(false, std::sync::atomic::Ordering::SeqCst);
-                        let msg = modular_core::types::Message::Clock(ClockMessages::Start);
-                        let _ = audio_processor.patch.dispatch_message(&msg);
-                    }
-
-                    // Write Link state to transport meter for UI visibility. Done
-                    // BEFORE the is_stopped() guard so the UI always shows the
-                    // free-running Link phase, even when Operator is stopped.
-                    audio_processor
-                        .link
-                        .write_meter(&audio_processor.transport_meter);
-
-                    let num_frames = output.len() / num_channels;
-                    let block_size = audio_processor.block_size;
-
-                    // Initial block-boundary entry: either fresh callback at a clean
-                    // boundary, or resuming mid-block from the previous callback.
-                    // Either way, eager-fill ROOT_CLOCK under THIS callback's
-                    // host-time anchor for the samples we will emit.
-                    if audio_processor.block_pos >= block_size {
-                        for module in audio_processor.patch.sampleables.values() {
-                            module.start_block();
+                        // Process any pending commands from the main thread
+                        {
+                            profiling::scope!("process_commands");
+                            audio_processor.process_commands();
                         }
-                        audio_processor.pull_input_block(&mut input_reader);
-                        audio_processor.block_pos = 0;
-                    }
 
-                    let mut written: usize = 0;
+                        // Capture Link session state once per buffer (before frame loop).
+                        audio_processor
+                            .link
+                            .capture_buffer_state(audio_processor.sample_rate);
 
-                    {
-                        let eager_end = block_size.min(audio_processor.block_pos + num_frames);
-                        audio_processor.eager_fill_clock(
-                            audio_processor.block_pos,
-                            eager_end,
-                            written,
-                        );
-                    }
+                        // Operator transport is decoupled from Link peer transport:
+                        // peers never start or stop Operator. The only Link-driven transport
+                        // action is releasing a locally-initiated quantized start when the
+                        // shared timeline reaches a bar boundary.
+                        if audio_processor.link.check_pending_start_release() {
+                            audio_processor
+                                .stopped
+                                .store(false, std::sync::atomic::Ordering::SeqCst);
+                            let msg = modular_core::types::Message::Clock(ClockMessages::Start);
+                            let _ = audio_processor.patch.dispatch_message(&msg);
+                        }
 
-                    {
-                        profiling::scope!("process_frames");
-                        while written < num_frames {
-                            // Cross internal block boundary mid-callback.
-                            if audio_processor.block_pos >= block_size {
-                                for module in audio_processor.patch.sampleables.values() {
-                                    module.start_block();
+                        // Write Link state to transport meter for UI visibility. Done
+                        // BEFORE the is_stopped() guard so the UI always shows the
+                        // free-running Link phase, even when Operator is stopped.
+                        audio_processor
+                            .link
+                            .write_meter(&audio_processor.transport_meter);
+
+                        let num_frames = output.len() / num_channels;
+                        let block_size = audio_processor.block_size;
+
+                        // Initial block-boundary entry: either fresh callback at a clean
+                        // boundary, or resuming mid-block from the previous callback.
+                        // Either way, eager-fill ROOT_CLOCK under THIS callback's
+                        // host-time anchor for the samples we will emit.
+                        if audio_processor.block_pos >= block_size {
+                            for module in audio_processor.patch.sampleables.values() {
+                                module.start_block();
+                            }
+                            audio_processor.pull_input_block(&mut input_reader);
+                            audio_processor.block_pos = 0;
+                        }
+
+                        let mut written: usize = 0;
+
+                        {
+                            let eager_end = block_size.min(audio_processor.block_pos + num_frames);
+                            audio_processor.eager_fill_clock(
+                                audio_processor.block_pos,
+                                eager_end,
+                                written,
+                            );
+                        }
+
+                        {
+                            profiling::scope!("process_frames");
+                            while written < num_frames {
+                                // Cross internal block boundary mid-callback.
+                                if audio_processor.block_pos >= block_size {
+                                    for module in audio_processor.patch.sampleables.values() {
+                                        module.start_block();
+                                    }
+                                    audio_processor.pull_input_block(&mut input_reader);
+                                    audio_processor.block_pos = 0;
+                                    let eager_end = block_size.min(num_frames - written);
+                                    audio_processor.eager_fill_clock(0, eager_end, written);
                                 }
-                                audio_processor.pull_input_block(&mut input_reader);
-                                audio_processor.block_pos = 0;
-                                let eager_end = block_size.min(num_frames - written);
-                                audio_processor.eager_fill_clock(0, eager_end, written);
-                            }
 
-                            let scan_end =
-                                block_size.min(audio_processor.block_pos + (num_frames - written));
+                                let scan_end = block_size
+                                    .min(audio_processor.block_pos + (num_frames - written));
 
-                            // Resolve trigger sample for queued patch swap.
-                            let trigger_sample: Option<usize> =
-                                match audio_processor.queued_update.as_ref().map(|(_, t)| t) {
-                                    Some(QueuedTrigger::Immediate) => {
-                                        Some(audio_processor.block_pos)
-                                    }
-                                    Some(QueuedTrigger::NextBar) => audio_processor.scan_trigger(
-                                        "barTrigger",
-                                        audio_processor.block_pos,
-                                        scan_end,
-                                    ),
-                                    Some(QueuedTrigger::NextBeat) => audio_processor.scan_trigger(
-                                        "beatTrigger",
-                                        audio_processor.block_pos,
-                                        scan_end,
-                                    ),
-                                    None => None,
-                                };
-
-                            let end = trigger_sample.map(|n| n.min(scan_end)).unwrap_or(scan_end);
-
-                            // Force every module to advance to `end`, in cache-efficient
-                            // producer-before-consumer order, so modules not reachable from
-                            // the output or any scope still process. The root/scope reads in
-                            // the drain below then become pure cache hits. Skipped while
-                            // stopped so the patch freezes on stop — the drain still ramps
-                            // connected modules out via the root pull during the fade.
-                            if end > audio_processor.block_pos && !audio_processor.is_stopped() {
-                                audio_processor.process_all_modules_to(end);
-                            }
-
-                            // Drain [block_pos, end) into cpal output, inlining the
-                            // volume-change state machine + soft clip that
-                            // `FinalStateProcessor` used to provide per-frame.
-                            if end > audio_processor.block_pos {
-                                let mut scope_guard = audio_processor.scope_collection.try_lock();
-                                let mut writer_guard = recording_writer.try_lock();
-                                for i in audio_processor.block_pos..end {
-                                    let is_stopped = audio_processor.is_stopped();
-                                    match (final_state_processor.prev_is_stopped, is_stopped) {
-                                        (true, false) => {
-                                            final_state_processor.volume_change =
-                                                VolumeChange::None;
-                                            final_state_processor.attenuation_factor = 1.0;
+                                // Resolve trigger sample for queued patch swap.
+                                let trigger_sample: Option<usize> =
+                                    match audio_processor.queued_update.as_ref().map(|(_, t)| t) {
+                                        Some(QueuedTrigger::Immediate) => {
+                                            Some(audio_processor.block_pos)
                                         }
-                                        (false, true) => {
-                                            final_state_processor.volume_change =
-                                                VolumeChange::Decrease;
-                                        }
-                                        _ => {}
-                                    }
-                                    final_state_processor.prev_is_stopped = is_stopped;
-                                    if matches!(
-                                        final_state_processor.volume_change,
-                                        VolumeChange::Decrease
-                                    ) {
-                                        final_state_processor.attenuation_factor *= 0.999;
-                                        if final_state_processor.attenuation_factor < 0.0001 {
-                                            final_state_processor.attenuation_factor = 0.0;
-                                            final_state_processor.volume_change =
-                                                VolumeChange::None;
-                                        }
-                                    }
+                                        Some(QueuedTrigger::NextBar) => audio_processor
+                                            .scan_trigger(
+                                                "barTrigger",
+                                                audio_processor.block_pos,
+                                                scan_end,
+                                            ),
+                                        Some(QueuedTrigger::NextBeat) => audio_processor
+                                            .scan_trigger(
+                                                "beatTrigger",
+                                                audio_processor.block_pos,
+                                                scan_end,
+                                            ),
+                                        None => None,
+                                    };
 
-                                    let frame_start = written * num_channels;
+                                let end =
+                                    trigger_sample.map(|n| n.min(scan_end)).unwrap_or(scan_end);
 
-                                    if final_state_processor.attenuation_factor < f32::EPSILON {
-                                        for ch in 0..num_channels {
-                                            output[frame_start + ch] = T::from_sample(0.0f32);
+                                // Force every module to advance to `end`, in cache-efficient
+                                // producer-before-consumer order, so modules not reachable from
+                                // the output or any scope still process. The root/scope reads in
+                                // the drain below then become pure cache hits. Skipped while
+                                // stopped so the patch freezes on stop — the drain still ramps
+                                // connected modules out via the root pull during the fade.
+                                if end > audio_processor.block_pos && !audio_processor.is_stopped()
+                                {
+                                    audio_processor.process_all_modules_to(end);
+                                }
+
+                                // Drain [block_pos, end) into cpal output, inlining the
+                                // volume-change state machine + soft clip that
+                                // `FinalStateProcessor` used to provide per-frame.
+                                if end > audio_processor.block_pos {
+                                    let mut scope_guard =
+                                        audio_processor.scope_collection.try_lock();
+                                    let mut writer_guard = recording_writer.try_lock();
+                                    for i in audio_processor.block_pos..end {
+                                        let is_stopped = audio_processor.is_stopped();
+                                        match (final_state_processor.prev_is_stopped, is_stopped) {
+                                            (true, false) => {
+                                                final_state_processor.volume_change =
+                                                    VolumeChange::None;
+                                                final_state_processor.attenuation_factor = 1.0;
+                                            }
+                                            (false, true) => {
+                                                final_state_processor.volume_change =
+                                                    VolumeChange::Decrease;
+                                            }
+                                            _ => {}
                                         }
-                                        written += 1;
-                                        continue;
-                                    }
-
-                                    if let Some(root) =
-                                        audio_processor.patch.sampleables.get(&*ROOT_ID)
-                                    {
-                                        let mut any_audible = false;
-                                        let mut samples = [0.0f32; PORT_MAX_CHANNELS];
-                                        for ch in 0..num_channels.min(PORT_MAX_CHANNELS) {
-                                            let raw = root.get_value_at(&ROOT_OUTPUT_PORT, ch, i)
-                                                * AUDIO_OUTPUT_ATTENUATION;
-                                            let sample = safety_soft_clip(
-                                                raw * final_state_processor.attenuation_factor,
-                                            );
-                                            samples[ch] = sample;
-                                            if sample.abs() >= 0.0005 {
-                                                any_audible = true;
+                                        final_state_processor.prev_is_stopped = is_stopped;
+                                        if matches!(
+                                            final_state_processor.volume_change,
+                                            VolumeChange::Decrease
+                                        ) {
+                                            final_state_processor.attenuation_factor *= 0.999;
+                                            if final_state_processor.attenuation_factor < 0.0001 {
+                                                final_state_processor.attenuation_factor = 0.0;
+                                                final_state_processor.volume_change =
+                                                    VolumeChange::None;
                                             }
                                         }
-                                        if is_stopped && !any_audible {
-                                            final_state_processor.attenuation_factor = 0.0;
-                                            final_state_processor.volume_change =
-                                                VolumeChange::None;
+
+                                        let frame_start = written * num_channels;
+
+                                        if final_state_processor.attenuation_factor < f32::EPSILON {
                                             for ch in 0..num_channels {
                                                 output[frame_start + ch] = T::from_sample(0.0f32);
                                             }
-                                        } else {
-                                            for ch in 0..num_channels {
-                                                let v = if ch < PORT_MAX_CHANNELS {
-                                                    samples[ch]
-                                                } else {
-                                                    0.0
-                                                };
-                                                output[frame_start + ch] = T::from_sample(v);
-                                            }
+                                            written += 1;
+                                            continue;
                                         }
-                                        if let Some(writer_lock) = writer_guard.as_mut()
-                                            && let Some(writer) = writer_lock.as_mut()
+
+                                        if let Some(root) =
+                                            audio_processor.patch.sampleables.get(&*ROOT_ID)
                                         {
-                                            let v = root.get_value_at(&ROOT_OUTPUT_PORT, 0, i)
-                                                * AUDIO_OUTPUT_ATTENUATION
-                                                * final_state_processor.attenuation_factor;
-                                            let _ = writer
-                                                .write_sample(T::from_sample(safety_soft_clip(v)));
-                                        }
-                                        if let Some(scope_lock) = scope_guard.as_mut() {
-                                            for (key, scope_buffer) in scope_lock.iter_mut() {
-                                                if let Some(module) = audio_processor
-                                                    .patch
-                                                    .sampleables
-                                                    .get(&key.module_id)
-                                                {
-                                                    let s = module.get_value_at(
-                                                        &key.port_name,
-                                                        key.channel as usize,
-                                                        i,
-                                                    );
-                                                    scope_buffer.push(s);
+                                            let mut any_audible = false;
+                                            let mut samples = [0.0f32; PORT_MAX_CHANNELS];
+                                            for ch in 0..num_channels.min(PORT_MAX_CHANNELS) {
+                                                let raw =
+                                                    root.get_value_at(&ROOT_OUTPUT_PORT, ch, i)
+                                                        * AUDIO_OUTPUT_ATTENUATION;
+                                                let sample = safety_soft_clip(
+                                                    raw * final_state_processor.attenuation_factor,
+                                                );
+                                                samples[ch] = sample;
+                                                if sample.abs() >= 0.0005 {
+                                                    any_audible = true;
                                                 }
                                             }
+                                            if is_stopped && !any_audible {
+                                                final_state_processor.attenuation_factor = 0.0;
+                                                final_state_processor.volume_change =
+                                                    VolumeChange::None;
+                                                for ch in 0..num_channels {
+                                                    output[frame_start + ch] =
+                                                        T::from_sample(0.0f32);
+                                                }
+                                            } else {
+                                                for ch in 0..num_channels {
+                                                    let v = if ch < PORT_MAX_CHANNELS {
+                                                        samples[ch]
+                                                    } else {
+                                                        0.0
+                                                    };
+                                                    output[frame_start + ch] = T::from_sample(v);
+                                                }
+                                            }
+                                            if let Some(writer_lock) = writer_guard.as_mut()
+                                                && let Some(writer) = writer_lock.as_mut()
+                                            {
+                                                let v = root.get_value_at(&ROOT_OUTPUT_PORT, 0, i)
+                                                    * AUDIO_OUTPUT_ATTENUATION
+                                                    * final_state_processor.attenuation_factor;
+                                                let _ = writer.write_sample(T::from_sample(
+                                                    safety_soft_clip(v),
+                                                ));
+                                            }
+                                            if let Some(scope_lock) = scope_guard.as_mut() {
+                                                for (key, scope_buffer) in scope_lock.iter_mut() {
+                                                    if let Some(module) = audio_processor
+                                                        .patch
+                                                        .sampleables
+                                                        .get(&key.module_id)
+                                                    {
+                                                        let s = module.get_value_at(
+                                                            &key.port_name,
+                                                            key.channel as usize,
+                                                            i,
+                                                        );
+                                                        scope_buffer.push(s);
+                                                    }
+                                                }
+                                            }
+                                            for (key, xy_buffer) in &audio_processor.scope_xy_audio
+                                            {
+                                                let (Some(x_mod), Some(y_mod)) = (
+                                                    audio_processor
+                                                        .patch
+                                                        .sampleables
+                                                        .get(&key.pair.x.module_id),
+                                                    audio_processor
+                                                        .patch
+                                                        .sampleables
+                                                        .get(&key.pair.y.module_id),
+                                                ) else {
+                                                    continue;
+                                                };
+                                                let xv = x_mod.get_value_at(
+                                                    &key.pair.x.port_name,
+                                                    key.pair.x.channel as usize,
+                                                    i,
+                                                );
+                                                let yv = y_mod.get_value_at(
+                                                    &key.pair.y.port_name,
+                                                    key.pair.y.channel as usize,
+                                                    i,
+                                                );
+                                                xy_buffer.push(xv, yv);
+                                            }
+                                        } else {
+                                            for ch in 0..num_channels {
+                                                output[frame_start + ch] = T::from_sample(0.0f32);
+                                            }
                                         }
-                                        for (key, xy_buffer) in &audio_processor.scope_xy_audio {
-                                            let (Some(x_mod), Some(y_mod)) = (
-                                                audio_processor
-                                                    .patch
-                                                    .sampleables
-                                                    .get(&key.pair.x.module_id),
-                                                audio_processor
-                                                    .patch
-                                                    .sampleables
-                                                    .get(&key.pair.y.module_id),
-                                            ) else {
-                                                continue;
-                                            };
-                                            let xv = x_mod.get_value_at(
-                                                &key.pair.x.port_name,
-                                                key.pair.x.channel as usize,
-                                                i,
-                                            );
-                                            let yv = y_mod.get_value_at(
-                                                &key.pair.y.port_name,
-                                                key.pair.y.channel as usize,
-                                                i,
-                                            );
-                                            xy_buffer.push(xv, yv);
-                                        }
-                                    } else {
-                                        for ch in 0..num_channels {
-                                            output[frame_start + ch] = T::from_sample(0.0f32);
-                                        }
+
+                                        written += 1;
                                     }
+                                    // Publish each XY buffer's ring to its SeqLock region once per
+                                    // block so the main thread can read a coherent frame without a
+                                    // lock.
+                                    for (_key, xy_buffer) in &audio_processor.scope_xy_audio {
+                                        xy_buffer.publish();
+                                    }
+                                    audio_processor.block_pos = end;
+                                }
 
-                                    written += 1;
+                                // Apply queued swap if we stopped at the trigger sample.
+                                if trigger_sample == Some(audio_processor.block_pos)
+                                    && audio_processor.block_pos < block_size
+                                {
+                                    let (update, _) = audio_processor.queued_update.take().unwrap();
+                                    let applied_id = update.update_id;
+                                    let swap_pos = audio_processor.block_pos;
+                                    audio_processor.apply_patch_update(update, swap_pos);
+                                    audio_processor
+                                        .transport_meter
+                                        .write_applied_update_id(applied_id);
+                                    // ROOT_CLOCK's transport state carries across the swap via
+                                    // `transfer_state_from`. Its cache
+                                    // for `[swap_pos, block_size)` was filled under the OLD params;
+                                    // refill the remainder of this callback's range from `swap_pos`
+                                    // forward under the NEW patch.
+                                    if let Some(root_clock) =
+                                        audio_processor.patch.sampleables.get(&*ROOT_CLOCK_ID)
+                                    {
+                                        root_clock.set_initial_index(swap_pos);
+                                    }
+                                    let eager_end = block_size
+                                        .min(audio_processor.block_pos + (num_frames - written));
+                                    audio_processor.eager_fill_clock(swap_pos, eager_end, written);
                                 }
-                                // Publish each XY buffer's ring to its SeqLock region once per
-                                // block so the main thread can read a coherent frame without a
-                                // lock.
-                                for (_key, xy_buffer) in &audio_processor.scope_xy_audio {
-                                    xy_buffer.publish();
-                                }
-                                audio_processor.block_pos = end;
                             }
+                        }
 
-                            // Apply queued swap if we stopped at the trigger sample.
-                            if trigger_sample == Some(audio_processor.block_pos)
-                                && audio_processor.block_pos < block_size
+                        // Transport meter — read at the last sample we just consumed.
+                        {
+                            let last = audio_processor.block_pos.saturating_sub(1);
+                            let has_queued = audio_processor.queued_update.is_some();
+                            if let Some(clock) =
+                                audio_processor.patch.sampleables.get(&*ROOT_CLOCK_ID)
                             {
-                                let (update, _) = audio_processor.queued_update.take().unwrap();
-                                let applied_id = update.update_id;
-                                let swap_pos = audio_processor.block_pos;
-                                audio_processor.apply_patch_update(update, swap_pos);
+                                let bar_phase = clock.get_value_at("playhead", 0, last) as f64;
+                                let bar_count = clock.get_value_at("playhead", 1, last) as u64;
+                                let beat_in_bar = clock.get_value_at("beatInBar", 0, last) as u32;
+                                let is_playing = !audio_processor.is_stopped();
+                                audio_processor.transport_meter.write_from_audio(
+                                    bar_phase,
+                                    bar_count,
+                                    beat_in_bar,
+                                    is_playing,
+                                    has_queued,
+                                );
+                            } else {
                                 audio_processor
                                     .transport_meter
-                                    .write_applied_update_id(applied_id);
-                                // ROOT_CLOCK's transport state carries across the swap via
-                                // `transfer_state_from`. Its cache
-                                // for `[swap_pos, block_size)` was filled under the OLD params;
-                                // refill the remainder of this callback's range from `swap_pos`
-                                // forward under the NEW patch.
-                                if let Some(root_clock) =
-                                    audio_processor.patch.sampleables.get(&*ROOT_CLOCK_ID)
-                                {
-                                    root_clock.set_initial_index(swap_pos);
-                                }
-                                let eager_end = block_size
-                                    .min(audio_processor.block_pos + (num_frames - written));
-                                audio_processor.eager_fill_clock(swap_pos, eager_end, written);
+                                    .write_from_audio(0.0, 0, 0, false, has_queued);
                             }
                         }
-                    }
 
-                    // Transport meter — read at the last sample we just consumed.
-                    {
-                        let last = audio_processor.block_pos.saturating_sub(1);
-                        let has_queued = audio_processor.queued_update.is_some();
-                        if let Some(clock) = audio_processor.patch.sampleables.get(&*ROOT_CLOCK_ID)
+                        // Increment Link sample count for HostTimeFilter
+                        audio_processor.link.add_samples(num_frames as u64);
+
+                        // Collect module states for UI (e.g., seq step highlighting)
+                        // Done once per buffer, not per frame, to minimize overhead
                         {
-                            let bar_phase = clock.get_value_at("playhead", 0, last) as f64;
-                            let bar_count = clock.get_value_at("playhead", 1, last) as u64;
-                            let beat_in_bar = clock.get_value_at("beatInBar", 0, last) as u32;
-                            let is_playing = !audio_processor.is_stopped();
-                            audio_processor.transport_meter.write_from_audio(
-                                bar_phase,
-                                bar_count,
-                                beat_in_bar,
-                                is_playing,
-                                has_queued,
-                            );
-                        } else {
-                            audio_processor
-                                .transport_meter
-                                .write_from_audio(0.0, 0, 0, false, has_queued);
+                            profiling::scope!("collect_module_states");
+                            audio_processor.collect_module_states();
                         }
-                    }
 
-                    // Increment Link sample count for HostTimeFilter
-                    audio_processor.link.add_samples(num_frames as u64);
+                        // Retry any deferred profiler shared-map swap, then flush this
+                        // callback's per-module profile data into the cross-thread
+                        // snapshot. Both are no-ops when nothing is pending / profiling
+                        // is disabled (early-out inside the calls).
+                        audio_processor.retry_pending_profile_seed();
+                        modular_core::profiling::flush_into(
+                            &audio_processor.module_profile_collection,
+                        );
 
-                    // Collect module states for UI (e.g., seq step highlighting)
-                    // Done once per buffer, not per frame, to minimize overhead
-                    {
-                        profiling::scope!("collect_module_states");
-                        audio_processor.collect_module_states();
-                    }
+                        let elapsed_ns = callback_start.elapsed().as_nanos() as u64;
 
-                    // Retry any deferred profiler shared-map swap, then flush this
-                    // callback's per-module profile data into the cross-thread
-                    // snapshot. Both are no-ops when nothing is pending / profiling
-                    // is disabled (early-out inside the calls).
-                    audio_processor.retry_pending_profile_seed();
-                    modular_core::profiling::flush_into(&audio_processor.module_profile_collection);
-
-                    let elapsed_ns = callback_start.elapsed().as_nanos() as u64;
-
-                    audio_budget_meter.record_chunk(output.len() as u64, elapsed_ns);
+                        audio_budget_meter.record_chunk(output.len() as u64, elapsed_ns);
+                    })
                 }));
                 if result.is_err() {
                     // Panic hook (panic_log::install_panic_hook) has already written

--- a/crates/modular/src/lib.rs
+++ b/crates/modular/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(clippy::all)]
 
-#[cfg(feature = "alloc-detector")]
 mod alloc_detector;
 
 mod audio;

--- a/crates/modular_core/Cargo.toml
+++ b/crates/modular_core/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2024"
 [features]
 default = []
 tracy = ["profiling/profile-with-tracy", "modular_derive/tracy"]
-# Dev-only: exposes `profiling::current_module_id_into` for the audio allocation
-# detector in the `modular` crate. Enabled via that crate's `alloc-detector` feature.
-alloc-detector = []
 
 [[bin]]
 name = "generate-schemas"

--- a/crates/modular_core/src/profiling.rs
+++ b/crates/modular_core/src/profiling.rs
@@ -136,18 +136,6 @@ pub fn set_sample_rate(rate: u32) {
     SAMPLE_RATE.store(rate.max(1), Ordering::Relaxed);
 }
 
-/// Independent always-on profiling switch for the dev-only allocation detector.
-/// ORed into the enable decision in `refresh_enabled` so the detector's
-/// attribution survives the UI profiling enable refcount and the device-switch
-/// reset (both drive `ENABLED`). Set once by the detector's logger thread.
-#[cfg(feature = "alloc-detector")]
-static FORCE_ENABLED: AtomicBool = AtomicBool::new(false);
-
-#[cfg(feature = "alloc-detector")]
-pub fn set_force_enabled(on: bool) {
-    FORCE_ENABLED.store(on, Ordering::Relaxed);
-}
-
 struct Frame {
     /// Pointer + len back into the wrapper's owned `id: String`.
     ///
@@ -202,17 +190,7 @@ thread_local! {
 /// Refresh the thread-local enable mirror. Called once per audio callback
 /// at the top, before any module processing.
 pub fn refresh_enabled() {
-    let global_on = ENABLED.load(Ordering::Relaxed);
-    #[cfg(feature = "alloc-detector")]
-    let force_on = FORCE_ENABLED.load(Ordering::Relaxed);
-    #[cfg(not(feature = "alloc-detector"))]
-    let force_on = false;
-    let on = if force_on {
-        // alloc-detector: profile every callback regardless of the UI enable
-        // refcount and sample-rate, so audio-thread allocations can always be
-        // attributed to the running module.
-        true
-    } else if global_on {
+    let on = if ENABLED.load(Ordering::Relaxed) {
         let rate = SAMPLE_RATE.load(Ordering::Relaxed).max(1);
         let count = CALLBACK_COUNTER.fetch_add(1, Ordering::Relaxed);
         count.is_multiple_of(rate)
@@ -323,38 +301,6 @@ pub fn pop_frame(samples_processed: u32) {
             parent.last_resume = now;
         }
     });
-}
-
-/// Copy the id of the currently-executing module (the top profiler frame) into
-/// `buf`, returning the number of bytes written (0 if no frame is active). Used by
-/// the dev-only audio allocation detector to attribute an audio-thread allocation
-/// to the module whose `update()` is running. Alloc-free and lock-free; reads the
-/// same thread-local stack as `pop_frame` but never mutates `depth`. Only
-/// meaningful when called on the audio thread mid-process.
-#[cfg(feature = "alloc-detector")]
-#[inline]
-pub fn current_module_id_into(buf: &mut [u8; 64]) -> u8 {
-    PROFILER.with(|p| {
-        // `try_borrow`: if the stack is momentarily borrowed (e.g. an allocation
-        // fired from inside `push_frame`/`pop_frame`), skip attribution rather than
-        // panic on a double borrow.
-        let Ok(prof) = p.try_borrow() else {
-            return 0;
-        };
-        if prof.depth == 0 {
-            return 0;
-        }
-        // SAFETY: slot `depth - 1` is the live top frame; its `id_ptr`/`id_len`
-        // borrow the wrapper's write-once `id: String`, valid for the strict-LIFO
-        // span of the frame (the same contract `pop_frame` relies on). Read-only.
-        let frame = unsafe { prof.stack[prof.depth - 1].assume_init_ref() };
-        let n = frame.id_len.min(buf.len());
-        // SAFETY: as above — the id bytes are valid for `frame.id_len`; copy the
-        // first `n` (clamped to the buffer).
-        let id = unsafe { std::slice::from_raw_parts(frame.id_ptr, n) };
-        buf[..n].copy_from_slice(id);
-        n as u8
-    })
 }
 
 /// Drain the audio-thread-local records into the shared cross-thread


### PR DESCRIPTION
## What

Replaces the custom 346-line warn-and-attribute audio-thread allocation detector
with a thin **panic-on-first-(de)alloc** detector that captures a backtrace **at
the allocation site** and routes the panic through the existing audio-thread-panic
→ silence → restart path.

## Why

The previous detector accumulated audio-thread alloc/dealloc events through a
lock-free ring + background logger thread and attributed each to a module
*instance* via the profiler call-stack. The new approach trades instance-level
attribution for a **source-level backtrace** (which code actually allocated) plus a
hard restart, and deletes a large amount of unsafe allocator/ring/logger
machinery.

`assert_no_alloc` was evaluated first, but its `AllocDisabler` only *counts* at the
site — it can't trace the offending code without aborting the process. To get a
real allocation-site backtrace *and* a graceful restart, the backtrace must be
captured inside the allocator (capturing is safe; unwinding out of `GlobalAlloc`
is UB) and the panic deferred to the region boundary. So this keeps a small custom
allocator and adds **no new dependency**.

## How it works

`panic_on_alloc(f)` wraps the audio DSP region inside the cpal callback's
`catch_unwind`. While that region is active, the feature-gated
`#[global_allocator]` captures a `std::backtrace::Backtrace` at the site of the
**first** heap (de)allocation (re-entrancy-guarded, since capturing itself
allocates), stashed thread-local. Once the region exits — where allocating and
unwinding are safe again — `panic_on_alloc` panics with that backtrace. The
existing `catch_unwind` catches it, flips the poisoned-thread flag, emits silence,
and the stream restarts; the `panic_log` hook + panic payload carry the
allocation-site backtrace.

All detector state is thread-local, so two cpal callback threads briefly
overlapping during a device/sample-rate switch each capture into their own slot —
the old ring's `PRODUCER_BUSY` CAS and shared atomics are gone.

## Behavior change

- Panics on the **first** audio-thread (de)allocation — alloc *or* dealloc,
  including patch-apply deallocs such as scope teardown — rather than accumulating
  and logging.
- Per-module-*instance* attribution is removed in favor of the source-level
  backtrace. The profiler attribution hooks (`current_module_id_into`,
  `FORCE_ENABLED`/`set_force_enabled`) and the `modular_core` `alloc-detector`
  feature are deleted.

## Opt-in / safety (unchanged)

Gated behind `--features=alloc-detector` (`yarn build-native-alloc` /
`yarn start:alloc`); the default build installs no global allocator and
`panic_on_alloc` inlines to a direct call (byte-identical). Never ship.

## Verification

- Compiles in all three configs (default, `modular` pass-through,
  `--features=alloc-detector`); no new warnings.
- `yarn build-native-alloc` (release) succeeds; schemas regenerate.
- 674+ `modular_core` tests pass.
- Core mechanism runtime-verified in isolation: an in-region alloc/dealloc panics
  with a backtrace naming the actual allocating frame; clean and out-of-region
  code never panics; the re-entrancy guard (capturing a backtrace from inside the
  allocator) does not recurse.
- Not yet exercised: a live audio-stream integration run (panic→restart on the
  real `.node`) — needs an audio-device-driving harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
