### PR TITLE
feat(pattern): patternable @ weight and ! count operands, {} polymeter in operands

### DIFF
--- a/crates/modular/schemas.json
+++ b/crates/modular/schemas.json
@@ -14779,11 +14779,14 @@
                         "$ref": "#/$defs/MiniAST"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -14809,11 +14812,14 @@
                         "$ref": "#/$defs/MiniAST"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -14839,11 +14845,14 @@
                         "$ref": "#/$defs/MiniAST"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -14945,7 +14954,7 @@
               ]
             },
             {
-              "description": "Replicate: pattern ! n (repeat n times).\nCount is a plain u32 since Strudel doesn't support patterned replicate counts.",
+              "description": "Replicate: pattern ! n (repeat n times).",
               "type": "object",
               "properties": {
                 "Replicate": {
@@ -14957,9 +14966,7 @@
                       "$ref": "#/$defs/MiniAST"
                     },
                     {
-                      "type": "integer",
-                      "format": "uint32",
-                      "minimum": 0
+                      "$ref": "#/$defs/ReplicateCount"
                     }
                   ]
                 }
@@ -15133,11 +15140,14 @@
                         "$ref": "#/$defs/MiniASTF64"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -15163,11 +15173,14 @@
                         "$ref": "#/$defs/MiniASTF64"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -15193,11 +15206,14 @@
                         "$ref": "#/$defs/MiniASTF64"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -15299,7 +15315,7 @@
               ]
             },
             {
-              "description": "Replicate: pattern ! n (repeat n times).\nCount is a plain u32 since Strudel doesn't support patterned replicate counts.",
+              "description": "Replicate: pattern ! n (repeat n times).",
               "type": "object",
               "properties": {
                 "Replicate": {
@@ -15311,9 +15327,7 @@
                       "$ref": "#/$defs/MiniASTF64"
                     },
                     {
-                      "type": "integer",
-                      "format": "uint32",
-                      "minimum": 0
+                      "$ref": "#/$defs/ReplicateCount"
                     }
                   ]
                 }
@@ -15487,11 +15501,14 @@
                         "$ref": "#/$defs/MiniASTI32"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -15517,11 +15534,14 @@
                         "$ref": "#/$defs/MiniASTI32"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -15547,11 +15567,14 @@
                         "$ref": "#/$defs/MiniASTI32"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -15665,9 +15688,7 @@
                       "$ref": "#/$defs/MiniASTI32"
                     },
                     {
-                      "type": "integer",
-                      "format": "uint32",
-                      "minimum": 0
+                      "$ref": "#/$defs/ReplicateCount"
                     }
                   ]
                 }
@@ -15841,11 +15862,14 @@
                         "$ref": "#/$defs/MiniASTU32"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -15871,11 +15895,14 @@
                         "$ref": "#/$defs/MiniASTU32"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -15901,11 +15928,14 @@
                         "$ref": "#/$defs/MiniASTU32"
                       },
                       {
-                        "type": [
-                          "number",
-                          "null"
-                        ],
-                        "format": "double"
+                        "anyOf": [
+                          {
+                            "$ref": "#/$defs/Weight"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ]
                       }
                     ]
                   }
@@ -16007,7 +16037,7 @@
               ]
             },
             {
-              "description": "Replicate: pattern ! n (repeat n times).\nCount is a plain u32 since Strudel doesn't support patterned replicate counts.",
+              "description": "Replicate: pattern ! n (repeat n times).",
               "type": "object",
               "properties": {
                 "Replicate": {
@@ -16019,9 +16049,7 @@
                       "$ref": "#/$defs/MiniASTU32"
                     },
                     {
-                      "type": "integer",
-                      "format": "uint32",
-                      "minimum": 0
+                      "$ref": "#/$defs/ReplicateCount"
                     }
                   ]
                 }
@@ -16189,6 +16217,19 @@
             "ast",
             "source",
             "all_spans"
+          ]
+        },
+        "ReplicateCount": {
+          "description": "Replicate count operand (`!`).\n\nSerialized untagged: a static count is a bare JSON number, a patterned\ncount (`a!<2 3>`) is a `MiniASTU32` object. `Static` must stay the first\nvariant so untagged deserialization matches the bare number before\nattempting the pattern shape.",
+          "anyOf": [
+            {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            },
+            {
+              "$ref": "#/$defs/MiniASTU32"
+            }
           ]
         },
         "SectionCycles": {
@@ -16433,6 +16474,18 @@
             "__kind",
             "pattern",
             "bool_pattern"
+          ]
+        },
+        "Weight": {
+          "description": "Weight operand carried by a sequence entry (`@` or `_` elongation).\n\nSerialized untagged: a static weight is a bare JSON number, a patterned\nweight (`a@<1 2>`) is a `MiniASTF64` object. `Static` must stay the first\nvariant so untagged deserialization matches the bare number before\nattempting the pattern shape.",
+          "anyOf": [
+            {
+              "type": "number",
+              "format": "double"
+            },
+            {
+              "$ref": "#/$defs/MiniASTF64"
+            }
           ]
         }
       }

--- a/crates/modular_core/src/pattern_system/__fixtures__/peggy_parser_parity.json
+++ b/crates/modular_core/src/pattern_system/__fixtures__/peggy_parser_parity.json
@@ -1696,5 +1696,805 @@
         }
       ]
     }
+  },
+  {
+    "label": "patterned weight @[...]",
+    "input": "0@[2 1] 1",
+    "peggy_ast": {
+      "Sequence": [
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 0
+              },
+              "span": {
+                "start": 0,
+                "end": 1
+              }
+            }
+          },
+          {
+            "FastCat": [
+              [
+                {
+                  "Pure": {
+                    "node": 2,
+                    "span": {
+                      "start": 3,
+                      "end": 4
+                    }
+                  }
+                },
+                null
+              ],
+              [
+                {
+                  "Pure": {
+                    "node": 1,
+                    "span": {
+                      "start": 5,
+                      "end": 6
+                    }
+                  }
+                },
+                null
+              ]
+            ]
+          }
+        ],
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 1
+              },
+              "span": {
+                "start": 8,
+                "end": 9
+              }
+            }
+          },
+          null
+        ]
+      ]
+    }
+  },
+  {
+    "label": "patterned weight @<...>",
+    "input": "0@<1 2> 1",
+    "peggy_ast": {
+      "Sequence": [
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 0
+              },
+              "span": {
+                "start": 0,
+                "end": 1
+              }
+            }
+          },
+          {
+            "SlowCat": [
+              [
+                {
+                  "Pure": {
+                    "node": 1,
+                    "span": {
+                      "start": 3,
+                      "end": 4
+                    }
+                  }
+                },
+                null
+              ],
+              [
+                {
+                  "Pure": {
+                    "node": 2,
+                    "span": {
+                      "start": 5,
+                      "end": 6
+                    }
+                  }
+                },
+                null
+              ]
+            ]
+          }
+        ],
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 1
+              },
+              "span": {
+                "start": 8,
+                "end": 9
+              }
+            }
+          },
+          null
+        ]
+      ]
+    }
+  },
+  {
+    "label": "patterned weight @{...}",
+    "input": "0@{1 2} 1",
+    "peggy_ast": {
+      "Sequence": [
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 0
+              },
+              "span": {
+                "start": 0,
+                "end": 1
+              }
+            }
+          },
+          {
+            "Polymeter": {
+              "children": [
+                {
+                  "Sequence": [
+                    [
+                      {
+                        "Pure": {
+                          "node": 1,
+                          "span": {
+                            "start": 3,
+                            "end": 4
+                          }
+                        }
+                      },
+                      null
+                    ],
+                    [
+                      {
+                        "Pure": {
+                          "node": 2,
+                          "span": {
+                            "start": 5,
+                            "end": 6
+                          }
+                        }
+                      },
+                      null
+                    ]
+                  ]
+                }
+              ],
+              "steps_per_cycle": null
+            }
+          }
+        ],
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 1
+              },
+              "span": {
+                "start": 8,
+                "end": 9
+              }
+            }
+          },
+          null
+        ]
+      ]
+    }
+  },
+  {
+    "label": "patterned weight bracketed choice",
+    "input": "0@[1|2] 1",
+    "peggy_ast": {
+      "Sequence": [
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 0
+              },
+              "span": {
+                "start": 0,
+                "end": 1
+              }
+            }
+          },
+          {
+            "FastCat": [
+              [
+                {
+                  "RandomChoice": [
+                    [
+                      {
+                        "Pure": {
+                          "node": 1,
+                          "span": {
+                            "start": 3,
+                            "end": 4
+                          }
+                        }
+                      },
+                      {
+                        "Pure": {
+                          "node": 2,
+                          "span": {
+                            "start": 5,
+                            "end": 6
+                          }
+                        }
+                      }
+                    ],
+                    0
+                  ]
+                },
+                null
+              ]
+            ]
+          }
+        ],
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 1
+              },
+              "span": {
+                "start": 8,
+                "end": 9
+              }
+            }
+          },
+          null
+        ]
+      ]
+    }
+  },
+  {
+    "label": "patterned weight with operand replicate",
+    "input": "<0@<2!3 3> 1>",
+    "peggy_ast": {
+      "SlowCat": [
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 0
+              },
+              "span": {
+                "start": 1,
+                "end": 2
+              }
+            }
+          },
+          {
+            "SlowCat": [
+              [
+                {
+                  "Replicate": [
+                    {
+                      "Pure": {
+                        "node": 2,
+                        "span": {
+                          "start": 4,
+                          "end": 5
+                        }
+                      }
+                    },
+                    3
+                  ]
+                },
+                null
+              ],
+              [
+                {
+                  "Pure": {
+                    "node": 3,
+                    "span": {
+                      "start": 8,
+                      "end": 9
+                    }
+                  }
+                },
+                null
+              ]
+            ]
+          }
+        ],
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 1
+              },
+              "span": {
+                "start": 11,
+                "end": 12
+              }
+            }
+          },
+          null
+        ]
+      ]
+    }
+  },
+  {
+    "label": "patterned replicate !<...>",
+    "input": "0!<2 3> 1",
+    "peggy_ast": {
+      "Sequence": [
+        [
+          {
+            "Replicate": [
+              {
+                "Pure": {
+                  "node": {
+                    "Number": 0
+                  },
+                  "span": {
+                    "start": 0,
+                    "end": 1
+                  }
+                }
+              },
+              {
+                "SlowCat": [
+                  [
+                    {
+                      "Pure": {
+                        "node": 2,
+                        "span": {
+                          "start": 3,
+                          "end": 4
+                        }
+                      }
+                    },
+                    null
+                  ],
+                  [
+                    {
+                      "Pure": {
+                        "node": 3,
+                        "span": {
+                          "start": 5,
+                          "end": 6
+                        }
+                      }
+                    },
+                    null
+                  ]
+                ]
+              }
+            ]
+          },
+          null
+        ],
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 1
+              },
+              "span": {
+                "start": 8,
+                "end": 9
+              }
+            }
+          },
+          null
+        ]
+      ]
+    }
+  },
+  {
+    "label": "patterned replicate ![...]",
+    "input": "0![2 3] 1",
+    "peggy_ast": {
+      "Sequence": [
+        [
+          {
+            "Replicate": [
+              {
+                "Pure": {
+                  "node": {
+                    "Number": 0
+                  },
+                  "span": {
+                    "start": 0,
+                    "end": 1
+                  }
+                }
+              },
+              {
+                "FastCat": [
+                  [
+                    {
+                      "Pure": {
+                        "node": 2,
+                        "span": {
+                          "start": 3,
+                          "end": 4
+                        }
+                      }
+                    },
+                    null
+                  ],
+                  [
+                    {
+                      "Pure": {
+                        "node": 3,
+                        "span": {
+                          "start": 5,
+                          "end": 6
+                        }
+                      }
+                    },
+                    null
+                  ]
+                ]
+              }
+            ]
+          },
+          null
+        ],
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 1
+              },
+              "span": {
+                "start": 8,
+                "end": 9
+              }
+            }
+          },
+          null
+        ]
+      ]
+    }
+  },
+  {
+    "label": "patterned replicate !{...}",
+    "input": "0!{2 3} 1",
+    "peggy_ast": {
+      "Sequence": [
+        [
+          {
+            "Replicate": [
+              {
+                "Pure": {
+                  "node": {
+                    "Number": 0
+                  },
+                  "span": {
+                    "start": 0,
+                    "end": 1
+                  }
+                }
+              },
+              {
+                "Polymeter": {
+                  "children": [
+                    {
+                      "Sequence": [
+                        [
+                          {
+                            "Pure": {
+                              "node": 2,
+                              "span": {
+                                "start": 3,
+                                "end": 4
+                              }
+                            }
+                          },
+                          null
+                        ],
+                        [
+                          {
+                            "Pure": {
+                              "node": 3,
+                              "span": {
+                                "start": 5,
+                                "end": 6
+                              }
+                            }
+                          },
+                          null
+                        ]
+                      ]
+                    }
+                  ],
+                  "steps_per_cycle": null
+                }
+              }
+            ]
+          },
+          null
+        ],
+        [
+          {
+            "Pure": {
+              "node": {
+                "Number": 1
+              },
+              "span": {
+                "start": 8,
+                "end": 9
+              }
+            }
+          },
+          null
+        ]
+      ]
+    }
+  },
+  {
+    "label": "operand polymeter for fast",
+    "input": "0*{1 2 3}",
+    "peggy_ast": {
+      "Fast": [
+        {
+          "Pure": {
+            "node": {
+              "Number": 0
+            },
+            "span": {
+              "start": 0,
+              "end": 1
+            }
+          }
+        },
+        {
+          "Polymeter": {
+            "children": [
+              {
+                "Sequence": [
+                  [
+                    {
+                      "Pure": {
+                        "node": 1,
+                        "span": {
+                          "start": 3,
+                          "end": 4
+                        }
+                      }
+                    },
+                    null
+                  ],
+                  [
+                    {
+                      "Pure": {
+                        "node": 2,
+                        "span": {
+                          "start": 5,
+                          "end": 6
+                        }
+                      }
+                    },
+                    null
+                  ],
+                  [
+                    {
+                      "Pure": {
+                        "node": 3,
+                        "span": {
+                          "start": 7,
+                          "end": 8
+                        }
+                      }
+                    },
+                    null
+                  ]
+                ]
+              }
+            ],
+            "steps_per_cycle": null
+          }
+        }
+      ]
+    }
+  },
+  {
+    "label": "operand polymeter with % steps",
+    "input": "0*{1 2 3}%4",
+    "peggy_ast": {
+      "Fast": [
+        {
+          "Pure": {
+            "node": {
+              "Number": 0
+            },
+            "span": {
+              "start": 0,
+              "end": 1
+            }
+          }
+        },
+        {
+          "Polymeter": {
+            "children": [
+              {
+                "Sequence": [
+                  [
+                    {
+                      "Pure": {
+                        "node": 1,
+                        "span": {
+                          "start": 3,
+                          "end": 4
+                        }
+                      }
+                    },
+                    null
+                  ],
+                  [
+                    {
+                      "Pure": {
+                        "node": 2,
+                        "span": {
+                          "start": 5,
+                          "end": 6
+                        }
+                      }
+                    },
+                    null
+                  ],
+                  [
+                    {
+                      "Pure": {
+                        "node": 3,
+                        "span": {
+                          "start": 7,
+                          "end": 8
+                        }
+                      }
+                    },
+                    null
+                  ]
+                ]
+              }
+            ],
+            "steps_per_cycle": {
+              "Pure": {
+                "node": 4,
+                "span": {
+                  "start": 10,
+                  "end": 11
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "label": "operand polymeter for slow",
+    "input": "0/{2 3}",
+    "peggy_ast": {
+      "Slow": [
+        {
+          "Pure": {
+            "node": {
+              "Number": 0
+            },
+            "span": {
+              "start": 0,
+              "end": 1
+            }
+          }
+        },
+        {
+          "Polymeter": {
+            "children": [
+              {
+                "Sequence": [
+                  [
+                    {
+                      "Pure": {
+                        "node": 2,
+                        "span": {
+                          "start": 3,
+                          "end": 4
+                        }
+                      }
+                    },
+                    null
+                  ],
+                  [
+                    {
+                      "Pure": {
+                        "node": 3,
+                        "span": {
+                          "start": 5,
+                          "end": 6
+                        }
+                      }
+                    },
+                    null
+                  ]
+                ]
+              }
+            ],
+            "steps_per_cycle": null
+          }
+        }
+      ]
+    }
+  },
+  {
+    "label": "operand polymeter euclid steps",
+    "input": "0(3,{4 8})",
+    "peggy_ast": {
+      "Euclidean": {
+        "pattern": {
+          "Pure": {
+            "node": {
+              "Number": 0
+            },
+            "span": {
+              "start": 0,
+              "end": 1
+            }
+          }
+        },
+        "pulses": {
+          "Pure": {
+            "node": 3,
+            "span": {
+              "start": 2,
+              "end": 3
+            }
+          }
+        },
+        "steps": {
+          "Polymeter": {
+            "children": [
+              {
+                "Sequence": [
+                  [
+                    {
+                      "Pure": {
+                        "node": 4,
+                        "span": {
+                          "start": 5,
+                          "end": 6
+                        }
+                      }
+                    },
+                    null
+                  ],
+                  [
+                    {
+                      "Pure": {
+                        "node": 8,
+                        "span": {
+                          "start": 7,
+                          "end": 8
+                        }
+                      }
+                    },
+                    null
+                  ]
+                ]
+              }
+            ],
+            "steps_per_cycle": null
+          }
+        },
+        "rotation": null
+      }
+    }
   }
 ]

--- a/crates/modular_core/src/pattern_system/combinators.rs
+++ b/crates/modular_core/src/pattern_system/combinators.rs
@@ -6,7 +6,8 @@
 //! - `fastcat` - Concatenate patterns within one cycle
 //! - `timecat` - Concatenate patterns with explicit weights
 
-use super::{ArenaHap, Fraction, Pattern, State};
+use super::hap::ArenaHapContext;
+use super::{ArenaHap, Fraction, Pattern, State, TimeSpan};
 use bumpalo::Bump;
 use bumpalo::collections::Vec as BumpVec;
 
@@ -137,6 +138,263 @@ pub fn timecat<T: Clone + Send + Sync + 'static>(
     }
 
     stack(compressed).with_steps(total)
+}
+
+/// Weight operand for one [`dyn_timecat`] entry or slowcat-unroll slot: a
+/// constant span width, or a pattern sampled once per cycle at the cycle
+/// start.
+#[derive(Clone)]
+pub enum DynWeight {
+    Static(Fraction),
+    Pattern(Pattern<Fraction>),
+}
+
+/// Replicate-count operand: a constant copy count, or a pattern sampled once
+/// per cycle at the cycle start. Sampled values are bounded by the
+/// mini-notation limit validator, so the query path trusts them.
+#[derive(Clone)]
+pub enum DynCount {
+    Static(u32),
+    Pattern(Pattern<u32>),
+}
+
+/// One [`dyn_timecat`] entry: `count` copies of `pat`, each `weight` wide.
+/// A `!` replicate entry carries weight `Static(1)`; a `@` weighted entry
+/// carries count `Static(1)`.
+pub struct DynTimecatEntry<T> {
+    pub pat: Pattern<T>,
+    pub weight: DynWeight,
+    pub count: DynCount,
+}
+
+/// Sample a scalar operand pattern at a cycle start: value and context of
+/// the first hap whose part begins exactly at `cycle`. `None` when the
+/// operand is silent there.
+fn sample_at_cycle_start<'b, V: Clone + Send + Sync + 'static>(
+    pat: &Pattern<V>,
+    cycle: &Fraction,
+    bump: &'b Bump,
+) -> Option<(V, &'b ArenaHapContext<'b>)> {
+    let span = TimeSpan::new(cycle.clone(), cycle + &Fraction::from_integer(1));
+    let mut scratch: BumpVec<'_, ArenaHap<'_, V>> = BumpVec::new_in(bump);
+    pat.query_into(&State::new(span), bump, &mut scratch);
+    scratch
+        .iter()
+        .find(|h| &h.part.begin == cycle)
+        .map(|h| (h.value.clone(), h.context))
+}
+
+/// Weighted concatenation whose slot layout is re-derived every cycle.
+///
+/// Pattern-valued weights and counts are sampled at each cycle's start, then
+/// the cycle is laid out like [`timecat`]: each slot takes `weight/Σ` of the
+/// cycle (zero-weight slots vanish; an all-zero cycle is silent). Sampled
+/// operand contexts are combined into every hap a slot emits, so `@`/`!`
+/// operand atoms highlight exactly like `*` factors. The query allocates
+/// only from the arena.
+pub fn dyn_timecat<T: Clone + Send + Sync + 'static>(
+    entries: Vec<DynTimecatEntry<T>>,
+) -> Pattern<T> {
+    if entries.is_empty() {
+        return super::constructors::silence();
+    }
+    Pattern::new_into(
+        move |state: &State, bump: &Bump, out: &mut BumpVec<'_, ArenaHap<'_, T>>| {
+            state.span.for_each_cycle_span(|cycle_span| {
+                let cycle = cycle_span.begin.sam();
+                // Sample pass: resolve every entry's weight and count for
+                // this cycle before any span math.
+                let zero = Fraction::from_integer(0);
+                let mut resolved: BumpVec<'_, (Fraction, u32, Option<&ArenaHapContext>)> =
+                    BumpVec::new_in(bump);
+                resolved.reserve(entries.len());
+                let mut total = Fraction::from_integer(0);
+                for entry in entries.iter() {
+                    let (weight, wctx) = match &entry.weight {
+                        DynWeight::Static(w) => (w.clone(), None),
+                        DynWeight::Pattern(p) => match sample_at_cycle_start(p, &cycle, bump) {
+                            // A negative sampled weight collapses the slot,
+                            // like timecat's zero-weight skip.
+                            Some((v, ctx)) => (v.max_of(&zero), Some(ctx)),
+                            None => (Fraction::from_integer(1), None),
+                        },
+                    };
+                    let (count, cctx) = match &entry.count {
+                        DynCount::Static(c) => (*c, None),
+                        DynCount::Pattern(p) => match sample_at_cycle_start(p, &cycle, bump) {
+                            Some((v, ctx)) => (v, Some(ctx)),
+                            None => (1, None),
+                        },
+                    };
+                    let op_ctx = match (wctx, cctx) {
+                        (Some(w), Some(c)) => Some(ArenaHapContext::combine_in(w, c, bump)),
+                        (Some(w), None) => Some(w),
+                        (None, Some(c)) => Some(c),
+                        (None, None) => None,
+                    };
+                    total = &total + &(&weight * &Fraction::from_integer(count as i64));
+                    resolved.push((weight, count, op_ctx));
+                }
+                if total.is_zero() {
+                    return;
+                }
+                // Emit pass: compress each slot into its per-cycle span
+                // fraction (the same linear maps as compress_query_into).
+                let mut begin = Fraction::from_integer(0);
+                for (entry, (weight, count, op_ctx)) in entries.iter().zip(resolved.iter()) {
+                    for _ in 0..*count {
+                        if weight.is_zero() {
+                            continue;
+                        }
+                        let start_frac = &begin / &total;
+                        begin = &begin + weight;
+                        let end_frac = &begin / &total;
+                        if start_frac >= end_frac {
+                            continue;
+                        }
+                        let compressed_begin = &cycle + &start_frac;
+                        let compressed_end = &cycle + &end_frac;
+                        let compressed_span =
+                            TimeSpan::new(compressed_begin.clone(), compressed_end);
+                        let Some(intersect) = cycle_span.intersection(&compressed_span) else {
+                            continue;
+                        };
+                        let duration = &end_frac - &start_frac;
+                        let inv_d = Fraction::from_integer(1) / duration.clone();
+                        let b_q = &cycle - &(&compressed_begin * &inv_d);
+                        let inner_span = intersect.with_time(|t| t * &inv_d + &b_q);
+                        let mut scratch: BumpVec<'_, ArenaHap<'_, T>> = BumpVec::new_in(bump);
+                        entry
+                            .pat
+                            .query_into(&State::new(inner_span), bump, &mut scratch);
+                        let b_r = &compressed_begin - &(&cycle * &duration);
+                        for hap in scratch {
+                            let new_part = hap.part.with_time(|t| t * &duration + &b_r);
+                            let new_whole = hap
+                                .whole
+                                .as_ref()
+                                .map(|w| w.with_time(|t| t * &duration + &b_r));
+                            let Some(final_part) = new_part.intersection(&cycle_span) else {
+                                continue;
+                            };
+                            let context = match op_ctx {
+                                Some(op) => ArenaHapContext::combine_in(hap.context, op, bump),
+                                None => hap.context,
+                            };
+                            out.push(ArenaHap {
+                                whole: new_whole,
+                                part: final_part,
+                                value: hap.value,
+                                context,
+                            });
+                        }
+                    }
+                }
+            });
+        },
+    )
+}
+
+/// View a pattern through an affine cycle-index remap: wrapper cycle `k`
+/// shows source cycle `k·mul + offset` (intra-cycle position unchanged).
+/// The slowcat unroll wraps each slot in this so a slot re-queried at
+/// super-period `k` advances through its source's cycles instead of
+/// replaying one of them.
+pub fn stride_cycles<T: Clone + Send + Sync + 'static>(
+    pat: Pattern<T>,
+    mul: u64,
+    offset: u64,
+) -> Pattern<T> {
+    if mul == 1 && offset == 0 {
+        return pat;
+    }
+    let mul_minus_one = Fraction::from_integer(mul as i64 - 1);
+    let offset = Fraction::from_integer(offset as i64);
+    Pattern::new_into(
+        move |state: &State, bump: &Bump, out: &mut BumpVec<'_, ArenaHap<'_, T>>| {
+            state.span.for_each_cycle_span(|cycle_span| {
+                // Within one cycle the remap is a constant shift:
+                //   shift = k·(mul − 1) + offset.
+                let k = cycle_span.begin.sam();
+                let shift = &(&k * &mul_minus_one) + &offset;
+                let qspan = cycle_span.with_time(|t| t + &shift);
+                let mut scratch: BumpVec<'_, ArenaHap<'_, T>> = BumpVec::new_in(bump);
+                pat.query_into(&State::new(qspan), bump, &mut scratch);
+                out.reserve(scratch.len());
+                for hap in scratch {
+                    let new_part = hap.part.with_time(|t| t - &shift);
+                    let new_whole = hap.whole.as_ref().map(|w| w.with_time(|t| t - &shift));
+                    out.push(ArenaHap {
+                        whole: new_whole,
+                        part: new_part,
+                        value: hap.value,
+                        context: hap.context,
+                    });
+                }
+            });
+        },
+    )
+}
+
+/// Per-cycle step count of a polymeter voice: a static count or a set of
+/// `(weight, count)` operand specs whose sampled products are summed each
+/// cycle.
+#[derive(Clone)]
+pub enum StepSpec {
+    Static(Fraction),
+    Dyn(std::sync::Arc<[(DynWeight, DynCount)]>),
+}
+
+impl StepSpec {
+    /// Resolve the step count for the cycle starting at `cycle`.
+    fn sample(&self, cycle: &Fraction, bump: &Bump) -> Fraction {
+        match self {
+            StepSpec::Static(s) => s.clone(),
+            StepSpec::Dyn(entries) => {
+                let mut total = Fraction::from_integer(0);
+                for (weight, count) in entries.iter() {
+                    let w = match weight {
+                        DynWeight::Static(w) => w.clone(),
+                        DynWeight::Pattern(p) => sample_at_cycle_start(p, cycle, bump)
+                            .map(|(v, _)| v)
+                            .unwrap_or_else(|| Fraction::from_integer(1)),
+                    };
+                    let c = match count {
+                        DynCount::Static(c) => *c,
+                        DynCount::Pattern(p) => sample_at_cycle_start(p, cycle, bump)
+                            .map(|(v, _)| v)
+                            .unwrap_or(1),
+                    };
+                    total = &total + &(&w * &Fraction::from_integer(c as i64));
+                }
+                total
+            }
+        }
+    }
+}
+
+/// Per-cycle polymeter alignment factor: `spc(cycle) / steps(cycle)`, one
+/// hap per cycle, for feeding `Pattern::fast` when a voice's step count (or
+/// the steps-per-cycle default taken from the first voice) varies by cycle.
+/// The step count is clamped to at least 1, matching the static voice
+/// alignment.
+pub fn dyn_polymeter_factor(spc: StepSpec, steps: StepSpec) -> Pattern<Fraction> {
+    Pattern::new_into(
+        move |state: &State, bump: &Bump, out: &mut BumpVec<'_, ArenaHap<'_, Fraction>>| {
+            state.span.for_each_cycle_span(|cycle_span| {
+                let cycle = cycle_span.begin.sam();
+                let one = Fraction::from_integer(1);
+                let s = spc.sample(&cycle, bump);
+                let w = steps.sample(&cycle, bump).max_of(&one);
+                out.push(ArenaHap {
+                    whole: Some(cycle.whole_cycle()),
+                    part: cycle_span.clone(),
+                    value: &s / &w,
+                    context: ArenaHapContext::empty_ref(),
+                });
+            });
+        },
+    )
 }
 
 /// Arrange patterns over multiple cycles (Strudel's `arrange`).

--- a/crates/modular_core/src/pattern_system/mini/ast.rs
+++ b/crates/modular_core/src/pattern_system/mini/ast.rs
@@ -385,7 +385,9 @@ pub(crate) mod test_builders {
     //! programmatically. These replace the Pest parser in existing Rust
     //! tests — see `pattern_system::mini::tests` / convert tests.
 
-    use super::{AtomValue, Located, MiniAST, MiniASTF64, MiniASTI32, MiniASTU32, ReplicateCount, Weight};
+    use super::{
+        AtomValue, Located, MiniAST, MiniASTF64, MiniASTI32, MiniASTU32, ReplicateCount, Weight,
+    };
     use crate::pattern_system::SourceSpan;
 
     pub fn span(start: usize, end: usize) -> SourceSpan {

--- a/crates/modular_core/src/pattern_system/mini/ast.rs
+++ b/crates/modular_core/src/pattern_system/mini/ast.rs
@@ -32,6 +32,50 @@ impl<T> Located<T> {
     }
 }
 
+/// Weight operand carried by a sequence entry (`@` or `_` elongation).
+///
+/// Serialized untagged: a static weight is a bare JSON number, a patterned
+/// weight (`a@<1 2>`) is a `MiniASTF64` object. `Static` must stay the first
+/// variant so untagged deserialization matches the bare number before
+/// attempting the pattern shape.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum Weight {
+    Static(f64),
+    Pattern(Box<MiniASTF64>),
+}
+
+impl Weight {
+    pub fn as_static(&self) -> Option<f64> {
+        match self {
+            Weight::Static(w) => Some(*w),
+            Weight::Pattern(_) => None,
+        }
+    }
+}
+
+/// Replicate count operand (`!`).
+///
+/// Serialized untagged: a static count is a bare JSON number, a patterned
+/// count (`a!<2 3>`) is a `MiniASTU32` object. `Static` must stay the first
+/// variant so untagged deserialization matches the bare number before
+/// attempting the pattern shape.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ReplicateCount {
+    Static(u32),
+    Pattern(Box<MiniASTU32>),
+}
+
+impl ReplicateCount {
+    pub fn as_static(&self) -> Option<u32> {
+        match self {
+            ReplicateCount::Static(c) => Some(*c),
+            ReplicateCount::Pattern(_) => None,
+        }
+    }
+}
+
 /// AST for signed integer patterns (used for euclidean rotation).
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub enum MiniASTI32 {
@@ -45,13 +89,13 @@ pub enum MiniASTI32 {
     List(Located<Vec<MiniASTI32>>),
 
     /// Sequence of patterns (space-separated, played in order).
-    Sequence(Vec<(MiniASTI32, Option<f64>)>), // (pattern, optional weight)
+    Sequence(Vec<(MiniASTI32, Option<Weight>)>), // (pattern, optional weight)
 
     /// Fast subsequence from [...] syntax (explicit fastcat).
-    FastCat(Vec<(MiniASTI32, Option<f64>)>), // (pattern, optional weight)
+    FastCat(Vec<(MiniASTI32, Option<Weight>)>), // (pattern, optional weight)
 
     /// Slow subsequence (one item per cycle, with optional @ weight).
-    SlowCat(Vec<(MiniASTI32, Option<f64>)>),
+    SlowCat(Vec<(MiniASTI32, Option<Weight>)>),
 
     /// Stack: comma-separated patterns play simultaneously.
     Stack(Vec<MiniASTI32>),
@@ -66,7 +110,7 @@ pub enum MiniASTI32 {
     Slow(Box<MiniASTI32>, Box<MiniASTF64>),
 
     /// Replicate: pattern ! n (repeat n times).
-    Replicate(Box<MiniASTI32>, u32),
+    Replicate(Box<MiniASTI32>, ReplicateCount),
 
     /// Degrade: pattern ? prob (randomly drop with probability).
     Degrade(Box<MiniASTI32>, Option<f64>, u64),
@@ -103,13 +147,13 @@ pub enum MiniASTU32 {
     List(Located<Vec<MiniASTU32>>),
 
     /// Sequence of patterns (space-separated, played in order).
-    Sequence(Vec<(MiniASTU32, Option<f64>)>), // (pattern, optional weight)
+    Sequence(Vec<(MiniASTU32, Option<Weight>)>), // (pattern, optional weight)
 
     /// Fast subsequence from [...] syntax (explicit fastcat).
-    FastCat(Vec<(MiniASTU32, Option<f64>)>), // (pattern, optional weight)
+    FastCat(Vec<(MiniASTU32, Option<Weight>)>), // (pattern, optional weight)
 
     /// Slow subsequence (one item per cycle, with optional @ weight).
-    SlowCat(Vec<(MiniASTU32, Option<f64>)>),
+    SlowCat(Vec<(MiniASTU32, Option<Weight>)>),
 
     /// Stack: comma-separated patterns play simultaneously.
     Stack(Vec<MiniASTU32>),
@@ -124,8 +168,7 @@ pub enum MiniASTU32 {
     Slow(Box<MiniASTU32>, Box<MiniASTF64>),
 
     /// Replicate: pattern ! n (repeat n times).
-    /// Count is a plain u32 since Strudel doesn't support patterned replicate counts.
-    Replicate(Box<MiniASTU32>, u32),
+    Replicate(Box<MiniASTU32>, ReplicateCount),
 
     /// Degrade: pattern ? prob (randomly drop with probability).
     Degrade(Box<MiniASTU32>, Option<f64>, u64),
@@ -159,13 +202,13 @@ pub enum MiniASTF64 {
     List(Located<Vec<MiniASTF64>>),
 
     /// Sequence of patterns (space-separated, played in order).
-    Sequence(Vec<(MiniASTF64, Option<f64>)>), // (pattern, optional weight)
+    Sequence(Vec<(MiniASTF64, Option<Weight>)>), // (pattern, optional weight)
 
     /// Fast subsequence from [...] syntax (explicit fastcat).
-    FastCat(Vec<(MiniASTF64, Option<f64>)>), // (pattern, optional weight)
+    FastCat(Vec<(MiniASTF64, Option<Weight>)>), // (pattern, optional weight)
 
     /// Slow subsequence (one item per cycle, with optional @ weight).
-    SlowCat(Vec<(MiniASTF64, Option<f64>)>),
+    SlowCat(Vec<(MiniASTF64, Option<Weight>)>),
 
     /// Stack: comma-separated patterns play simultaneously.
     Stack(Vec<MiniASTF64>),
@@ -180,8 +223,7 @@ pub enum MiniASTF64 {
     Slow(Box<MiniASTF64>, Box<MiniASTF64>),
 
     /// Replicate: pattern ! n (repeat n times).
-    /// Count is a plain u32 since Strudel doesn't support patterned replicate counts.
-    Replicate(Box<MiniASTF64>, u32),
+    Replicate(Box<MiniASTF64>, ReplicateCount),
 
     /// Degrade: pattern ? prob (randomly drop with probability).
     Degrade(Box<MiniASTF64>, Option<f64>, u64),
@@ -215,17 +257,17 @@ pub enum MiniAST {
     List(Located<Vec<MiniAST>>),
 
     /// Sequence of patterns (space-separated, played in order).
-    Sequence(Vec<(MiniAST, Option<f64>)>), // (pattern, optional weight)
+    Sequence(Vec<(MiniAST, Option<Weight>)>), // (pattern, optional weight)
 
     /// Fast subsequence from [...] syntax (explicit fastcat).
     /// Unlike Sequence which is the implicit result of space-separated elements,
     /// FastCat preserves that this came from explicit [...] grouping.
     /// This distinction matters for nesting: `<[c e]>` should be slowcat of one fastcat,
     /// not slowcat of two elements.
-    FastCat(Vec<(MiniAST, Option<f64>)>), // (pattern, optional weight)
+    FastCat(Vec<(MiniAST, Option<Weight>)>), // (pattern, optional weight)
 
     /// Slow subsequence (one item per cycle, with optional @ weight).
-    SlowCat(Vec<(MiniAST, Option<f64>)>),
+    SlowCat(Vec<(MiniAST, Option<Weight>)>),
 
     /// Stack: comma-separated patterns play simultaneously.
     Stack(Vec<MiniAST>),
@@ -240,8 +282,7 @@ pub enum MiniAST {
     Slow(Box<MiniAST>, Box<MiniASTF64>),
 
     /// Replicate: pattern ! n (repeat n times).
-    /// Count is a plain u32 since Strudel doesn't support patterned replicate counts.
-    Replicate(Box<MiniAST>, u32),
+    Replicate(Box<MiniAST>, ReplicateCount),
 
     /// Degrade: pattern ? prob (randomly drop with probability).
     Degrade(Box<MiniAST>, Option<f64>, u64),
@@ -344,7 +385,7 @@ pub(crate) mod test_builders {
     //! programmatically. These replace the Pest parser in existing Rust
     //! tests — see `pattern_system::mini::tests` / convert tests.
 
-    use super::{AtomValue, Located, MiniAST, MiniASTF64, MiniASTI32, MiniASTU32};
+    use super::{AtomValue, Located, MiniAST, MiniASTF64, MiniASTI32, MiniASTU32, ReplicateCount, Weight};
     use crate::pattern_system::SourceSpan;
 
     pub fn span(start: usize, end: usize) -> SourceSpan {
@@ -371,16 +412,23 @@ pub(crate) mod test_builders {
         MiniAST::Rest(span(start, end))
     }
 
+    fn static_weights(items: Vec<(MiniAST, Option<f64>)>) -> Vec<(MiniAST, Option<Weight>)> {
+        items
+            .into_iter()
+            .map(|(p, w)| (p, w.map(Weight::Static)))
+            .collect()
+    }
+
     pub fn seq(items: Vec<(MiniAST, Option<f64>)>) -> MiniAST {
-        MiniAST::Sequence(items)
+        MiniAST::Sequence(static_weights(items))
     }
 
     pub fn fastcat(items: Vec<(MiniAST, Option<f64>)>) -> MiniAST {
-        MiniAST::FastCat(items)
+        MiniAST::FastCat(static_weights(items))
     }
 
     pub fn slowcat(items: Vec<(MiniAST, Option<f64>)>) -> MiniAST {
-        MiniAST::SlowCat(items)
+        MiniAST::SlowCat(static_weights(items))
     }
 
     pub fn fast_f64(pattern: MiniAST, factor: f64, start: usize, end: usize) -> MiniAST {
@@ -415,7 +463,7 @@ pub(crate) mod test_builders {
     }
 
     pub fn replicate(pattern: MiniAST, count: u32) -> MiniAST {
-        MiniAST::Replicate(Box::new(pattern), count)
+        MiniAST::Replicate(Box::new(pattern), ReplicateCount::Static(count))
     }
 
     pub fn degrade(pattern: MiniAST, prob: Option<f64>, seed: u64) -> MiniAST {
@@ -444,14 +492,12 @@ fn collect_leaf_spans_recursive(ast: &MiniAST, spans: &mut Vec<(usize, usize)>) 
                 collect_leaf_spans_recursive(child, spans);
             }
         }
-        MiniAST::Sequence(items) | MiniAST::FastCat(items) => {
-            for (child, _weight) in items {
+        MiniAST::Sequence(items) | MiniAST::FastCat(items) | MiniAST::SlowCat(items) => {
+            for (child, weight) in items {
                 collect_leaf_spans_recursive(child, spans);
-            }
-        }
-        MiniAST::SlowCat(items) => {
-            for (child, _weight) in items {
-                collect_leaf_spans_recursive(child, spans);
+                if let Some(Weight::Pattern(w)) = weight {
+                    collect_f64_spans(w, spans);
+                }
             }
         }
         MiniAST::RandomChoice(items, _) | MiniAST::Stack(items) => {
@@ -467,8 +513,11 @@ fn collect_leaf_spans_recursive(ast: &MiniAST, spans: &mut Vec<(usize, usize)>) 
             collect_leaf_spans_recursive(pattern, spans);
             collect_f64_spans(factor, spans);
         }
-        MiniAST::Replicate(pattern, _count) => {
+        MiniAST::Replicate(pattern, count) => {
             collect_leaf_spans_recursive(pattern, spans);
+            if let ReplicateCount::Pattern(c) = count {
+                collect_u32_spans(c, spans);
+            }
         }
         MiniAST::Degrade(pattern, _prob, _) => {
             collect_leaf_spans_recursive(pattern, spans);
@@ -514,14 +563,12 @@ fn collect_f64_spans(ast: &MiniASTF64, spans: &mut Vec<(usize, usize)>) {
                 collect_f64_spans(child, spans);
             }
         }
-        MiniASTF64::Sequence(items) | MiniASTF64::FastCat(items) => {
-            for (child, _weight) in items {
+        MiniASTF64::Sequence(items) | MiniASTF64::FastCat(items) | MiniASTF64::SlowCat(items) => {
+            for (child, weight) in items {
                 collect_f64_spans(child, spans);
-            }
-        }
-        MiniASTF64::SlowCat(items) => {
-            for (child, _weight) in items {
-                collect_f64_spans(child, spans);
+                if let Some(Weight::Pattern(w)) = weight {
+                    collect_f64_spans(w, spans);
+                }
             }
         }
         MiniASTF64::RandomChoice(items, _) | MiniASTF64::Stack(items) => {
@@ -537,8 +584,11 @@ fn collect_f64_spans(ast: &MiniASTF64, spans: &mut Vec<(usize, usize)>) {
             collect_f64_spans(pattern, spans);
             collect_f64_spans(factor, spans);
         }
-        MiniASTF64::Replicate(pattern, _count) => {
+        MiniASTF64::Replicate(pattern, count) => {
             collect_f64_spans(pattern, spans);
+            if let ReplicateCount::Pattern(c) = count {
+                collect_u32_spans(c, spans);
+            }
         }
         MiniASTF64::Degrade(pattern, _prob, _) => {
             collect_f64_spans(pattern, spans);
@@ -584,14 +634,12 @@ fn collect_u32_spans(ast: &MiniASTU32, spans: &mut Vec<(usize, usize)>) {
                 collect_u32_spans(child, spans);
             }
         }
-        MiniASTU32::Sequence(items) | MiniASTU32::FastCat(items) => {
-            for (child, _weight) in items {
+        MiniASTU32::Sequence(items) | MiniASTU32::FastCat(items) | MiniASTU32::SlowCat(items) => {
+            for (child, weight) in items {
                 collect_u32_spans(child, spans);
-            }
-        }
-        MiniASTU32::SlowCat(items) => {
-            for (child, _weight) in items {
-                collect_u32_spans(child, spans);
+                if let Some(Weight::Pattern(w)) = weight {
+                    collect_f64_spans(w, spans);
+                }
             }
         }
         MiniASTU32::RandomChoice(items, _) | MiniASTU32::Stack(items) => {
@@ -607,8 +655,11 @@ fn collect_u32_spans(ast: &MiniASTU32, spans: &mut Vec<(usize, usize)>) {
             collect_u32_spans(pattern, spans);
             collect_f64_spans(factor, spans);
         }
-        MiniASTU32::Replicate(pattern, _count) => {
+        MiniASTU32::Replicate(pattern, count) => {
             collect_u32_spans(pattern, spans);
+            if let ReplicateCount::Pattern(c) = count {
+                collect_u32_spans(c, spans);
+            }
         }
         MiniASTU32::Degrade(pattern, _prob, _) => {
             collect_u32_spans(pattern, spans);
@@ -654,14 +705,12 @@ fn collect_i32_spans(ast: &MiniASTI32, spans: &mut Vec<(usize, usize)>) {
                 collect_i32_spans(child, spans);
             }
         }
-        MiniASTI32::Sequence(items) | MiniASTI32::FastCat(items) => {
-            for (child, _weight) in items {
+        MiniASTI32::Sequence(items) | MiniASTI32::FastCat(items) | MiniASTI32::SlowCat(items) => {
+            for (child, weight) in items {
                 collect_i32_spans(child, spans);
-            }
-        }
-        MiniASTI32::SlowCat(items) => {
-            for (child, _weight) in items {
-                collect_i32_spans(child, spans);
+                if let Some(Weight::Pattern(w)) = weight {
+                    collect_f64_spans(w, spans);
+                }
             }
         }
         MiniASTI32::RandomChoice(items, _) | MiniASTI32::Stack(items) => {
@@ -677,8 +726,11 @@ fn collect_i32_spans(ast: &MiniASTI32, spans: &mut Vec<(usize, usize)>) {
             collect_i32_spans(pattern, spans);
             collect_f64_spans(factor, spans);
         }
-        MiniASTI32::Replicate(pattern, _count) => {
+        MiniASTI32::Replicate(pattern, count) => {
             collect_i32_spans(pattern, spans);
+            if let ReplicateCount::Pattern(c) = count {
+                collect_u32_spans(c, spans);
+            }
         }
         MiniASTI32::Degrade(pattern, _prob, _) => {
             collect_i32_spans(pattern, spans);

--- a/crates/modular_core/src/pattern_system/mini/convert.rs
+++ b/crates/modular_core/src/pattern_system/mini/convert.rs
@@ -3,7 +3,9 @@
 //! The conversion is parameterized by the target atom type through
 //! the `FromMiniAtom` trait.
 
-use super::ast::{AtomValue, Located, MiniAST, MiniASTF64, MiniASTI32, MiniASTU32};
+use super::ast::{
+    AtomValue, Located, MiniAST, MiniASTF64, MiniASTI32, MiniASTU32, ReplicateCount, Weight,
+};
 use crate::pattern_system::{
     Fraction, Pattern,
     combinators::{fastcat, slowcat, stack, timecat},
@@ -257,7 +259,15 @@ macro_rules! define_validate_limits {
                     node.iter().try_for_each(|a| $name(a, budget))
                 }
                 $ast::Sequence(items) | $ast::FastCat(items) | $ast::SlowCat(items) => {
-                    items.iter().try_for_each(|(p, _)| $name(p, budget))
+                    items.iter().try_for_each(|(p, w)| {
+                        if let Some(Weight::Pattern(wp)) = w {
+                            // A weight operand is a separate pattern,
+                            // materialized on its own, so it starts from a
+                            // fresh budget.
+                            validate_limits_f64(wp, 1)?;
+                        }
+                        $name(p, budget)
+                    })
                 }
                 $ast::Stack(items) | $ast::RandomChoice(items, _) => {
                     items.iter().try_for_each(|a| $name(a, budget))
@@ -269,12 +279,22 @@ macro_rules! define_validate_limits {
                     validate_limits_f64(factor, 1)
                 }
                 $ast::Replicate(pattern, count) => {
+                    let max_count = match count {
+                        ReplicateCount::Static(c) => *c,
+                        // A patterned count is a separate operand pattern
+                        // (fresh budget); its largest leaf bounds every value
+                        // the query path can ever sample.
+                        ReplicateCount::Pattern(cp) => {
+                            validate_limits_u32(cp, 1)?;
+                            max_u32_leaf(cp)
+                        }
+                    };
                     // A zero count must not zero the running budget: every
                     // nested product would stay 0 and slip under the cap.
-                    let expansion = budget.saturating_mul((*count).max(1));
+                    let expansion = budget.saturating_mul(max_count.max(1));
                     if expansion > MAX_EXPANSION {
                         return Err(ConvertError::OperatorError(format!(
-                            "replicate count {count} expands the pattern to {expansion} steps, past the maximum of {MAX_EXPANSION}"
+                            "replicate count {max_count} expands the pattern to {expansion} steps, past the maximum of {MAX_EXPANSION}"
                         )));
                     }
                     $name(pattern, expansion)
@@ -370,10 +390,15 @@ fn eval_f64(ast: &MiniASTF64) -> f64 {
 fn step_count_main(ast: &MiniAST) -> f64 {
     match ast {
         MiniAST::Sequence(items) | MiniAST::FastCat(items) | MiniAST::SlowCat(items) => {
-            let total: f64 = items.iter().map(|(_, w)| w.unwrap_or(1.0)).sum();
+            let total: f64 = items
+                .iter()
+                .map(|(_, w)| w.as_ref().and_then(Weight::as_static).unwrap_or(1.0))
+                .sum();
             if total == 0.0 { 1.0 } else { total }
         }
-        MiniAST::Replicate(inner, count) => step_count_main(inner) * (*count as f64),
+        MiniAST::Replicate(inner, count) => {
+            step_count_main(inner) * (count.as_static().unwrap_or(1) as f64)
+        }
         MiniAST::Polymeter {
             steps_per_cycle, ..
         } => steps_per_cycle.as_deref().map(eval_f64).unwrap_or(1.0),
@@ -384,10 +409,15 @@ fn step_count_main(ast: &MiniAST) -> f64 {
 fn step_count_f64(ast: &MiniASTF64) -> f64 {
     match ast {
         MiniASTF64::Sequence(items) | MiniASTF64::FastCat(items) | MiniASTF64::SlowCat(items) => {
-            let total: f64 = items.iter().map(|(_, w)| w.unwrap_or(1.0)).sum();
+            let total: f64 = items
+                .iter()
+                .map(|(_, w)| w.as_ref().and_then(Weight::as_static).unwrap_or(1.0))
+                .sum();
             if total == 0.0 { 1.0 } else { total }
         }
-        MiniASTF64::Replicate(inner, count) => step_count_f64(inner) * (*count as f64),
+        MiniASTF64::Replicate(inner, count) => {
+            step_count_f64(inner) * (count.as_static().unwrap_or(1) as f64)
+        }
         MiniASTF64::Polymeter {
             steps_per_cycle, ..
         } => steps_per_cycle.as_deref().map(eval_f64).unwrap_or(1.0),
@@ -398,10 +428,15 @@ fn step_count_f64(ast: &MiniASTF64) -> f64 {
 fn step_count_u32(ast: &MiniASTU32) -> f64 {
     match ast {
         MiniASTU32::Sequence(items) | MiniASTU32::FastCat(items) | MiniASTU32::SlowCat(items) => {
-            let total: f64 = items.iter().map(|(_, w)| w.unwrap_or(1.0)).sum();
+            let total: f64 = items
+                .iter()
+                .map(|(_, w)| w.as_ref().and_then(Weight::as_static).unwrap_or(1.0))
+                .sum();
             if total == 0.0 { 1.0 } else { total }
         }
-        MiniASTU32::Replicate(inner, count) => step_count_u32(inner) * (*count as f64),
+        MiniASTU32::Replicate(inner, count) => {
+            step_count_u32(inner) * (count.as_static().unwrap_or(1) as f64)
+        }
         MiniASTU32::Polymeter {
             steps_per_cycle, ..
         } => steps_per_cycle.as_deref().map(eval_f64).unwrap_or(1.0),
@@ -412,10 +447,15 @@ fn step_count_u32(ast: &MiniASTU32) -> f64 {
 fn step_count_i32(ast: &MiniASTI32) -> f64 {
     match ast {
         MiniASTI32::Sequence(items) | MiniASTI32::FastCat(items) | MiniASTI32::SlowCat(items) => {
-            let total: f64 = items.iter().map(|(_, w)| w.unwrap_or(1.0)).sum();
+            let total: f64 = items
+                .iter()
+                .map(|(_, w)| w.as_ref().and_then(Weight::as_static).unwrap_or(1.0))
+                .sum();
             if total == 0.0 { 1.0 } else { total }
         }
-        MiniASTI32::Replicate(inner, count) => step_count_i32(inner) * (*count as f64),
+        MiniASTI32::Replicate(inner, count) => {
+            step_count_i32(inner) * (count.as_static().unwrap_or(1) as f64)
+        }
         MiniASTI32::Polymeter {
             steps_per_cycle, ..
         } => steps_per_cycle.as_deref().map(eval_f64).unwrap_or(1.0),
@@ -453,11 +493,12 @@ fn convert_f64_pattern(ast: &MiniASTF64) -> Pattern<Fraction> {
             let expanded: Vec<(&MiniASTF64, Option<f64>)> = elements
                 .iter()
                 .flat_map(|(p, w)| match p {
-                    MiniASTF64::Replicate(inner, count) => {
-                        std::iter::repeat_n((inner.as_ref(), None), *count as usize)
-                            .collect::<Vec<_>>()
-                    }
-                    other => vec![(other, *w)],
+                    MiniASTF64::Replicate(inner, count) => std::iter::repeat_n(
+                        (inner.as_ref(), None),
+                        count.as_static().unwrap_or(1) as usize,
+                    )
+                    .collect::<Vec<_>>(),
+                    other => vec![(other, w.as_ref().and_then(Weight::as_static))],
                 })
                 .collect();
 
@@ -485,11 +526,12 @@ fn convert_f64_pattern(ast: &MiniASTF64) -> Pattern<Fraction> {
             let expanded: Vec<(&MiniASTF64, Option<f64>)> = elements
                 .iter()
                 .flat_map(|(p, w)| match p {
-                    MiniASTF64::Replicate(inner, count) => {
-                        std::iter::repeat_n((inner.as_ref(), None), *count as usize)
-                            .collect::<Vec<_>>()
-                    }
-                    other => vec![(other, *w)],
+                    MiniASTF64::Replicate(inner, count) => std::iter::repeat_n(
+                        (inner.as_ref(), None),
+                        count.as_static().unwrap_or(1) as usize,
+                    )
+                    .collect::<Vec<_>>(),
+                    other => vec![(other, w.as_ref().and_then(Weight::as_static))],
                 })
                 .collect();
 
@@ -538,7 +580,9 @@ fn convert_f64_pattern(ast: &MiniASTF64) -> Pattern<Fraction> {
 
         MiniASTF64::Replicate(pattern, count) => {
             let pat = convert_f64_pattern(pattern);
-            let pats: Vec<Pattern<Fraction>> = (0..*count).map(|_| pat.clone()).collect();
+            let pats: Vec<Pattern<Fraction>> = (0..count.as_static().unwrap_or(1))
+                .map(|_| pat.clone())
+                .collect();
             fastcat(pats)
         }
 
@@ -602,11 +646,12 @@ fn convert_u32_pattern(ast: &MiniASTU32) -> Pattern<u32> {
             let expanded: Vec<(&MiniASTU32, Option<f64>)> = elements
                 .iter()
                 .flat_map(|(p, w)| match p {
-                    MiniASTU32::Replicate(inner, count) => {
-                        std::iter::repeat_n((inner.as_ref(), None), *count as usize)
-                            .collect::<Vec<_>>()
-                    }
-                    other => vec![(other, *w)],
+                    MiniASTU32::Replicate(inner, count) => std::iter::repeat_n(
+                        (inner.as_ref(), None),
+                        count.as_static().unwrap_or(1) as usize,
+                    )
+                    .collect::<Vec<_>>(),
+                    other => vec![(other, w.as_ref().and_then(Weight::as_static))],
                 })
                 .collect();
 
@@ -632,11 +677,12 @@ fn convert_u32_pattern(ast: &MiniASTU32) -> Pattern<u32> {
             let expanded: Vec<(&MiniASTU32, Option<f64>)> = elements
                 .iter()
                 .flat_map(|(p, w)| match p {
-                    MiniASTU32::Replicate(inner, count) => {
-                        std::iter::repeat_n((inner.as_ref(), None), *count as usize)
-                            .collect::<Vec<_>>()
-                    }
-                    other => vec![(other, *w)],
+                    MiniASTU32::Replicate(inner, count) => std::iter::repeat_n(
+                        (inner.as_ref(), None),
+                        count.as_static().unwrap_or(1) as usize,
+                    )
+                    .collect::<Vec<_>>(),
+                    other => vec![(other, w.as_ref().and_then(Weight::as_static))],
                 })
                 .collect();
 
@@ -685,7 +731,9 @@ fn convert_u32_pattern(ast: &MiniASTU32) -> Pattern<u32> {
 
         MiniASTU32::Replicate(pattern, count) => {
             let pat = convert_u32_pattern(pattern);
-            let pats: Vec<Pattern<u32>> = (0..*count).map(|_| pat.clone()).collect();
+            let pats: Vec<Pattern<u32>> = (0..count.as_static().unwrap_or(1))
+                .map(|_| pat.clone())
+                .collect();
             fastcat(pats)
         }
 
@@ -743,11 +791,12 @@ fn convert_i32_pattern(ast: &MiniASTI32) -> Pattern<i32> {
             let expanded: Vec<(&MiniASTI32, Option<f64>)> = elements
                 .iter()
                 .flat_map(|(p, w)| match p {
-                    MiniASTI32::Replicate(inner, count) => {
-                        std::iter::repeat_n((inner.as_ref(), None), *count as usize)
-                            .collect::<Vec<_>>()
-                    }
-                    other => vec![(other, *w)],
+                    MiniASTI32::Replicate(inner, count) => std::iter::repeat_n(
+                        (inner.as_ref(), None),
+                        count.as_static().unwrap_or(1) as usize,
+                    )
+                    .collect::<Vec<_>>(),
+                    other => vec![(other, w.as_ref().and_then(Weight::as_static))],
                 })
                 .collect();
 
@@ -773,11 +822,12 @@ fn convert_i32_pattern(ast: &MiniASTI32) -> Pattern<i32> {
             let expanded: Vec<(&MiniASTI32, Option<f64>)> = elements
                 .iter()
                 .flat_map(|(p, w)| match p {
-                    MiniASTI32::Replicate(inner, count) => {
-                        std::iter::repeat_n((inner.as_ref(), None), *count as usize)
-                            .collect::<Vec<_>>()
-                    }
-                    other => vec![(other, *w)],
+                    MiniASTI32::Replicate(inner, count) => std::iter::repeat_n(
+                        (inner.as_ref(), None),
+                        count.as_static().unwrap_or(1) as usize,
+                    )
+                    .collect::<Vec<_>>(),
+                    other => vec![(other, w.as_ref().and_then(Weight::as_static))],
                 })
                 .collect();
 
@@ -826,7 +876,9 @@ fn convert_i32_pattern(ast: &MiniASTI32) -> Pattern<i32> {
 
         MiniASTI32::Replicate(pattern, count) => {
             let pat = convert_i32_pattern(pattern);
-            let pats: Vec<Pattern<i32>> = (0..*count).map(|_| pat.clone()).collect();
+            let pats: Vec<Pattern<i32>> = (0..count.as_static().unwrap_or(1))
+                .map(|_| pat.clone())
+                .collect();
             fastcat(pats)
         }
 
@@ -900,6 +952,15 @@ fn eval_i32(ast: &MiniASTI32) -> i32 {
         MiniASTI32::Euclidean { pattern, .. } => eval_i32(pattern),
         MiniASTI32::Polymeter { children, .. } => children.first().map(eval_i32).unwrap_or(0),
     }
+}
+
+/// True when any entry carries a patterned `@` weight or is a `!` replicate
+/// with a patterned count, so the sequence's layout varies per cycle.
+fn has_dynamic_entries(items: &[(MiniAST, Option<Weight>)]) -> bool {
+    items.iter().any(|(p, w)| {
+        matches!(w, Some(Weight::Pattern(_)))
+            || matches!(p, MiniAST::Replicate(_, ReplicateCount::Pattern(_)))
+    })
 }
 
 fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertError> {
@@ -993,6 +1054,11 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
         }
 
         MiniAST::Sequence(elements) | MiniAST::FastCat(elements) => {
+            if has_dynamic_entries(elements) {
+                return Err(ConvertError::OperatorError(
+                    "patterned @ weights and ! counts are not implemented".to_string(),
+                ));
+            }
             // Expand Replicate nodes into sibling steps. In Strudel `[a b!2 c]`
             // is `[a b b c]`: `!n` adds `n` sibling steps that share the
             // parent's stepping, not one step holding a fastcat of `n` copies.
@@ -1000,11 +1066,12 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
             let expanded: Vec<(&MiniAST, Option<f64>)> = elements
                 .iter()
                 .flat_map(|(p, w)| match p {
-                    MiniAST::Replicate(inner, count) => {
-                        std::iter::repeat_n((inner.as_ref(), None), *count as usize)
-                            .collect::<Vec<_>>()
-                    }
-                    other => vec![(other, *w)],
+                    MiniAST::Replicate(inner, count) => std::iter::repeat_n(
+                        (inner.as_ref(), None),
+                        count.as_static().unwrap_or(1) as usize,
+                    )
+                    .collect::<Vec<_>>(),
+                    other => vec![(other, w.as_ref().and_then(Weight::as_static))],
                 })
                 .collect();
 
@@ -1026,6 +1093,11 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
         }
 
         MiniAST::SlowCat(patterns) => {
+            if has_dynamic_entries(patterns) {
+                return Err(ConvertError::OperatorError(
+                    "patterned @ weights and ! counts are not implemented".to_string(),
+                ));
+            }
             // Expand Replicate nodes within SlowCat.
             // In Strudel/Tidal, <a!3 b> means "slowcat of a, a, a, b" (each on separate cycles),
             // not "slowcat of fastcat(a,a,a), b" (which would be 3 a's in cycle 1, b in cycle 2).
@@ -1034,10 +1106,13 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
                 .flat_map(|(p, w)| match p {
                     MiniAST::Replicate(inner, count) => {
                         // Replicated entries each get weight 1 (or None)
-                        std::iter::repeat_n((inner.as_ref(), None), *count as usize)
-                            .collect::<Vec<_>>()
+                        std::iter::repeat_n(
+                            (inner.as_ref(), None),
+                            count.as_static().unwrap_or(1) as usize,
+                        )
+                        .collect::<Vec<_>>()
                     }
-                    other => vec![(other, *w)],
+                    other => vec![(other, w.as_ref().and_then(Weight::as_static))],
                 })
                 .collect();
 
@@ -1096,8 +1171,13 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
         }
 
         MiniAST::Replicate(pattern, count) => {
+            let Some(count) = count.as_static() else {
+                return Err(ConvertError::OperatorError(
+                    "patterned @ weights and ! counts are not implemented".to_string(),
+                ));
+            };
             let pat = convert_inner(pattern)?;
-            let pats: Vec<Pattern<T>> = (0..*count).map(|_| pat.clone()).collect();
+            let pats: Vec<Pattern<T>> = (0..count).map(|_| pat.clone()).collect();
             Ok(fastcat(pats))
         }
 
@@ -1730,7 +1810,10 @@ mod tests {
     fn test_eval_f64_sequence() {
         let ast = MiniASTF64::Sequence(vec![
             (MiniASTF64::Pure(Located::new(3.0, 0, 1)), None),
-            (MiniASTF64::Pure(Located::new(4.0, 2, 3)), Some(2.0)),
+            (
+                MiniASTF64::Pure(Located::new(4.0, 2, 3)),
+                Some(Weight::Static(2.0)),
+            ),
         ]);
         assert!((eval_f64(&ast) - 3.0).abs() < 0.001); // Returns first element
     }
@@ -1776,7 +1859,10 @@ mod tests {
 
     #[test]
     fn test_eval_f64_replicate() {
-        let ast = MiniASTF64::Replicate(Box::new(MiniASTF64::Pure(Located::new(11.0, 0, 2))), 3);
+        let ast = MiniASTF64::Replicate(
+            Box::new(MiniASTF64::Pure(Located::new(11.0, 0, 2))),
+            ReplicateCount::Static(3),
+        );
         assert!((eval_f64(&ast) - 11.0).abs() < 0.001);
     }
 
@@ -1859,7 +1945,7 @@ mod tests {
                 (MiniASTF64::Pure(Located::new(24.0, 0, 2)), None),
                 (MiniASTF64::Pure(Located::new(25.0, 3, 5)), None),
             ])),
-            3,
+            ReplicateCount::Static(3),
         );
         assert!((eval_f64(&ast) - 24.0).abs() < 0.001);
     }
@@ -1941,7 +2027,10 @@ mod tests {
     fn test_eval_u32_sequence() {
         let ast = MiniASTU32::Sequence(vec![
             (MiniASTU32::Pure(Located::new(3, 0, 1)), None),
-            (MiniASTU32::Pure(Located::new(4, 2, 3)), Some(2.0)),
+            (
+                MiniASTU32::Pure(Located::new(4, 2, 3)),
+                Some(Weight::Static(2.0)),
+            ),
         ]);
         assert_eq!(eval_u32(&ast), 3);
     }
@@ -1987,7 +2076,10 @@ mod tests {
 
     #[test]
     fn test_eval_u32_replicate() {
-        let ast = MiniASTU32::Replicate(Box::new(MiniASTU32::Pure(Located::new(11, 0, 2))), 3);
+        let ast = MiniASTU32::Replicate(
+            Box::new(MiniASTU32::Pure(Located::new(11, 0, 2))),
+            ReplicateCount::Static(3),
+        );
         assert_eq!(eval_u32(&ast), 11);
     }
 
@@ -2066,7 +2158,7 @@ mod tests {
                 (MiniASTU32::Pure(Located::new(24, 0, 2)), None),
                 (MiniASTU32::Pure(Located::new(25, 3, 5)), None),
             ])),
-            3,
+            ReplicateCount::Static(3),
         );
         assert_eq!(eval_u32(&ast), 24);
     }
@@ -2114,7 +2206,7 @@ mod tests {
                 (MiniASTF64::Pure(Located::new(1.5, 0, 3)), None),
                 (MiniASTF64::Pure(Located::new(2.5, 4, 7)), None),
             ])),
-            3,
+            ReplicateCount::Static(3),
         );
         assert!((eval_f64(&ast) - 1.5).abs() < 0.001);
     }
@@ -2533,7 +2625,7 @@ mod tests {
     #[test]
     fn test_replicate_count_limit_in_operand_pattern() {
         // Limits apply inside typed operand patterns (e.g. a `*` factor).
-        let factor = MiniASTF64::Replicate(Box::new(f64_pure(2.0)), 2000);
+        let factor = MiniASTF64::Replicate(Box::new(f64_pure(2.0)), ReplicateCount::Static(2000));
         let ast = MiniAST::Fast(Box::new(num_atom(1.0)), Box::new(factor));
         assert!(convert::<f64>(&ast).is_err());
     }

--- a/crates/modular_core/src/pattern_system/mini/convert.rs
+++ b/crates/modular_core/src/pattern_system/mini/convert.rs
@@ -8,7 +8,10 @@ use super::ast::{
 };
 use crate::pattern_system::{
     Fraction, Pattern,
-    combinators::{fastcat, slowcat, stack, timecat},
+    combinators::{
+        DynCount, DynTimecatEntry, DynWeight, StepSpec, dyn_polymeter_factor, dyn_timecat, fastcat,
+        slowcat, stack, stride_cycles, timecat,
+    },
     constructors,
     constructors::pure_with_span,
     random::choose_with_seed,
@@ -244,6 +247,382 @@ fn max_u32_leaf(ast: &MiniASTU32) -> u32 {
     }
 }
 
+/// LCM of two periods, `None` past `MAX_EXPANSION` (treated like an
+/// aperiodic operand by the slowcat unroll).
+fn lcm_u64(a: u64, b: u64) -> Option<u64> {
+    fn gcd(mut a: u64, mut b: u64) -> u64 {
+        while b != 0 {
+            (a, b) = (b, a % b);
+        }
+        a
+    }
+    if a == 0 || b == 0 {
+        return Some(1);
+    }
+    mul_capped(a / gcd(a, b), b)
+}
+
+/// Product of two periods, `None` past `MAX_EXPANSION`.
+fn mul_capped(a: u64, b: u64) -> Option<u64> {
+    a.checked_mul(b).filter(|p| *p <= MAX_EXPANSION as u64)
+}
+
+/// Generates the cycle-period analysis for a typed operand AST: the number
+/// of cycles after which the operand, as lowered by its operand converter,
+/// provably repeats. The result is a valid multiple of the fundamental
+/// period, not necessarily minimal. `None` marks operands with no usable
+/// period: `|` random choice, patterned `fast`/`slow` factors, nested
+/// dynamic slowcats, and anything whose bound overflows `MAX_EXPANSION`.
+macro_rules! define_operand_period {
+    ($name:ident, $ast:ident, $step_count:ident, $step_spec:ident) => {
+        fn $name(ast: &$ast) -> Option<u64> {
+            match ast {
+                $ast::Pure(_) | $ast::Rest(_) => Some(1),
+                $ast::List(Located { node, .. }) => node.first().map_or(Some(1), $name),
+                $ast::Sequence(items) | $ast::FastCat(items) => {
+                    // A dynamic layout re-rolls with the joint period of the
+                    // children and their weight/count operands.
+                    let mut p = 1u64;
+                    for (child, w) in items {
+                        p = lcm_u64(p, $name(child)?)?;
+                        if let Some(Weight::Pattern(wp)) = w {
+                            p = lcm_u64(p, operand_period_f64(wp)?)?;
+                        }
+                    }
+                    Some(p)
+                }
+                $ast::SlowCat(items) => {
+                    if items.iter().any(|(p, w)| {
+                        matches!(w, Some(Weight::Pattern(_)))
+                            || matches!(p, $ast::Replicate(_, ReplicateCount::Pattern(_)))
+                    }) {
+                        // A nested dynamic slowcat unrolls on its own; bounding
+                        // its period here is not worth the complexity.
+                        return None;
+                    }
+                    // Static weighted slowcat lowers to timecat(...)._slow(total):
+                    // inner cycles advance one per `total` outer cycles, so the
+                    // pattern repeats after numer(total · L) outer cycles, L being
+                    // the LCM of the entries' periods.
+                    let mut l = 1u64;
+                    let mut total = Fraction::from_integer(0);
+                    for (child, w) in items {
+                        let (inner, copies, weight): (&$ast, u32, Fraction) = match child {
+                            $ast::Replicate(inner_p, count) => (
+                                inner_p.as_ref(),
+                                count.as_static().unwrap_or(1),
+                                Fraction::from_integer(1),
+                            ),
+                            other => (
+                                other,
+                                1,
+                                Fraction::from(
+                                    w.as_ref().and_then(Weight::as_static).unwrap_or(1.0),
+                                ),
+                            ),
+                        };
+                        l = lcm_u64(l, $name(inner)?)?;
+                        total = &total + &(&weight * &Fraction::from_integer(copies as i64));
+                    }
+                    if total <= Fraction::from_integer(0) {
+                        return Some(1);
+                    }
+                    let period = &total * &Fraction::from_integer(l as i64);
+                    let n = period.numer() as u64;
+                    if n > MAX_EXPANSION as u64 {
+                        None
+                    } else {
+                        Some(n)
+                    }
+                }
+                $ast::Stack(items) => {
+                    let mut p = 1u64;
+                    for child in items {
+                        p = lcm_u64(p, $name(child)?)?;
+                    }
+                    Some(p)
+                }
+                $ast::RandomChoice(..) => None,
+                $ast::Fast(pattern, factor) => {
+                    let MiniASTF64::Pure(Located { node, .. }) = factor.as_ref() else {
+                        return None;
+                    };
+                    let f = Fraction::from(*node);
+                    if f.is_zero() {
+                        // fast(0) is silence.
+                        return Some(1);
+                    }
+                    mul_capped($name(pattern)?, f.denom() as u64)
+                }
+                $ast::Slow(pattern, factor) => {
+                    let MiniASTF64::Pure(Located { node, .. }) = factor.as_ref() else {
+                        return None;
+                    };
+                    let f = Fraction::from(*node);
+                    if f.is_zero() {
+                        // slow(0) is silence.
+                        return Some(1);
+                    }
+                    mul_capped($name(pattern)?, f.numer().unsigned_abs())
+                }
+                $ast::Replicate(inner, count) => {
+                    let mut p = $name(inner)?;
+                    if let ReplicateCount::Pattern(cp) = count {
+                        p = lcm_u64(p, operand_period_u32(cp)?)?;
+                    }
+                    Some(p)
+                }
+                // Degrade and euclidean args are identities in the operand
+                // converters, so only the inner pattern contributes.
+                $ast::Degrade(pattern, _, _) => $name(pattern),
+                $ast::Euclidean { pattern, .. } => $name(pattern),
+                $ast::Polymeter {
+                    children,
+                    steps_per_cycle,
+                } => {
+                    // Voices lower to `child.fast(spc / w)`; each multiplies
+                    // the period by its factor's denominator. Per-cycle step
+                    // counts make the factors patterns, so bail.
+                    if steps_per_cycle.is_none()
+                        && children
+                            .first()
+                            .is_some_and(|c| matches!($step_spec(c), StepSpec::Dyn(_)))
+                    {
+                        return None;
+                    }
+                    let spc = Fraction::from(
+                        steps_per_cycle
+                            .as_deref()
+                            .map(eval_f64)
+                            .unwrap_or_else(|| children.first().map($step_count).unwrap_or(1.0)),
+                    );
+                    let mut p = 1u64;
+                    for c in children {
+                        if matches!($step_spec(c), StepSpec::Dyn(_)) {
+                            return None;
+                        }
+                        let w = Fraction::from($step_count(c).max(1.0));
+                        let f = &spc / &w;
+                        if f.is_zero() {
+                            continue;
+                        }
+                        p = lcm_u64(p, mul_capped($name(c)?, f.denom() as u64)?)?;
+                    }
+                    Some(p)
+                }
+            }
+        }
+    };
+}
+
+define_operand_period!(
+    operand_period_f64,
+    MiniASTF64,
+    step_count_f64,
+    step_spec_f64
+);
+define_operand_period!(
+    operand_period_u32,
+    MiniASTU32,
+    step_count_u32,
+    step_spec_u32
+);
+
+/// Generates the dynamic-entry analysis shared by the four converters:
+/// detection of patterned `@`/`!` operands on sequence entries, the joint
+/// unroll pass count and slot bound for a dynamic slowcat, and a polymeter
+/// voice's per-cycle step spec.
+macro_rules! define_dyn_entry_analysis {
+    ($has_dyn:ident, $passes:ident, $slots_bound:ident, $step_spec:ident, $ast:ident, $step_count:ident) => {
+        /// True when any entry carries a patterned `@` weight or a patterned
+        /// `!` count, so the layout varies per cycle.
+        fn $has_dyn(items: &[($ast, Option<Weight>)]) -> bool {
+            items.iter().any(|(p, w)| {
+                matches!(w, Some(Weight::Pattern(_)))
+                    || matches!(p, $ast::Replicate(_, ReplicateCount::Pattern(_)))
+            })
+        }
+
+        /// Joint unroll pass count for a dynamic slowcat: LCM of every
+        /// dynamic operand's period. `None` when an operand is aperiodic or
+        /// the LCM overflows `MAX_EXPANSION`.
+        fn $passes(items: &[($ast, Option<Weight>)]) -> Option<u64> {
+            let mut passes = 1u64;
+            for (p, w) in items {
+                if let Some(Weight::Pattern(wp)) = w {
+                    passes = lcm_u64(passes, operand_period_f64(wp)?)?;
+                }
+                if let $ast::Replicate(_, ReplicateCount::Pattern(cp)) = p {
+                    passes = lcm_u64(passes, operand_period_u32(cp)?)?;
+                }
+            }
+            Some(passes)
+        }
+
+        /// Upper bound on the slots a dynamic slowcat unrolls into:
+        /// passes × Σ per-entry maximum copies.
+        fn $slots_bound(items: &[($ast, Option<Weight>)], passes: u64) -> u64 {
+            let per_pass: u64 = items
+                .iter()
+                .map(|(p, _)| match p {
+                    $ast::Replicate(_, ReplicateCount::Static(c)) => (*c).max(1) as u64,
+                    $ast::Replicate(_, ReplicateCount::Pattern(cp)) => {
+                        max_u32_leaf(cp).max(1) as u64
+                    }
+                    _ => 1,
+                })
+                .sum();
+            passes.saturating_mul(per_pass)
+        }
+
+        /// Per-cycle step spec of a polymeter voice. Mirrors the static
+        /// `step_count` readout: sequence entries contribute their weight
+        /// (default 1) and a top-level replicate contributes
+        /// `step_count(inner) × count`.
+        fn $step_spec(child: &$ast) -> StepSpec {
+            match child {
+                $ast::Sequence(items) | $ast::FastCat(items) | $ast::SlowCat(items)
+                    if items
+                        .iter()
+                        .any(|(_, w)| matches!(w, Some(Weight::Pattern(_)))) =>
+                {
+                    StepSpec::Dyn(
+                        items
+                            .iter()
+                            .map(|(_, w)| (dyn_weight_spec(w), DynCount::Static(1)))
+                            .collect::<Vec<_>>()
+                            .into(),
+                    )
+                }
+                $ast::Replicate(inner, count @ ReplicateCount::Pattern(_)) => StepSpec::Dyn(
+                    vec![(
+                        DynWeight::Static(Fraction::from($step_count(inner))),
+                        dyn_count_spec(count),
+                    )]
+                    .into(),
+                ),
+                _ => StepSpec::Static(Fraction::from($step_count(child))),
+            }
+        }
+    };
+}
+
+define_dyn_entry_analysis!(
+    has_dynamic_entries_main,
+    slowcat_passes_main,
+    slowcat_slots_bound_main,
+    step_spec_main,
+    MiniAST,
+    step_count_main
+);
+define_dyn_entry_analysis!(
+    has_dynamic_entries_f64,
+    slowcat_passes_f64,
+    slowcat_slots_bound_f64,
+    step_spec_f64,
+    MiniASTF64,
+    step_count_f64
+);
+define_dyn_entry_analysis!(
+    has_dynamic_entries_u32,
+    slowcat_passes_u32,
+    slowcat_slots_bound_u32,
+    step_spec_u32,
+    MiniASTU32,
+    step_count_u32
+);
+define_dyn_entry_analysis!(
+    has_dynamic_entries_i32,
+    slowcat_passes_i32,
+    slowcat_slots_bound_i32,
+    step_spec_i32,
+    MiniASTI32,
+    step_count_i32
+);
+
+/// Lower a sequence entry's `@` weight to a [`DynWeight`] spec (default 1).
+fn dyn_weight_spec(w: &Option<Weight>) -> DynWeight {
+    match w {
+        None => DynWeight::Static(Fraction::from_integer(1)),
+        Some(Weight::Static(x)) => DynWeight::Static(Fraction::from(*x)),
+        Some(Weight::Pattern(p)) => DynWeight::Pattern(convert_f64_pattern(p)),
+    }
+}
+
+/// Lower a `!` count to a [`DynCount`] spec.
+fn dyn_count_spec(c: &ReplicateCount) -> DynCount {
+    match c {
+        ReplicateCount::Static(n) => DynCount::Static(*n),
+        ReplicateCount::Pattern(p) => DynCount::Pattern(convert_u32_pattern(p)),
+    }
+}
+
+/// Sample an operand pattern at unroll pass `i`: the value and source span
+/// of the first hap whose part begins exactly at cycle `i`.
+fn sample_pass<V: Clone + Send + Sync + 'static>(
+    pat: &Pattern<V>,
+    pass: &Fraction,
+) -> Option<(V, Option<crate::pattern_system::SourceSpan>)> {
+    let haps = pat.query_arc(pass.clone(), pass + &Fraction::from_integer(1));
+    haps.into_iter()
+        .find(|h| &h.part.begin == pass)
+        .map(|h| (h.value, h.context.source_span))
+}
+
+/// Statically unroll a dynamic slowcat: sample every `@`/`!` operand at pass
+/// index 0..passes, lay the sampled slots out with
+/// `timecat(...)._slow(total)`, and wrap each slot in [`stride_cycles`] so
+/// the slot at pass `i` shows its source's cycle `k·passes + i` during
+/// super-period `k` — every entry advances one of its own cycles per pass.
+/// Sampled operand spans become modifier spans on their slots. The limit
+/// validator has already bounded `passes` and the slot count and rejected
+/// aperiodic operands.
+fn unroll_dyn_slowcat<T: Clone + Send + Sync + 'static>(
+    entries: Vec<DynTimecatEntry<T>>,
+    passes: u64,
+) -> Pattern<T> {
+    let mut slots: Vec<(Fraction, Pattern<T>)> = Vec::new();
+    let mut total = Fraction::from_integer(0);
+    let zero = Fraction::from_integer(0);
+    for i in 0..passes {
+        let pass = Fraction::from_integer(i as i64);
+        for entry in &entries {
+            let (weight, wspan) = match &entry.weight {
+                DynWeight::Static(w) => (w.clone(), None),
+                DynWeight::Pattern(p) => match sample_pass(p, &pass) {
+                    Some((v, span)) => (v.max_of(&zero), span),
+                    None => (Fraction::from_integer(1), None),
+                },
+            };
+            let (count, cspan) = match &entry.count {
+                DynCount::Static(c) => (*c, None),
+                DynCount::Pattern(p) => match sample_pass(p, &pass) {
+                    Some((v, span)) => (v, span),
+                    None => (1, None),
+                },
+            };
+            if weight.is_zero() || count == 0 {
+                continue;
+            }
+            let mut slot = stride_cycles(entry.pat.clone(), passes, i);
+            if let Some(span) = wspan {
+                slot = slot.with_modifier_span(span);
+            }
+            if let Some(span) = cspan {
+                slot = slot.with_modifier_span(span);
+            }
+            for _ in 0..count {
+                slots.push((weight.clone(), slot.clone()));
+                total = &total + &weight;
+            }
+        }
+    }
+    if total.is_zero() {
+        return constructors::silence();
+    }
+    timecat(slots)._slow(total)
+}
+
 /// Generates a limit validator for one of the four structurally identical
 /// AST enums. `budget` carries the product of the enclosing `!n`/euclidean-step
 /// expansions down each path; a node whose expansion pushes that running
@@ -251,19 +630,43 @@ fn max_u32_leaf(ast: &MiniASTU32) -> u32 {
 /// are not a single number (`eval_f64` reads exactly one constant, so any
 /// other shape would be silently collapsed).
 macro_rules! define_validate_limits {
-    ($name:ident, $ast:ident) => {
+    ($name:ident, $ast:ident, $has_dyn:ident, $passes:ident, $slots_bound:ident) => {
         fn $name(ast: &$ast, budget: u32) -> Result<(), ConvertError> {
             match ast {
                 $ast::Pure(_) | $ast::Rest(_) => Ok(()),
                 $ast::List(Located { node, .. }) => {
                     node.iter().try_for_each(|a| $name(a, budget))
                 }
-                $ast::Sequence(items) | $ast::FastCat(items) | $ast::SlowCat(items) => {
+                $ast::Sequence(items) | $ast::FastCat(items) => {
                     items.iter().try_for_each(|(p, w)| {
                         if let Some(Weight::Pattern(wp)) = w {
                             // A weight operand is a separate pattern,
                             // materialized on its own, so it starts from a
                             // fresh budget.
+                            validate_limits_f64(wp, 1)?;
+                        }
+                        $name(p, budget)
+                    })
+                }
+                $ast::SlowCat(items) => {
+                    if $has_dyn(items) {
+                        // A dynamic slowcat is unrolled over one joint period
+                        // of its operands at conversion time; the pass count
+                        // and the unrolled slot count must both stay bounded.
+                        let Some(passes) = $passes(items) else {
+                            return Err(ConvertError::OperatorError(format!(
+                                "a `@`/`!` operand inside `<...>` must repeat within {MAX_EXPANSION} cycles; `|` random choice has no fixed period"
+                            )));
+                        };
+                        let slots = $slots_bound(items, passes);
+                        if slots > MAX_EXPANSION as u64 {
+                            return Err(ConvertError::OperatorError(format!(
+                                "patterned `@`/`!` operands unroll this `<...>` into {slots} steps, past the maximum of {MAX_EXPANSION}"
+                            )));
+                        }
+                    }
+                    items.iter().try_for_each(|(p, w)| {
+                        if let Some(Weight::Pattern(wp)) = w {
                             validate_limits_f64(wp, 1)?;
                         }
                         $name(p, budget)
@@ -343,10 +746,34 @@ macro_rules! define_validate_limits {
     };
 }
 
-define_validate_limits!(validate_limits_main, MiniAST);
-define_validate_limits!(validate_limits_f64, MiniASTF64);
-define_validate_limits!(validate_limits_u32, MiniASTU32);
-define_validate_limits!(validate_limits_i32, MiniASTI32);
+define_validate_limits!(
+    validate_limits_main,
+    MiniAST,
+    has_dynamic_entries_main,
+    slowcat_passes_main,
+    slowcat_slots_bound_main
+);
+define_validate_limits!(
+    validate_limits_f64,
+    MiniASTF64,
+    has_dynamic_entries_f64,
+    slowcat_passes_f64,
+    slowcat_slots_bound_f64
+);
+define_validate_limits!(
+    validate_limits_u32,
+    MiniASTU32,
+    has_dynamic_entries_u32,
+    slowcat_passes_u32,
+    slowcat_slots_bound_u32
+);
+define_validate_limits!(
+    validate_limits_i32,
+    MiniASTI32,
+    has_dynamic_entries_i32,
+    slowcat_passes_i32,
+    slowcat_slots_bound_i32
+);
 
 /// Evaluate a MiniASTF64 to get a single f64 value.
 ///
@@ -489,6 +916,26 @@ fn convert_f64_pattern(ast: &MiniASTF64) -> Pattern<Fraction> {
                 return constructors::pure(Fraction::from_integer(0));
             }
 
+            if has_dynamic_entries_f64(elements) {
+                // Per-cycle layout (see the MiniAST::Sequence arm).
+                let entries = elements
+                    .iter()
+                    .map(|(p, w)| match p {
+                        MiniASTF64::Replicate(inner, count) => DynTimecatEntry {
+                            pat: convert_f64_pattern(inner),
+                            weight: DynWeight::Static(Fraction::from_integer(1)),
+                            count: dyn_count_spec(count),
+                        },
+                        other => DynTimecatEntry {
+                            pat: convert_f64_pattern(other),
+                            weight: dyn_weight_spec(w),
+                            count: DynCount::Static(1),
+                        },
+                    })
+                    .collect();
+                return dyn_timecat(entries);
+            }
+
             // Expand Replicate into sibling steps (see MiniAST::Sequence).
             let expanded: Vec<(&MiniASTF64, Option<f64>)> = elements
                 .iter()
@@ -522,6 +969,26 @@ fn convert_f64_pattern(ast: &MiniASTF64) -> Pattern<Fraction> {
         }
 
         MiniASTF64::SlowCat(elements) => {
+            if has_dynamic_entries_f64(elements) {
+                // Unroll over one joint operand period (see MiniAST::SlowCat).
+                let passes = slowcat_passes_f64(elements).unwrap_or(1);
+                let entries = elements
+                    .iter()
+                    .map(|(p, w)| match p {
+                        MiniASTF64::Replicate(inner, count) => DynTimecatEntry {
+                            pat: convert_f64_pattern(inner),
+                            weight: DynWeight::Static(Fraction::from_integer(1)),
+                            count: dyn_count_spec(count),
+                        },
+                        other => DynTimecatEntry {
+                            pat: convert_f64_pattern(other),
+                            weight: dyn_weight_spec(w),
+                            count: DynCount::Static(1),
+                        },
+                    })
+                    .collect();
+                return unroll_dyn_slowcat(entries, passes);
+            }
             // Expand Replicate nodes within SlowCat (see MiniAST::SlowCat for details)
             let expanded: Vec<(&MiniASTF64, Option<f64>)> = elements
                 .iter()
@@ -580,10 +1047,17 @@ fn convert_f64_pattern(ast: &MiniASTF64) -> Pattern<Fraction> {
 
         MiniASTF64::Replicate(pattern, count) => {
             let pat = convert_f64_pattern(pattern);
-            let pats: Vec<Pattern<Fraction>> = (0..count.as_static().unwrap_or(1))
-                .map(|_| pat.clone())
-                .collect();
-            fastcat(pats)
+            match count.as_static() {
+                Some(count) => {
+                    let pats: Vec<Pattern<Fraction>> = (0..count).map(|_| pat.clone()).collect();
+                    fastcat(pats)
+                }
+                None => dyn_timecat(vec![DynTimecatEntry {
+                    pat,
+                    weight: DynWeight::Static(Fraction::from_integer(1)),
+                    count: dyn_count_spec(count),
+                }]),
+            }
         }
 
         MiniASTF64::Degrade(pattern, _prob, _seed) => {
@@ -602,18 +1076,28 @@ fn convert_f64_pattern(ast: &MiniASTF64) -> Pattern<Fraction> {
             children,
             steps_per_cycle,
         } => {
-            let spc = steps_per_cycle
-                .as_deref()
-                .map(eval_f64)
-                .unwrap_or_else(|| children.first().map(step_count_f64).unwrap_or(1.0));
+            let spc_spec = match steps_per_cycle.as_deref() {
+                Some(s) => StepSpec::Static(Fraction::from(eval_f64(s))),
+                None => children
+                    .first()
+                    .map(step_spec_f64)
+                    .unwrap_or(StepSpec::Static(Fraction::from_integer(1))),
+            };
             let scaled: Vec<Pattern<Fraction>> = children
                 .iter()
                 .map(|c| {
-                    let w = step_count_f64(c).max(1.0);
-                    // Divide as Fractions: quantizing the f64 quotient would
-                    // corrupt exact ratios like 4/3 and the pattern's period.
-                    convert_f64_pattern(c)
-                        .fast(constructors::pure(Fraction::from(spc) / Fraction::from(w)))
+                    let pat = convert_f64_pattern(c);
+                    match (&spc_spec, step_spec_f64(c)) {
+                        (StepSpec::Static(spc), StepSpec::Static(w)) => {
+                            // Divide as Fractions: quantizing the f64 quotient would
+                            // corrupt exact ratios like 4/3 and the pattern's period.
+                            let w = w.max_of(&Fraction::from_integer(1));
+                            pat.fast(constructors::pure(spc / &w))
+                        }
+                        (_, child_spec) => {
+                            pat.fast(dyn_polymeter_factor(spc_spec.clone(), child_spec))
+                        }
+                    }
                 })
                 .collect();
             stack(scaled)
@@ -640,6 +1124,26 @@ fn convert_u32_pattern(ast: &MiniASTU32) -> Pattern<u32> {
         MiniASTU32::Sequence(elements) | MiniASTU32::FastCat(elements) => {
             if elements.is_empty() {
                 return pure(0);
+            }
+
+            if has_dynamic_entries_u32(elements) {
+                // Per-cycle layout (see the MiniAST::Sequence arm).
+                let entries = elements
+                    .iter()
+                    .map(|(p, w)| match p {
+                        MiniASTU32::Replicate(inner, count) => DynTimecatEntry {
+                            pat: convert_u32_pattern(inner),
+                            weight: DynWeight::Static(Fraction::from_integer(1)),
+                            count: dyn_count_spec(count),
+                        },
+                        other => DynTimecatEntry {
+                            pat: convert_u32_pattern(other),
+                            weight: dyn_weight_spec(w),
+                            count: DynCount::Static(1),
+                        },
+                    })
+                    .collect();
+                return dyn_timecat(entries);
             }
 
             // Expand Replicate into sibling steps (see MiniAST::Sequence).
@@ -673,6 +1177,26 @@ fn convert_u32_pattern(ast: &MiniASTU32) -> Pattern<u32> {
         }
 
         MiniASTU32::SlowCat(elements) => {
+            if has_dynamic_entries_u32(elements) {
+                // Unroll over one joint operand period (see MiniAST::SlowCat).
+                let passes = slowcat_passes_u32(elements).unwrap_or(1);
+                let entries = elements
+                    .iter()
+                    .map(|(p, w)| match p {
+                        MiniASTU32::Replicate(inner, count) => DynTimecatEntry {
+                            pat: convert_u32_pattern(inner),
+                            weight: DynWeight::Static(Fraction::from_integer(1)),
+                            count: dyn_count_spec(count),
+                        },
+                        other => DynTimecatEntry {
+                            pat: convert_u32_pattern(other),
+                            weight: dyn_weight_spec(w),
+                            count: DynCount::Static(1),
+                        },
+                    })
+                    .collect();
+                return unroll_dyn_slowcat(entries, passes);
+            }
             // Expand Replicate nodes within SlowCat (see MiniAST::SlowCat for details)
             let expanded: Vec<(&MiniASTU32, Option<f64>)> = elements
                 .iter()
@@ -731,10 +1255,17 @@ fn convert_u32_pattern(ast: &MiniASTU32) -> Pattern<u32> {
 
         MiniASTU32::Replicate(pattern, count) => {
             let pat = convert_u32_pattern(pattern);
-            let pats: Vec<Pattern<u32>> = (0..count.as_static().unwrap_or(1))
-                .map(|_| pat.clone())
-                .collect();
-            fastcat(pats)
+            match count.as_static() {
+                Some(count) => {
+                    let pats: Vec<Pattern<u32>> = (0..count).map(|_| pat.clone()).collect();
+                    fastcat(pats)
+                }
+                None => dyn_timecat(vec![DynTimecatEntry {
+                    pat,
+                    weight: DynWeight::Static(Fraction::from_integer(1)),
+                    count: dyn_count_spec(count),
+                }]),
+            }
         }
 
         MiniASTU32::Degrade(pattern, _prob, _seed) => {
@@ -748,17 +1279,27 @@ fn convert_u32_pattern(ast: &MiniASTU32) -> Pattern<u32> {
             children,
             steps_per_cycle,
         } => {
-            let spc = steps_per_cycle
-                .as_deref()
-                .map(eval_f64)
-                .unwrap_or_else(|| children.first().map(step_count_u32).unwrap_or(1.0));
+            let spc_spec = match steps_per_cycle.as_deref() {
+                Some(s) => StepSpec::Static(Fraction::from(eval_f64(s))),
+                None => children
+                    .first()
+                    .map(step_spec_u32)
+                    .unwrap_or(StepSpec::Static(Fraction::from_integer(1))),
+            };
             let scaled: Vec<Pattern<u32>> = children
                 .iter()
                 .map(|c| {
-                    let w = step_count_u32(c).max(1.0);
-                    // Divide as Fractions (see the MiniASTF64::Polymeter arm).
-                    convert_u32_pattern(c)
-                        .fast(constructors::pure(Fraction::from(spc) / Fraction::from(w)))
+                    let pat = convert_u32_pattern(c);
+                    match (&spc_spec, step_spec_u32(c)) {
+                        (StepSpec::Static(spc), StepSpec::Static(w)) => {
+                            // Divide as Fractions (see the MiniASTF64::Polymeter arm).
+                            let w = w.max_of(&Fraction::from_integer(1));
+                            pat.fast(constructors::pure(spc / &w))
+                        }
+                        (_, child_spec) => {
+                            pat.fast(dyn_polymeter_factor(spc_spec.clone(), child_spec))
+                        }
+                    }
                 })
                 .collect();
             stack(scaled)
@@ -785,6 +1326,26 @@ fn convert_i32_pattern(ast: &MiniASTI32) -> Pattern<i32> {
         MiniASTI32::Sequence(elements) | MiniASTI32::FastCat(elements) => {
             if elements.is_empty() {
                 return pure(0);
+            }
+
+            if has_dynamic_entries_i32(elements) {
+                // Per-cycle layout (see the MiniAST::Sequence arm).
+                let entries = elements
+                    .iter()
+                    .map(|(p, w)| match p {
+                        MiniASTI32::Replicate(inner, count) => DynTimecatEntry {
+                            pat: convert_i32_pattern(inner),
+                            weight: DynWeight::Static(Fraction::from_integer(1)),
+                            count: dyn_count_spec(count),
+                        },
+                        other => DynTimecatEntry {
+                            pat: convert_i32_pattern(other),
+                            weight: dyn_weight_spec(w),
+                            count: DynCount::Static(1),
+                        },
+                    })
+                    .collect();
+                return dyn_timecat(entries);
             }
 
             // Expand Replicate into sibling steps (see MiniAST::Sequence).
@@ -818,6 +1379,26 @@ fn convert_i32_pattern(ast: &MiniASTI32) -> Pattern<i32> {
         }
 
         MiniASTI32::SlowCat(elements) => {
+            if has_dynamic_entries_i32(elements) {
+                // Unroll over one joint operand period (see MiniAST::SlowCat).
+                let passes = slowcat_passes_i32(elements).unwrap_or(1);
+                let entries = elements
+                    .iter()
+                    .map(|(p, w)| match p {
+                        MiniASTI32::Replicate(inner, count) => DynTimecatEntry {
+                            pat: convert_i32_pattern(inner),
+                            weight: DynWeight::Static(Fraction::from_integer(1)),
+                            count: dyn_count_spec(count),
+                        },
+                        other => DynTimecatEntry {
+                            pat: convert_i32_pattern(other),
+                            weight: dyn_weight_spec(w),
+                            count: DynCount::Static(1),
+                        },
+                    })
+                    .collect();
+                return unroll_dyn_slowcat(entries, passes);
+            }
             // Expand Replicate nodes within SlowCat (see MiniAST::SlowCat for details)
             let expanded: Vec<(&MiniASTI32, Option<f64>)> = elements
                 .iter()
@@ -876,10 +1457,17 @@ fn convert_i32_pattern(ast: &MiniASTI32) -> Pattern<i32> {
 
         MiniASTI32::Replicate(pattern, count) => {
             let pat = convert_i32_pattern(pattern);
-            let pats: Vec<Pattern<i32>> = (0..count.as_static().unwrap_or(1))
-                .map(|_| pat.clone())
-                .collect();
-            fastcat(pats)
+            match count.as_static() {
+                Some(count) => {
+                    let pats: Vec<Pattern<i32>> = (0..count).map(|_| pat.clone()).collect();
+                    fastcat(pats)
+                }
+                None => dyn_timecat(vec![DynTimecatEntry {
+                    pat,
+                    weight: DynWeight::Static(Fraction::from_integer(1)),
+                    count: dyn_count_spec(count),
+                }]),
+            }
         }
 
         MiniASTI32::Degrade(pattern, _prob, _seed) => convert_i32_pattern(pattern),
@@ -890,17 +1478,27 @@ fn convert_i32_pattern(ast: &MiniASTI32) -> Pattern<i32> {
             children,
             steps_per_cycle,
         } => {
-            let spc = steps_per_cycle
-                .as_deref()
-                .map(eval_f64)
-                .unwrap_or_else(|| children.first().map(step_count_i32).unwrap_or(1.0));
+            let spc_spec = match steps_per_cycle.as_deref() {
+                Some(s) => StepSpec::Static(Fraction::from(eval_f64(s))),
+                None => children
+                    .first()
+                    .map(step_spec_i32)
+                    .unwrap_or(StepSpec::Static(Fraction::from_integer(1))),
+            };
             let scaled: Vec<Pattern<i32>> = children
                 .iter()
                 .map(|c| {
-                    let w = step_count_i32(c).max(1.0);
-                    // Divide as Fractions (see the MiniASTF64::Polymeter arm).
-                    convert_i32_pattern(c)
-                        .fast(constructors::pure(Fraction::from(spc) / Fraction::from(w)))
+                    let pat = convert_i32_pattern(c);
+                    match (&spc_spec, step_spec_i32(c)) {
+                        (StepSpec::Static(spc), StepSpec::Static(w)) => {
+                            // Divide as Fractions (see the MiniASTF64::Polymeter arm).
+                            let w = w.max_of(&Fraction::from_integer(1));
+                            pat.fast(constructors::pure(spc / &w))
+                        }
+                        (_, child_spec) => {
+                            pat.fast(dyn_polymeter_factor(spc_spec.clone(), child_spec))
+                        }
+                    }
                 })
                 .collect();
             stack(scaled)
@@ -952,15 +1550,6 @@ fn eval_i32(ast: &MiniASTI32) -> i32 {
         MiniASTI32::Euclidean { pattern, .. } => eval_i32(pattern),
         MiniASTI32::Polymeter { children, .. } => children.first().map(eval_i32).unwrap_or(0),
     }
-}
-
-/// True when any entry carries a patterned `@` weight or is a `!` replicate
-/// with a patterned count, so the sequence's layout varies per cycle.
-fn has_dynamic_entries(items: &[(MiniAST, Option<Weight>)]) -> bool {
-    items.iter().any(|(p, w)| {
-        matches!(w, Some(Weight::Pattern(_)))
-            || matches!(p, MiniAST::Replicate(_, ReplicateCount::Pattern(_)))
-    })
 }
 
 fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertError> {
@@ -1054,10 +1643,26 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
         }
 
         MiniAST::Sequence(elements) | MiniAST::FastCat(elements) => {
-            if has_dynamic_entries(elements) {
-                return Err(ConvertError::OperatorError(
-                    "patterned @ weights and ! counts are not implemented".to_string(),
-                ));
+            if has_dynamic_entries_main(elements) {
+                // Per-cycle layout: weights/counts are sampled each cycle
+                // start by dyn_timecat. Replicate copies keep weight 1, like
+                // the static expansion below.
+                let entries = elements
+                    .iter()
+                    .map(|(p, w)| match p {
+                        MiniAST::Replicate(inner, count) => Ok(DynTimecatEntry {
+                            pat: convert_inner(inner)?,
+                            weight: DynWeight::Static(Fraction::from_integer(1)),
+                            count: dyn_count_spec(count),
+                        }),
+                        other => Ok(DynTimecatEntry {
+                            pat: convert_inner(other)?,
+                            weight: dyn_weight_spec(w),
+                            count: DynCount::Static(1),
+                        }),
+                    })
+                    .collect::<Result<Vec<_>, ConvertError>>()?;
+                return Ok(dyn_timecat(entries));
             }
             // Expand Replicate nodes into sibling steps. In Strudel `[a b!2 c]`
             // is `[a b b c]`: `!n` adds `n` sibling steps that share the
@@ -1093,10 +1698,27 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
         }
 
         MiniAST::SlowCat(patterns) => {
-            if has_dynamic_entries(patterns) {
-                return Err(ConvertError::OperatorError(
-                    "patterned @ weights and ! counts are not implemented".to_string(),
-                ));
+            if has_dynamic_entries_main(patterns) {
+                // Unroll one joint operand period into the static weighted
+                // slowcat machinery; the validator has already bounded the
+                // pass and slot counts.
+                let passes = slowcat_passes_main(patterns).unwrap_or(1);
+                let entries = patterns
+                    .iter()
+                    .map(|(p, w)| match p {
+                        MiniAST::Replicate(inner, count) => Ok(DynTimecatEntry {
+                            pat: convert_inner(inner)?,
+                            weight: DynWeight::Static(Fraction::from_integer(1)),
+                            count: dyn_count_spec(count),
+                        }),
+                        other => Ok(DynTimecatEntry {
+                            pat: convert_inner(other)?,
+                            weight: dyn_weight_spec(w),
+                            count: DynCount::Static(1),
+                        }),
+                    })
+                    .collect::<Result<Vec<_>, ConvertError>>()?;
+                return Ok(unroll_dyn_slowcat(entries, passes));
             }
             // Expand Replicate nodes within SlowCat.
             // In Strudel/Tidal, <a!3 b> means "slowcat of a, a, a, b" (each on separate cycles),
@@ -1171,14 +1793,19 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
         }
 
         MiniAST::Replicate(pattern, count) => {
-            let Some(count) = count.as_static() else {
-                return Err(ConvertError::OperatorError(
-                    "patterned @ weights and ! counts are not implemented".to_string(),
-                ));
-            };
             let pat = convert_inner(pattern)?;
-            let pats: Vec<Pattern<T>> = (0..count).map(|_| pat.clone()).collect();
-            Ok(fastcat(pats))
+            match count.as_static() {
+                Some(count) => {
+                    let pats: Vec<Pattern<T>> = (0..count).map(|_| pat.clone()).collect();
+                    Ok(fastcat(pats))
+                }
+                // A patterned count re-samples the copy count every cycle.
+                None => Ok(dyn_timecat(vec![DynTimecatEntry {
+                    pat,
+                    weight: DynWeight::Static(Fraction::from_integer(1)),
+                    count: dyn_count_spec(count),
+                }])),
+            }
         }
 
         MiniAST::Degrade(pattern, prob, seed) => {
@@ -1230,17 +1857,29 @@ fn convert_inner<T: FromMiniAtom>(ast: &MiniAST) -> Result<Pattern<T>, ConvertEr
             // Polymeter: stack each child scaled so its step count maps to
             // `steps_per_cycle`. Default stepsPerCycle is the first child's
             // own step count — matches strudel's fallback in mini.mjs.
-            let spc = steps_per_cycle
-                .as_deref()
-                .map(eval_f64)
-                .unwrap_or_else(|| children.first().map(step_count_main).unwrap_or(1.0));
+            let spc_spec = match steps_per_cycle.as_deref() {
+                Some(s) => StepSpec::Static(Fraction::from(eval_f64(s))),
+                None => children
+                    .first()
+                    .map(step_spec_main)
+                    .unwrap_or(StepSpec::Static(Fraction::from_integer(1))),
+            };
             let scaled: Vec<Pattern<T>> = children
                 .iter()
                 .map(|c| {
-                    let w = step_count_main(c).max(1.0);
                     let pat = convert_inner(c)?;
-                    // Divide as Fractions (see the MiniASTF64::Polymeter arm).
-                    Ok(pat.fast(constructors::pure(Fraction::from(spc) / Fraction::from(w))))
+                    Ok(match (&spc_spec, step_spec_main(c)) {
+                        (StepSpec::Static(spc), StepSpec::Static(w)) => {
+                            // Divide as Fractions (see the MiniASTF64::Polymeter arm).
+                            let w = w.max_of(&Fraction::from_integer(1));
+                            pat.fast(constructors::pure(spc / &w))
+                        }
+                        // A patterned @/! in a voice makes its step count (and
+                        // so the alignment factor) vary per cycle.
+                        (_, child_spec) => {
+                            pat.fast(dyn_polymeter_factor(spc_spec.clone(), child_spec))
+                        }
+                    })
                 })
                 .collect::<Result<_, ConvertError>>()?;
             Ok(stack(scaled))
@@ -3174,5 +3813,367 @@ mod tests {
         assert_eq!(h1[0].value, Some(2.0));
         assert_eq!(h2.len(), 1);
         assert_eq!(h2[0].value, Some(3.0));
+    }
+
+    // ===== Patterned @ weights and ! counts =====
+
+    /// (part, whole, value) triples for structural hap comparison across two
+    /// lowerings of equivalent patterns (contexts carry different spans).
+    fn hap_shapes<T: Clone + PartialEq + std::fmt::Debug + Send + Sync + 'static>(
+        pat: &Pattern<T>,
+        from: i64,
+        to: i64,
+    ) -> Vec<((Fraction, Fraction), Option<(Fraction, Fraction)>, T)> {
+        let mut haps = pat.query_arc(Fraction::from_integer(from), Fraction::from_integer(to));
+        haps.sort_by(|a, b| a.part.begin.partial_cmp(&b.part.begin).unwrap());
+        haps.iter()
+            .map(|h| {
+                (
+                    (h.part.begin.clone(), h.part.end.clone()),
+                    h.whole.as_ref().map(|w| (w.begin.clone(), w.end.clone())),
+                    h.value.clone(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_dyn_weight_fastcat_relayouts_per_cycle() {
+        // `0@<1 3> 1`: the weight operand advances per cycle, so the layout
+        // alternates between equal halves and 3/4 + 1/4.
+        let ast = parse("0@<1 3> 1").unwrap();
+        let pat: Pattern<f64> = convert(&ast).unwrap();
+
+        let h0 = pat.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
+        assert_eq!(h0.len(), 2);
+        assert_eq!(
+            h0[0].whole.as_ref().unwrap().duration(),
+            Fraction::new(1, 2)
+        );
+        assert_eq!(
+            h0[1].whole.as_ref().unwrap().duration(),
+            Fraction::new(1, 2)
+        );
+
+        let h1 = pat.query_arc(Fraction::from_integer(1), Fraction::from_integer(2));
+        assert_eq!(h1.len(), 2);
+        assert_eq!(h1[0].value, 0.0);
+        assert_eq!(
+            h1[0].whole.as_ref().unwrap().duration(),
+            Fraction::new(3, 4)
+        );
+        assert_eq!(h1[1].value, 1.0);
+        assert_eq!(
+            h1[1].whole.as_ref().unwrap().duration(),
+            Fraction::new(1, 4)
+        );
+
+        // Cycle 2 wraps back to the cycle-0 layout.
+        let h2 = pat.query_arc(Fraction::from_integer(2), Fraction::from_integer(3));
+        assert_eq!(
+            h2[0].whole.as_ref().unwrap().duration(),
+            Fraction::new(1, 2)
+        );
+    }
+
+    #[test]
+    fn test_dyn_weight_bracket_matches_static() {
+        // A single-valued operand is indistinguishable from the bare number.
+        let dynamic = parse("0@[2] 1").unwrap();
+        let static_ = parse("0@2 1").unwrap();
+        let dyn_pat: Pattern<f64> = convert(&dynamic).unwrap();
+        let static_pat: Pattern<f64> = convert(&static_).unwrap();
+        assert_eq!(hap_shapes(&dyn_pat, 0, 4), hap_shapes(&static_pat, 0, 4));
+    }
+
+    #[test]
+    fn test_dyn_replicate_sequence_per_cycle() {
+        // `0!<2 3> 1`: 2 copies + 1 on even cycles, 3 copies + 1 on odd.
+        let ast = parse("0!<2 3> 1").unwrap();
+        let pat: Pattern<f64> = convert(&ast).unwrap();
+
+        let h0 = pat.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
+        assert_eq!(h0.len(), 3);
+        assert_eq!(h0.iter().filter(|h| h.value == 0.0).count(), 2);
+
+        let h1 = pat.query_arc(Fraction::from_integer(1), Fraction::from_integer(2));
+        assert_eq!(h1.len(), 4);
+        assert_eq!(h1.iter().filter(|h| h.value == 0.0).count(), 3);
+        // Copies split the cycle evenly with the trailing 1: four 1/4 slots.
+        assert_eq!(
+            h1[0].whole.as_ref().unwrap().duration(),
+            Fraction::new(1, 4)
+        );
+    }
+
+    #[test]
+    fn test_dyn_replicate_standalone_per_cycle() {
+        let ast = parse("0!<2 3>").unwrap();
+        let pat: Pattern<f64> = convert(&ast).unwrap();
+        let h0 = pat.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
+        let h1 = pat.query_arc(Fraction::from_integer(1), Fraction::from_integer(2));
+        assert_eq!(h0.len(), 2);
+        assert_eq!(h1.len(), 3);
+    }
+
+    #[test]
+    fn test_dyn_slowcat_unroll_weight() {
+        // `<0@<1 2> 1>` unrolls over the operand's period 2: slots
+        // 0@1 1@1 0@2 1@1, total 5 cycles, repeating.
+        let ast = parse("<0@<1 2> 1>").unwrap();
+        let pat: Pattern<f64> = convert(&ast).unwrap();
+        let expected = [0.0, 1.0, 0.0, 0.0, 1.0];
+        for cycle in 0..10 {
+            let haps = pat.query_arc(
+                Fraction::from_integer(cycle),
+                Fraction::from_integer(cycle + 1),
+            );
+            assert_eq!(haps.len(), 1, "cycle {cycle}");
+            assert_eq!(
+                haps[0].value,
+                expected[(cycle % 5) as usize],
+                "cycle {cycle}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dyn_slowcat_unroll_replicate() {
+        // `<a!<2 3> b>` unrolls to a,a,b,a,a,a,b over 7 cycles. a=69, b=71.
+        let ast = parse("<a!<2 3> b>").unwrap();
+        let pat: Pattern<f64> = convert(&ast).unwrap();
+        let expected = [69.0, 69.0, 71.0, 69.0, 69.0, 69.0, 71.0];
+        for cycle in 0..14 {
+            let haps = pat.query_arc(
+                Fraction::from_integer(cycle),
+                Fraction::from_integer(cycle + 1),
+            );
+            assert_eq!(haps.len(), 1, "cycle {cycle}");
+            assert_eq!(
+                haps[0].value,
+                expected[(cycle % 7) as usize],
+                "cycle {cycle}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dyn_slowcat_joint_period() {
+        // Two operands with periods 3 and 2 unroll over lcm 6 passes:
+        // weights per pass (1,2) (2,1) (3,2) (1,1) (2,2) (3,1), total 21.
+        let ast = parse("<0@<1 2 3> 1@<2 1>>").unwrap();
+        let pat: Pattern<f64> = convert(&ast).unwrap();
+        let mut expected = Vec::new();
+        for (w0, w1) in [(1, 2), (2, 1), (3, 2), (1, 1), (2, 2), (3, 1)] {
+            expected.extend(std::iter::repeat_n(0.0, w0));
+            expected.extend(std::iter::repeat_n(1.0, w1));
+        }
+        assert_eq!(expected.len(), 21);
+        for cycle in 0..42 {
+            let haps = pat.query_arc(
+                Fraction::from_integer(cycle),
+                Fraction::from_integer(cycle + 1),
+            );
+            assert_eq!(haps.len(), 1, "cycle {cycle}");
+            assert_eq!(
+                haps[0].value,
+                expected[(cycle % 21) as usize],
+                "cycle {cycle}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dyn_slowcat_ground_truth_vector() {
+        // User-supplied equivalence pinning the unroll semantics: operand
+        // periods 4 and 4 → 4 passes; weights per pass (2,2) (2,2) (2,2)
+        // (3,1); the structured child `<0 -1>` advances one of its own
+        // cycles per pass. Composition under an outer `*8` must hold too.
+        let dynamic = parse("<<0 -1>@<2!3 3> -3@<2!3 1>>*8").unwrap();
+        let unrolled = parse("<0@2 -3@2 -1@2 -3@2 0@2 -3@2 -1@3 -3@1>*8").unwrap();
+        let dyn_pat: Pattern<f64> = convert(&dynamic).unwrap();
+        let unrolled_pat: Pattern<f64> = convert(&unrolled).unwrap();
+        // 4 outer cycles = 32 pattern cycles = two 16-cycle super-periods.
+        assert_eq!(hap_shapes(&dyn_pat, 0, 4), hap_shapes(&unrolled_pat, 0, 4));
+    }
+
+    #[test]
+    fn test_dyn_slowcat_degenerate_weight_matches_static() {
+        // `@<2>` (period-1 operand) must lower to exactly the static `@2`
+        // behavior, including how the structured child advances per
+        // super-period.
+        let dynamic = parse("<<0 -1>@<2> 1>").unwrap();
+        let static_ = parse("<<0 -1>@2 1>").unwrap();
+        let dyn_pat: Pattern<f64> = convert(&dynamic).unwrap();
+        let static_pat: Pattern<f64> = convert(&static_).unwrap();
+        assert_eq!(hap_shapes(&dyn_pat, 0, 12), hap_shapes(&static_pat, 0, 12));
+    }
+
+    #[test]
+    fn test_dyn_slowcat_degenerate_replicate_matches_static() {
+        let dynamic = parse("<g!<3> b>").unwrap();
+        let static_ = parse("<g!3 b>").unwrap();
+        let dyn_pat: Pattern<f64> = convert(&dynamic).unwrap();
+        let static_pat: Pattern<f64> = convert(&static_).unwrap();
+        assert_eq!(hap_shapes(&dyn_pat, 0, 12), hap_shapes(&static_pat, 0, 12));
+    }
+
+    #[test]
+    fn test_dyn_polymeter_steps_weight() {
+        // `{0@<1 2> 1, 7}` as an operand subtree: voice 0's step count
+        // alternates 2, 3 and is the steps-per-cycle default, so voice 1
+        // fires 2× then 3× per cycle. Parsed via a `*` operand because `{}`
+        // only exists inside modifier operands.
+        let ast = parse("0*{0@<1 2> 1, 7}").unwrap();
+        let MiniAST::Fast(_, operand) = &ast else {
+            panic!("expected Fast, got {ast:?}");
+        };
+        let pat = convert_f64_pattern(operand);
+        for (cycle, want_sevens) in [(0i64, 2usize), (1, 3), (2, 2)] {
+            let haps = pat.query_arc(
+                Fraction::from_integer(cycle),
+                Fraction::from_integer(cycle + 1),
+            );
+            let sevens = haps
+                .iter()
+                .filter(|h| h.value == Fraction::from_integer(7))
+                .count();
+            assert_eq!(
+                sevens, want_sevens,
+                "cycle {cycle}: voice 1 fires spc(cycle) times"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dyn_polymeter_steps_replicate() {
+        // `{0!<2 3>, 7}`: voice 0 is a top-level replicate, so its step
+        // count is the sampled copy count; voice 1 follows it.
+        let ast = parse("0*{0!<2 3>, 7}").unwrap();
+        let MiniAST::Fast(_, operand) = &ast else {
+            panic!("expected Fast, got {ast:?}");
+        };
+        let pat = convert_f64_pattern(operand);
+        for (cycle, want) in [(0i64, 2usize), (1, 3), (2, 2)] {
+            let haps = pat.query_arc(
+                Fraction::from_integer(cycle),
+                Fraction::from_integer(cycle + 1),
+            );
+            let sevens = haps
+                .iter()
+                .filter(|h| h.value == Fraction::from_integer(7))
+                .count();
+            let zeros = haps
+                .iter()
+                .filter(|h| h.value == Fraction::from_integer(0))
+                .count();
+            assert_eq!(sevens, want, "cycle {cycle}: voice 1 follows voice 0");
+            assert_eq!(zeros, want, "cycle {cycle}: voice 0 replicates itself");
+        }
+    }
+
+    #[test]
+    fn test_operand_polymeter_for_fast() {
+        // `0*{1 2 3}%4` speeds the atom by the polymeter's per-slot factor
+        // stream: 4 quarter-cycle factor slots per cycle.
+        let ast = parse("0*{1 2 3}%4").unwrap();
+        let pat: Pattern<f64> = convert(&ast).unwrap();
+        let h0 = pat.query_arc(Fraction::from_integer(0), Fraction::from_integer(1));
+        // Factor slots for cycle 0 are 1,2,3,1 (wrapping voice): onsets
+        // 1/4·(1) + 1/4·(2 → 1 shown at slot rate…) — assert the count is
+        // stable and positive rather than pinning exact subdivision.
+        assert!(!h0.is_empty());
+        // The static single-voice form must equal the plain subsequence.
+        let braced = parse("0*{1 2 3}").unwrap();
+        let plain = parse("0*[1 2 3]").unwrap();
+        let braced_pat: Pattern<f64> = convert(&braced).unwrap();
+        let plain_pat: Pattern<f64> = convert(&plain).unwrap();
+        assert_eq!(hap_shapes(&braced_pat, 0, 3), hap_shapes(&plain_pat, 0, 3));
+    }
+
+    #[test]
+    fn test_dyn_slowcat_aperiodic_operand_errors() {
+        // `|` random choice has no period, so it cannot be unrolled.
+        let ast = parse("<0@[1|2] 1>").unwrap();
+        let result: Result<Pattern<f64>, _> = convert(&ast);
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("must repeat"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_dyn_slowcat_period_cap_errors() {
+        // The weight operand's own period (1200) exceeds MAX_EXPANSION.
+        let ast = parse("<0@<1!600 2!600> 1>").unwrap();
+        let result: Result<Pattern<f64>, _> = convert(&ast);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dyn_slowcat_slot_bound_errors() {
+        // 2 passes × max count 600 = 1200 unrolled slots, past MAX_EXPANSION.
+        let ast = parse("<0!<600 599> 1>").unwrap();
+        let result: Result<Pattern<f64>, _> = convert(&ast);
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("unroll"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_dyn_replicate_count_limit() {
+        // A patterned count is bounded by its largest leaf.
+        let ast = parse("0![2000]").unwrap();
+        let result: Result<Pattern<f64>, _> = convert(&ast);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_dyn_weight_operand_spans() {
+        // `c@<2 3> e`: c's haps carry the sampled weight atom's span as a
+        // modifier span, like a `*` factor; e's haps carry none.
+        //  c=0-1 @ < 2=3-4, 3=5-6 > space e=8-9
+        let ast = parse("c@<2 3> e").unwrap();
+        let pat: Pattern<f64> = convert(&ast).unwrap();
+
+        for (cycle, want_span) in [(0i64, (3, 4)), (1, (5, 6))] {
+            let haps = pat.query_arc(
+                Fraction::from_integer(cycle),
+                Fraction::from_integer(cycle + 1),
+            );
+            let c_hap = haps.iter().find(|h| h.value == 60.0).unwrap();
+            let spans: Vec<(usize, usize)> = c_hap
+                .context
+                .modifier_spans
+                .iter()
+                .map(|s| (s.start, s.end))
+                .collect();
+            assert_eq!(spans, vec![want_span], "cycle {cycle}");
+            let e_hap = haps.iter().find(|h| h.value == 64.0).unwrap();
+            assert!(e_hap.context.modifier_spans.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_weight_serde_roundtrip() {
+        // Static weights stay bare JSON numbers; patterned weights are
+        // externally tagged operand objects. Both round-trip.
+        let dynamic = parse("0@<1 2> 1").unwrap();
+        let json = serde_json::to_string(&dynamic).unwrap();
+        let back: MiniAST = serde_json::from_str(&json).unwrap();
+        assert_eq!(dynamic, back);
+
+        let static_ = parse("0@2 1!3").unwrap();
+        let json = serde_json::to_string(&static_).unwrap();
+        assert!(
+            json.contains("[2.0") || json.contains(",2.0]") || json.contains("2.0]"),
+            "static weight should serialize as a bare number: {json}"
+        );
+        assert!(json.contains("3"), "static count stays a number: {json}");
+        let back: MiniAST = serde_json::from_str(&json).unwrap();
+        assert_eq!(static_, back);
     }
 }

--- a/crates/modular_core/src/pattern_system/mini/test_parser.rs
+++ b/crates/modular_core/src/pattern_system/mini/test_parser.rs
@@ -26,9 +26,12 @@
 //! - Sequences, stacks (`,`), fast subsequences `[...]`, slow subsequences `<...>`
 //! - Atoms: numbers, hz (`440hz`), notes (`c4`, `d#4`, `cb3`), rest (`~`)
 //! - Note letters 'a'..'g' also parse as a note without octave.
-//! - Modifiers: `*`, `/`, `!`, `?`, `@`, `(k,n,rot?)`
+//! - Modifiers: `*`, `/`, `!`, `?`, `@`, `(k,n,rot?)`. Modifier operands are
+//!   numbers or adjacent `[...]` / `<...>` / `{...}%n` subtrees; `@` and `!`
+//!   accept the same bracketed operands (adjacent only, single `!`).
 //! - Random choice: `a|b|c`
-//! - No sample-name identifiers, no module refs, no midi/volts atoms.
+//! - No sample-name identifiers, no module refs, no midi/volts atoms, no `_`
+//!   elongation, no polymeter outside modifier operands.
 
 #![allow(dead_code)]
 
@@ -203,9 +206,15 @@ impl<'a> Parser<'a> {
             match self.peek() {
                 Some(b'@') => {
                     self.pos += 1;
-                    let n = self.maybe_number()?;
-                    // Bare `@` is weight 2 (matches Tidal/krill and `_`).
-                    weight = Some(Weight::Static(n.unwrap_or(2.0)));
+                    // A bracketed pattern operand binds only when adjacent
+                    // to `@`; `a@ [1 2]` keeps `[1 2]` as its own element.
+                    if matches!(self.peek(), Some(b'[') | Some(b'<') | Some(b'{')) {
+                        weight = Some(Weight::Pattern(Box::new(self.mod_operand_f64()?)));
+                    } else {
+                        let n = self.maybe_number()?;
+                        // Bare `@` is weight 2 (matches Tidal/krill and `_`).
+                        weight = Some(Weight::Static(n.unwrap_or(2.0)));
+                    }
                 }
                 Some(b'*') => {
                     self.pos += 1;
@@ -218,19 +227,8 @@ impl<'a> Parser<'a> {
                     ast = MiniAST::Slow(Box::new(ast), Box::new(op));
                 }
                 Some(b'!') => {
-                    // Accumulate consecutive `!`/`!n` into one Replicate:
-                    // total copies = 1 + Σ(value - 1), bare `!` = 2, `!n` = n.
-                    // Matches Tidal's `pRepeat = 1 + sum es` and krill. No
-                    // whitespace handling — the twin only sees adjacent `!`.
-                    let mut total: i64 = 1;
-                    while self.peek() == Some(b'!') {
-                        self.pos += 1;
-                        total += self.maybe_integer()?.unwrap_or(2) - 1;
-                    }
-                    if total < 0 {
-                        return Err(ParseError("negative replicate count".into()));
-                    }
-                    ast = MiniAST::Replicate(Box::new(ast), ReplicateCount::Static(total as u32));
+                    let count = self.replicate_count()?;
+                    ast = MiniAST::Replicate(Box::new(ast), count);
                 }
                 Some(b'?') => {
                     self.pos += 1;
@@ -465,6 +463,43 @@ impl<'a> Parser<'a> {
         s.parse::<f64>().map_err(|e| ParseError(e.to_string()))
     }
 
+    /// Parse a chain of adjacent `!` modifiers into one replicate count:
+    /// total copies = 1 + Σ(value − 1), bare `!` = 2, `!n` = n — matching
+    /// Tidal's `pRepeat = 1 + sum es` and krill. No whitespace handling —
+    /// the twin only sees adjacent `!`. A bracketed pattern count binds only
+    /// when adjacent and must be the sole `!` in the chain. Assumes the
+    /// cursor sits on the first `!`.
+    fn replicate_count(&mut self) -> ParseResult<ReplicateCount> {
+        let mut total: i64 = 1;
+        let mut parts = 0usize;
+        let mut patterned = None;
+        while self.peek() == Some(b'!') {
+            self.pos += 1;
+            parts += 1;
+            if matches!(self.peek(), Some(b'[') | Some(b'<') | Some(b'{')) {
+                patterned = Some(self.mod_operand_u32()?);
+            } else {
+                total += self.maybe_integer()?.unwrap_or(2) - 1;
+            }
+        }
+        match patterned {
+            Some(op) => {
+                if parts > 1 {
+                    return Err(ParseError(
+                        "`!` with a patterned count cannot be chained with other `!`s".into(),
+                    ));
+                }
+                Ok(ReplicateCount::Pattern(Box::new(op)))
+            }
+            None => {
+                if total < 0 {
+                    return Err(ParseError("negative replicate count".into()));
+                }
+                Ok(ReplicateCount::Static(total as u32))
+            }
+        }
+    }
+
     fn maybe_number(&mut self) -> ParseResult<Option<f64>> {
         // A number also starts with `.` when a digit follows (`.5`).
         let starts_number = match (self.peek(), self.peek_at(1)) {
@@ -552,6 +587,35 @@ impl<'a> Parser<'a> {
                     other => to_slowcat(other),
                 })
             }
+            Some(b'{') => {
+                self.consume(b'{');
+                self.skip_ws();
+                let mut children = vec![self.sequence_expr_f64()?];
+                loop {
+                    self.skip_ws();
+                    if self.peek() == Some(b',') {
+                        self.pos += 1;
+                        self.skip_ws();
+                        children.push(self.sequence_expr_f64()?);
+                    } else {
+                        break;
+                    }
+                }
+                if !self.consume(b'}') {
+                    return Err(ParseError("expected }".into()));
+                }
+                // `%` steps override binds adjacently after the brace.
+                let steps_per_cycle = if self.peek() == Some(b'%') {
+                    self.pos += 1;
+                    Some(Box::new(self.mod_operand_f64()?))
+                } else {
+                    None
+                };
+                Ok(MiniASTF64::Polymeter {
+                    children,
+                    steps_per_cycle,
+                })
+            }
             _ => {
                 let start = self.pos;
                 let n = self.number()?;
@@ -588,19 +652,59 @@ impl<'a> Parser<'a> {
             if self.at_end()
                 || matches!(
                     self.peek(),
-                    Some(b']') | Some(b'>') | Some(b')') | Some(b',')
+                    Some(b']') | Some(b'>') | Some(b')') | Some(b',') | Some(b'}')
                 )
             {
                 break;
             }
-            let base = self.mod_operand_f64()?;
-            self.skip_ws();
-            let weight = if self.peek() == Some(b'@') {
-                self.pos += 1;
-                self.maybe_number()?.map(Weight::Static)
-            } else {
-                None
-            };
+            let mut base = self.mod_operand_f64()?;
+            // Numeric random choice binds at element level inside operand
+            // subtrees (`[1|2]`), mirroring OperandRandomChoiceF64.
+            {
+                let saved = self.pos;
+                self.skip_ws();
+                if self.peek() == Some(b'|') {
+                    let mut choices = vec![base];
+                    loop {
+                        self.skip_ws();
+                        if self.peek() != Some(b'|') {
+                            break;
+                        }
+                        self.pos += 1;
+                        self.skip_ws();
+                        let start = self.pos;
+                        let n = self.number()?;
+                        choices.push(MiniASTF64::Pure(Located::new(n, start, self.pos)));
+                    }
+                    let seed = self.next_seed();
+                    base = MiniASTF64::RandomChoice(choices, seed);
+                } else {
+                    self.pos = saved;
+                }
+            }
+            // Operand elements carry `!` replicate chains (adjacent) and an
+            // optional `@` weight, like main-grammar elements.
+            let mut weight: Option<Weight> = None;
+            loop {
+                if self.peek() == Some(b'!') {
+                    let count = self.replicate_count()?;
+                    base = MiniASTF64::Replicate(Box::new(base), count);
+                    continue;
+                }
+                let saved = self.pos;
+                self.skip_ws();
+                if self.peek() == Some(b'@') {
+                    self.pos += 1;
+                    if matches!(self.peek(), Some(b'[') | Some(b'<') | Some(b'{')) {
+                        weight = Some(Weight::Pattern(Box::new(self.mod_operand_f64()?)));
+                    } else {
+                        weight = self.maybe_number()?.map(Weight::Static);
+                    }
+                } else {
+                    self.pos = saved;
+                    break;
+                }
+            }
             elems.push((base, weight));
         }
         if elems.is_empty() {
@@ -650,6 +754,35 @@ impl<'a> Parser<'a> {
                     other => to_slowcat(other),
                 })
             }
+            Some(b'{') => {
+                self.consume(b'{');
+                self.skip_ws();
+                let mut children = vec![self.sequence_expr_u32()?];
+                loop {
+                    self.skip_ws();
+                    if self.peek() == Some(b',') {
+                        self.pos += 1;
+                        self.skip_ws();
+                        children.push(self.sequence_expr_u32()?);
+                    } else {
+                        break;
+                    }
+                }
+                if !self.consume(b'}') {
+                    return Err(ParseError("expected }".into()));
+                }
+                // `%` steps override binds adjacently after the brace.
+                let steps_per_cycle = if self.peek() == Some(b'%') {
+                    self.pos += 1;
+                    Some(Box::new(self.mod_operand_f64()?))
+                } else {
+                    None
+                };
+                Ok(MiniASTU32::Polymeter {
+                    children,
+                    steps_per_cycle,
+                })
+            }
             _ => {
                 let start = self.pos;
                 let n = self.integer()?;
@@ -689,7 +822,7 @@ impl<'a> Parser<'a> {
             if self.at_end()
                 || matches!(
                     self.peek(),
-                    Some(b']') | Some(b'>') | Some(b')') | Some(b',')
+                    Some(b']') | Some(b'>') | Some(b')') | Some(b',') | Some(b'}')
                 )
             {
                 break;
@@ -744,6 +877,35 @@ impl<'a> Parser<'a> {
                     other => to_slowcat(other),
                 })
             }
+            Some(b'{') => {
+                self.consume(b'{');
+                self.skip_ws();
+                let mut children = vec![self.sequence_expr_i32()?];
+                loop {
+                    self.skip_ws();
+                    if self.peek() == Some(b',') {
+                        self.pos += 1;
+                        self.skip_ws();
+                        children.push(self.sequence_expr_i32()?);
+                    } else {
+                        break;
+                    }
+                }
+                if !self.consume(b'}') {
+                    return Err(ParseError("expected }".into()));
+                }
+                // `%` steps override binds adjacently after the brace.
+                let steps_per_cycle = if self.peek() == Some(b'%') {
+                    self.pos += 1;
+                    Some(Box::new(self.mod_operand_f64()?))
+                } else {
+                    None
+                };
+                Ok(MiniASTI32::Polymeter {
+                    children,
+                    steps_per_cycle,
+                })
+            }
             _ => {
                 let start = self.pos;
                 let n = self.integer()?;
@@ -780,7 +942,7 @@ impl<'a> Parser<'a> {
             if self.at_end()
                 || matches!(
                     self.peek(),
-                    Some(b']') | Some(b'>') | Some(b')') | Some(b',')
+                    Some(b']') | Some(b'>') | Some(b')') | Some(b',') | Some(b'}')
                 )
             {
                 break;

--- a/crates/modular_core/src/pattern_system/mini/test_parser.rs
+++ b/crates/modular_core/src/pattern_system/mini/test_parser.rs
@@ -32,7 +32,9 @@
 
 #![allow(dead_code)]
 
-use super::ast::{AtomValue, Located, MiniAST, MiniASTF64, MiniASTI32, MiniASTU32};
+use super::ast::{
+    AtomValue, Located, MiniAST, MiniASTF64, MiniASTI32, MiniASTU32, ReplicateCount, Weight,
+};
 use crate::pattern_system::SourceSpan;
 
 pub type ParseResult<T> = Result<T, ParseError>;
@@ -168,7 +170,7 @@ impl<'a> Parser<'a> {
     }
 
     fn sequence_expr(&mut self) -> ParseResult<MiniAST> {
-        let mut elems: Vec<(MiniAST, Option<f64>)> = Vec::new();
+        let mut elems: Vec<(MiniAST, Option<Weight>)> = Vec::new();
         loop {
             self.skip_ws();
             // `|` ends a sequence so the enclosing `choice_expr` can pick it
@@ -194,16 +196,16 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn element_with_weight(&mut self) -> ParseResult<(MiniAST, Option<f64>)> {
+    fn element_with_weight(&mut self) -> ParseResult<(MiniAST, Option<Weight>)> {
         let mut ast = self.element_base()?;
-        let mut weight: Option<f64> = None;
+        let mut weight: Option<Weight> = None;
         loop {
             match self.peek() {
                 Some(b'@') => {
                     self.pos += 1;
                     let n = self.maybe_number()?;
                     // Bare `@` is weight 2 (matches Tidal/krill and `_`).
-                    weight = Some(n.unwrap_or(2.0));
+                    weight = Some(Weight::Static(n.unwrap_or(2.0)));
                 }
                 Some(b'*') => {
                     self.pos += 1;
@@ -228,7 +230,7 @@ impl<'a> Parser<'a> {
                     if total < 0 {
                         return Err(ParseError("negative replicate count".into()));
                     }
-                    ast = MiniAST::Replicate(Box::new(ast), total as u32);
+                    ast = MiniAST::Replicate(Box::new(ast), ReplicateCount::Static(total as u32));
                 }
                 Some(b'?') => {
                     self.pos += 1;
@@ -580,7 +582,7 @@ impl<'a> Parser<'a> {
     }
 
     fn sequence_expr_f64(&mut self) -> ParseResult<MiniASTF64> {
-        let mut elems: Vec<(MiniASTF64, Option<f64>)> = Vec::new();
+        let mut elems: Vec<(MiniASTF64, Option<Weight>)> = Vec::new();
         loop {
             self.skip_ws();
             if self.at_end()
@@ -595,7 +597,7 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let weight = if self.peek() == Some(b'@') {
                 self.pos += 1;
-                self.maybe_number()?
+                self.maybe_number()?.map(Weight::Static)
             } else {
                 None
             };
@@ -681,7 +683,7 @@ impl<'a> Parser<'a> {
     }
 
     fn sequence_expr_u32(&mut self) -> ParseResult<MiniASTU32> {
-        let mut elems: Vec<(MiniASTU32, Option<f64>)> = Vec::new();
+        let mut elems: Vec<(MiniASTU32, Option<Weight>)> = Vec::new();
         loop {
             self.skip_ws();
             if self.at_end()
@@ -772,7 +774,7 @@ impl<'a> Parser<'a> {
     }
 
     fn sequence_expr_i32(&mut self) -> ParseResult<MiniASTI32> {
-        let mut elems: Vec<(MiniASTI32, Option<f64>)> = Vec::new();
+        let mut elems: Vec<(MiniASTI32, Option<Weight>)> = Vec::new();
         loop {
             self.skip_ws();
             if self.at_end()
@@ -890,7 +892,9 @@ mod tests {
             MiniAST::Sequence(items) => {
                 assert_eq!(items.len(), 2);
                 match &items[0].0 {
-                    MiniAST::Replicate(_, count) => assert_eq!(*count, 2),
+                    MiniAST::Replicate(_, count) => {
+                        assert_eq!(*count, ReplicateCount::Static(2))
+                    }
                     other => panic!("expected Replicate, got {:?}", other),
                 }
                 assert_eq!(num(&items[1].0), 2.0);
@@ -1006,7 +1010,7 @@ mod tests {
         match &ast {
             MiniAST::Sequence(items) => {
                 assert_eq!(items.len(), 2);
-                assert_eq!(items[0].1, Some(2.0));
+                assert_eq!(items[0].1, Some(Weight::Static(2.0)));
                 assert_eq!(items[1].1, None);
             }
             other => panic!("expected Sequence, got {:?}", other),
@@ -1018,7 +1022,7 @@ mod tests {
         let ast = parse("a!3").unwrap();
         match &ast {
             MiniAST::Replicate(inner, count) => {
-                assert_eq!(*count, 3);
+                assert_eq!(*count, ReplicateCount::Static(3));
                 match inner.as_ref() {
                     MiniAST::Pure(l) => {
                         assert!(matches!(l.node, AtomValue::Note { letter: 'a', .. }))

--- a/src/main/dsl/miniNotation/__tests__/parser.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/parser.test.ts
@@ -334,6 +334,114 @@ describe('modifiers', () => {
     });
 });
 
+describe('patterned @/! operands', () => {
+    test('weight @<...> stores a SlowCat operand AST', () => {
+        const r = $p('0@<1 2> 1');
+        if (!('Sequence' in r.ast)) return expect.fail('expected Sequence');
+        const weight = r.ast.Sequence[0][1];
+        expect(
+            typeof weight === 'object' && weight !== null && 'SlowCat' in weight,
+        ).toBe(true);
+        expect(r.ast.Sequence[1][1]).toBeNull();
+    });
+
+    test('weight @[...] stores a FastCat operand AST', () => {
+        const r = $p('0@[2 1] 1');
+        if (!('Sequence' in r.ast)) return expect.fail('expected Sequence');
+        const weight = r.ast.Sequence[0][1];
+        expect(
+            typeof weight === 'object' && weight !== null && 'FastCat' in weight,
+        ).toBe(true);
+    });
+
+    test('weight @{...} stores a Polymeter operand AST', () => {
+        const r = $p('0@{1 2} 1');
+        if (!('Sequence' in r.ast)) return expect.fail('expected Sequence');
+        const weight = r.ast.Sequence[0][1];
+        expect(
+            typeof weight === 'object' &&
+                weight !== null &&
+                'Polymeter' in weight,
+        ).toBe(true);
+    });
+
+    test('weight @[1|2] carries a bracketed random choice', () => {
+        const r = $p('0@[1|2] 1');
+        if (!('Sequence' in r.ast)) return expect.fail('expected Sequence');
+        const weight = r.ast.Sequence[0][1];
+        expect(JSON.stringify(weight)).toContain('RandomChoice');
+    });
+
+    test('bare | after @n stays a sequence-level choice', () => {
+        const r = $p('0@1|1');
+        expect('RandomChoice' in r.ast).toBe(true);
+    });
+
+    test('@ with whitespace before a bracket keeps the bracket separate', () => {
+        // `0@ [1 2]`: bare `@` (weight 2) followed by a fastcat element.
+        const r = $p('0@ [1 2]');
+        if (!('Sequence' in r.ast)) return expect.fail('expected Sequence');
+        expect(r.ast.Sequence).toHaveLength(2);
+        expect(r.ast.Sequence[0][1]).toBe(2);
+        expect('FastCat' in r.ast.Sequence[1][0]).toBe(true);
+    });
+
+    test('replicate !<...> stores a pattern count', () => {
+        const r = $p('0!<2 3>');
+        if (!('Replicate' in r.ast)) return expect.fail('expected Replicate');
+        const count = r.ast.Replicate[1];
+        expect(typeof count === 'object' && 'SlowCat' in count).toBe(true);
+    });
+
+    test('replicate ![...] stores a pattern count', () => {
+        const r = $p('0![2 3]');
+        if (!('Replicate' in r.ast)) return expect.fail('expected Replicate');
+        expect(typeof r.ast.Replicate[1]).toBe('object');
+    });
+
+    test('replicate !{...} stores a Polymeter count', () => {
+        const r = $p('0!{2 3}');
+        if (!('Replicate' in r.ast)) return expect.fail('expected Replicate');
+        const count = r.ast.Replicate[1];
+        expect(typeof count === 'object' && 'Polymeter' in count).toBe(true);
+    });
+
+    test('! with whitespace before a bracket keeps the bracket separate', () => {
+        // `0! [2 3]`: bare `!` (2 copies) followed by a fastcat element.
+        const r = $p('0! [2 3]');
+        if (!('Sequence' in r.ast)) return expect.fail('expected Sequence');
+        expect(r.ast.Sequence).toHaveLength(2);
+        const [first] = r.ast.Sequence[0];
+        if (!('Replicate' in first)) return expect.fail('expected Replicate');
+        expect(first.Replicate[1]).toBe(2);
+    });
+
+    test('chaining ! around a patterned count is a parse error', () => {
+        expect(() => $p('0![2 3]!2')).toThrow(MiniParseError);
+        expect(() => $p('0!2![2 3]')).toThrow(MiniParseError);
+    });
+
+    test('`_` cannot elongate a pattern-weighted element', () => {
+        expect(() => $p('0@<1 2> _')).toThrow(MiniParseError);
+    });
+
+    test('fast operand accepts {} polymeter with % steps', () => {
+        const r = $p('0*{1 2 3}%4');
+        if (!('Fast' in r.ast)) return expect.fail('expected Fast');
+        const factor = r.ast.Fast[1];
+        if (!('Polymeter' in factor)) return expect.fail('expected Polymeter');
+        expect(factor.Polymeter.children).toHaveLength(1);
+        expect(factor.Polymeter.steps_per_cycle).toEqual({
+            Pure: { node: 4, span: expect.anything() },
+        });
+    });
+
+    test('slow and euclid operands accept {} polymeter', () => {
+        expect(() => $p('0/{2 3}')).not.toThrow();
+        expect(() => $p('0(3,{4 8})')).not.toThrow();
+    });
+});
+
 // Whitespace is accepted between an element and its modifier sigils, and
 // between a mandatory-operand sigil (`*`, `/`, and `@`) and its operand —
 // e.g. `<...> / 4` is a Slow modifier. The optional-operand sigils `!` and

--- a/src/main/dsl/miniNotation/__tests__/peggy_parser_parity_fixture.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/peggy_parser_parity_fixture.test.ts
@@ -102,6 +102,18 @@ const PARITY_CASES: Array<{ label: string; input: string }> = [
     { label: 'truthy with euclidean', input: 'x(3,8)' },
     { label: 'truthy in slow subsequence', input: '<x ~>' },
     { label: 'truthy with fast modifier', input: 'x*2' },
+    { label: 'patterned weight @[...]', input: '0@[2 1] 1' },
+    { label: 'patterned weight @<...>', input: '0@<1 2> 1' },
+    { label: 'patterned weight @{...}', input: '0@{1 2} 1' },
+    { label: 'patterned weight bracketed choice', input: '0@[1|2] 1' },
+    { label: 'patterned weight with operand replicate', input: '<0@<2!3 3> 1>' },
+    { label: 'patterned replicate !<...>', input: '0!<2 3> 1' },
+    { label: 'patterned replicate ![...]', input: '0![2 3] 1' },
+    { label: 'patterned replicate !{...}', input: '0!{2 3} 1' },
+    { label: 'operand polymeter for fast', input: '0*{1 2 3}' },
+    { label: 'operand polymeter with % steps', input: '0*{1 2 3}%4' },
+    { label: 'operand polymeter for slow', input: '0/{2 3}' },
+    { label: 'operand polymeter euclid steps', input: '0(3,{4 8})' },
 ];
 
 /**

--- a/src/main/dsl/miniNotation/__tests__/sp.test.ts
+++ b/src/main/dsl/miniNotation/__tests__/sp.test.ts
@@ -264,6 +264,15 @@ const GRAMMAR_CASES: Array<{ label: string; source: string }> = [
     { label: 'weight @n positional', source: '0@2 1' },
     { label: 'random choice |', source: '0|1|2' },
     { label: 'rest inside choice', source: '0|~|2' },
+    { label: 'patterned weight @<...>', source: '0@<1 2> 1' },
+    { label: 'patterned weight @[...]', source: '0@[2 1] 1' },
+    { label: 'patterned weight @{...}', source: '0@{1 2} 1' },
+    { label: 'patterned weight bracketed choice', source: '0@[1|2] 1' },
+    { label: 'patterned replicate !<...>', source: '0!<2 3> 1' },
+    { label: 'patterned replicate ![...]', source: '0![2 3] 1' },
+    { label: 'operand polymeter for fast', source: '0*{1 2 3}' },
+    { label: 'operand polymeter with % steps', source: '0*{1 2 3}%4' },
+    { label: 'euclid arg polymeter', source: '0(3,{4 8})' },
 ];
 
 describe('peggy grammar survives replaceSignals (regression)', () => {

--- a/src/main/dsl/miniNotation/ast.ts
+++ b/src/main/dsl/miniNotation/ast.ts
@@ -13,8 +13,11 @@
  * with multiple positional fields serialize as a tuple (array) payload, so
  * `Fast(Box<MiniAST>, Box<MiniASTF64>)` becomes `{ "Fast": [ast, factor] }`.
  *
- * `Sequence(Vec<(MiniAST, Option<f64>)>)` serializes as
- * `{ "Sequence": [[child, weight | null], ...] }`.
+ * `Sequence(Vec<(MiniAST, Option<Weight>)>)` serializes as
+ * `{ "Sequence": [[child, weight], ...] }`, where the weight slot is
+ * untagged on the Rust side: a static weight is a bare number (or null),
+ * a patterned weight (`a@<1 2>`) is a `MiniASTF64` object. Replicate counts
+ * follow the same untagged scheme with `MiniASTU32`.
  */
 
 /** Source location in the original pattern string, half-open `[start, end)`. */
@@ -49,19 +52,25 @@ export type AtomValue =
      */
     | 'Truthy';
 
+/** `@` weight on a sequence entry: static number or pattern operand. */
+export type Weight = number | MiniASTF64;
+
+/** `!` replicate count: static number or pattern operand. */
+export type ReplicateCount = number | MiniASTU32;
+
 /** Top-level AST node. */
 export type MiniAST =
     | { Pure: Located<AtomValue> }
     | { Rest: SourceSpan }
     | { List: Located<MiniAST[]> }
-    | { Sequence: Array<[MiniAST, number | null]> }
-    | { FastCat: Array<[MiniAST, number | null]> }
-    | { SlowCat: Array<[MiniAST, number | null]> }
+    | { Sequence: Array<[MiniAST, Weight | null]> }
+    | { FastCat: Array<[MiniAST, Weight | null]> }
+    | { SlowCat: Array<[MiniAST, Weight | null]> }
     | { Stack: MiniAST[] }
     | { RandomChoice: [MiniAST[], number] }
     | { Fast: [MiniAST, MiniASTF64] }
     | { Slow: [MiniAST, MiniASTF64] }
-    | { Replicate: [MiniAST, number] }
+    | { Replicate: [MiniAST, ReplicateCount] }
     | { Degrade: [MiniAST, number | null, number] }
     | {
           Euclidean: {
@@ -83,14 +92,14 @@ export type MiniASTF64 =
     | { Pure: Located<number> }
     | { Rest: SourceSpan }
     | { List: Located<MiniASTF64[]> }
-    | { Sequence: Array<[MiniASTF64, number | null]> }
-    | { FastCat: Array<[MiniASTF64, number | null]> }
-    | { SlowCat: Array<[MiniASTF64, number | null]> }
+    | { Sequence: Array<[MiniASTF64, Weight | null]> }
+    | { FastCat: Array<[MiniASTF64, Weight | null]> }
+    | { SlowCat: Array<[MiniASTF64, Weight | null]> }
     | { Stack: MiniASTF64[] }
     | { RandomChoice: [MiniASTF64[], number] }
     | { Fast: [MiniASTF64, MiniASTF64] }
     | { Slow: [MiniASTF64, MiniASTF64] }
-    | { Replicate: [MiniASTF64, number] }
+    | { Replicate: [MiniASTF64, ReplicateCount] }
     | { Degrade: [MiniASTF64, number | null, number] }
     | {
           Euclidean: {
@@ -112,14 +121,14 @@ export type MiniASTU32 =
     | { Pure: Located<number> }
     | { Rest: SourceSpan }
     | { List: Located<MiniASTU32[]> }
-    | { Sequence: Array<[MiniASTU32, number | null]> }
-    | { FastCat: Array<[MiniASTU32, number | null]> }
-    | { SlowCat: Array<[MiniASTU32, number | null]> }
+    | { Sequence: Array<[MiniASTU32, Weight | null]> }
+    | { FastCat: Array<[MiniASTU32, Weight | null]> }
+    | { SlowCat: Array<[MiniASTU32, Weight | null]> }
     | { Stack: MiniASTU32[] }
     | { RandomChoice: [MiniASTU32[], number] }
     | { Fast: [MiniASTU32, MiniASTF64] }
     | { Slow: [MiniASTU32, MiniASTF64] }
-    | { Replicate: [MiniASTU32, number] }
+    | { Replicate: [MiniASTU32, ReplicateCount] }
     | { Degrade: [MiniASTU32, number | null, number] }
     | {
           Euclidean: {
@@ -141,14 +150,14 @@ export type MiniASTI32 =
     | { Pure: Located<number> }
     | { Rest: SourceSpan }
     | { List: Located<MiniASTI32[]> }
-    | { Sequence: Array<[MiniASTI32, number | null]> }
-    | { FastCat: Array<[MiniASTI32, number | null]> }
-    | { SlowCat: Array<[MiniASTI32, number | null]> }
+    | { Sequence: Array<[MiniASTI32, Weight | null]> }
+    | { FastCat: Array<[MiniASTI32, Weight | null]> }
+    | { SlowCat: Array<[MiniASTI32, Weight | null]> }
     | { Stack: MiniASTI32[] }
     | { RandomChoice: [MiniASTI32[], number] }
     | { Fast: [MiniASTI32, MiniASTF64] }
     | { Slow: [MiniASTI32, MiniASTF64] }
-    | { Replicate: [MiniASTI32, number] }
+    | { Replicate: [MiniASTI32, ReplicateCount] }
     | { Degrade: [MiniASTI32, number | null, number] }
     | {
           Euclidean: {

--- a/src/main/dsl/miniNotation/collectLeafSpans.ts
+++ b/src/main/dsl/miniNotation/collectLeafSpans.ts
@@ -18,7 +18,9 @@ import type {
     MiniASTF64,
     MiniASTI32,
     MiniASTU32,
+    ReplicateCount,
     SourceSpan,
+    Weight,
 } from './ast';
 
 type Span = [number, number];
@@ -53,18 +55,33 @@ function walkCommon<T extends AnyAst>(
         return 'handled';
     }
     if ('Sequence' in ast) {
-        for (const [child] of ast.Sequence as Array<[T, number | null]>)
+        for (const [child, weight] of ast.Sequence as Array<
+            [T, Weight | null]
+        >) {
             self(child, out);
+            if (typeof weight === 'object' && weight !== null)
+                walkF64(weight, out);
+        }
         return 'handled';
     }
     if ('FastCat' in ast) {
-        for (const [child] of ast.FastCat as Array<[T, number | null]>)
+        for (const [child, weight] of ast.FastCat as Array<
+            [T, Weight | null]
+        >) {
             self(child, out);
+            if (typeof weight === 'object' && weight !== null)
+                walkF64(weight, out);
+        }
         return 'handled';
     }
     if ('SlowCat' in ast) {
-        for (const [child] of ast.SlowCat as Array<[T, number | null]>)
+        for (const [child, weight] of ast.SlowCat as Array<
+            [T, Weight | null]
+        >) {
             self(child, out);
+            if (typeof weight === 'object' && weight !== null)
+                walkF64(weight, out);
+        }
         return 'handled';
     }
     if ('RandomChoice' in ast) {
@@ -77,8 +94,9 @@ function walkCommon<T extends AnyAst>(
         return 'handled';
     }
     if ('Replicate' in ast) {
-        const [pattern] = ast.Replicate as [T, number];
+        const [pattern, count] = ast.Replicate as [T, ReplicateCount];
         self(pattern, out);
+        if (typeof count === 'object') walkU32(count, out);
         return 'handled';
     }
     if ('Degrade' in ast) {

--- a/src/main/dsl/miniNotation/grammar.generated.ts
+++ b/src/main/dsl/miniNotation/grammar.generated.ts
@@ -43,6 +43,11 @@
           throw new Error("leading `_` has no element to elongate");
         }
         const last = out[out.length - 1];
+        // Elongation adds 1 to a numeric weight; a patterned weight has no
+        // meaningful +1.
+        if (typeof last[1] === 'object' && last[1] !== null) {
+          throw new Error("`_` cannot elongate an element whose weight is a pattern");
+        }
         last[1] = (last[1] ?? 1) + 1;
         continue;
       }
@@ -377,23 +382,35 @@ function peg$parse(input, options) {
   function peg$f24(sign, digits) {
     return parseInt((sign || "") + digits, 10);
   }
-  function peg$f25(n) {    return n === null ? 2 : n;  }
-  function peg$f26(op) {
+  function peg$f25(op) {    return op;  }
+  function peg$f26(n) {    return n === null ? 2 : n;  }
+  function peg$f27(s) {    return s.fast;  }
+  function peg$f28(s) {    return s.slow;  }
+  function peg$f29(op) {
     return (ast, _c) => ({ Fast: [ast, op] });
   }
-  function peg$f27(op) {
+  function peg$f30(op) {
     return (ast, _c) => ({ Slow: [ast, op] });
   }
-  function peg$f28(n) {    return n === null ? 2 : n;  }
-  function peg$f29(parts) {
-    const total = parts.reduce((acc, v) => acc + (v - 1), 1);
+  function peg$f31(op) {    return op ?? null;  }
+  function peg$f32(parts) {
+    const patterned = parts.find(p => p !== null && typeof p === 'object');
+    if (patterned !== undefined) {
+      if (parts.length > 1) {
+        error("`!` with a patterned count cannot be chained with other `!`s");
+      }
+      return (ast, _c) => ({ Replicate: [ast, patterned] });
+    }
+    const total = parts.reduce((acc, v) => acc + ((v ?? 2) - 1), 1);
     if (total < 0) error("Replicate count must be a non-negative integer");
     return (ast, _c) => ({ Replicate: [ast, total] });
   }
-  function peg$f30(p) {
+  function peg$f33(s) {    return s.fast;  }
+  function peg$f34(s) {    return s.slow;  }
+  function peg$f35(p) {
     return (ast, c) => ({ Degrade: [ast, p, c.nextSeed()] });
   }
-  function peg$f31(pulses, steps, rot) {
+  function peg$f36(pulses, steps, rot) {
     return (ast, _c) => ({
       Euclidean: {
         pattern: ast,
@@ -403,26 +420,26 @@ function peg$parse(input, options) {
       },
     });
   }
-  function peg$f32(r) {    return r;  }
-  function peg$f33(n) {
+  function peg$f37(r) {    return r;  }
+  function peg$f38(n) {
     return { Pure: located(n, location()) };
   }
-  function peg$f34(s) {    return s.fast;  }
-  function peg$f35(s) {    return s.slow;  }
-  function peg$f36(r) {    return r;  }
-  function peg$f37(n) {
+  function peg$f39(s) {    return s.fast;  }
+  function peg$f40(s) {    return s.slow;  }
+  function peg$f41(r) {    return r;  }
+  function peg$f42(n) {
     if (n < 0) error("Euclidean pulses/steps must be non-negative integers");
     return { Pure: located(n, location()) };
   }
-  function peg$f38(s) {    return s.fast;  }
-  function peg$f39(s) {    return s.slow;  }
-  function peg$f40(r) {    return r;  }
-  function peg$f41(n) {
+  function peg$f43(s) {    return s.fast;  }
+  function peg$f44(s) {    return s.slow;  }
+  function peg$f45(r) {    return r;  }
+  function peg$f46(n) {
     return { Pure: located(n, location()) };
   }
-  function peg$f42(s) {    return s.fast;  }
-  function peg$f43(s) {    return s.slow;  }
-  function peg$f44(first, tail) {
+  function peg$f47(s) {    return s.fast;  }
+  function peg$f48(s) {    return s.slow;  }
+  function peg$f49(first, tail) {
     if (tail.length === 0) {
       return { fast: { FastCat: first.asCat }, slow: { SlowCat: first.asCat } };
     }
@@ -432,10 +449,10 @@ function peg$parse(input, options) {
       slow: { Stack: all.map(s => ({ SlowCat: s.asCat })) },
     };
   }
-  function peg$f45(elems) {    return { asCat: applyElongation(elems) };  }
-  function peg$f46() {    return { kind: 'elongation' };  }
-  function peg$f47(e) {    return { kind: 'element', entry: e };  }
-  function peg$f48(base, parts) {
+  function peg$f50(elems) {    return { asCat: applyElongation(elems) };  }
+  function peg$f51() {    return { kind: 'elongation' };  }
+  function peg$f52(e) {    return { kind: 'element', entry: e };  }
+  function peg$f53(base, parts) {
     let ast = base;
     let weight = null;
     for (const part of parts) {
@@ -447,17 +464,22 @@ function peg$parse(input, options) {
     }
     return [ast, weight];
   }
-  function peg$f49(first, rest) {
+  function peg$f54(first, rest) {
     const seed = ctx.nextSeed();
     return { RandomChoice: [[first, ...rest], seed] };
   }
-  function peg$f50() {    return { Rest: spanOf(location()) };  }
-  function peg$f51(n) {    return { Pure: located(n, location()) };  }
-  function peg$f52() {    return { Rest: spanOf(location()) };  }
-  function peg$f53(n) {    return { Pure: located(n, location()) };  }
-  function peg$f54(s) {    return s.fast;  }
-  function peg$f55(s) {    return s.slow;  }
-  function peg$f56(first, tail) {
+  function peg$f55() {    return { Rest: spanOf(location()) };  }
+  function peg$f56(n) {    return { Pure: located(n, location()) };  }
+  function peg$f57() {    return { Rest: spanOf(location()) };  }
+  function peg$f58(n) {    return { Pure: located(n, location()) };  }
+  function peg$f59(s) {    return s.fast;  }
+  function peg$f60(s) {    return s.slow;  }
+  function peg$f61(head, tail, steps) {
+    const toChild = (s) =>
+      s.asCat.length === 1 && s.asCat[0][1] === null ? s.asCat[0][0] : { Sequence: s.asCat };
+    return { Polymeter: { children: [head, ...tail].map(toChild), steps_per_cycle: steps } };
+  }
+  function peg$f62(first, tail) {
     if (tail.length === 0) {
       return { fast: { FastCat: first.asCat }, slow: { SlowCat: first.asCat } };
     }
@@ -467,10 +489,10 @@ function peg$parse(input, options) {
       slow: { Stack: all.map(s => ({ SlowCat: s.asCat })) },
     };
   }
-  function peg$f57(elems) {    return { asCat: applyElongation(elems) };  }
-  function peg$f58() {    return { kind: 'elongation' };  }
-  function peg$f59(e) {    return { kind: 'element', entry: e };  }
-  function peg$f60(base, parts) {
+  function peg$f63(elems) {    return { asCat: applyElongation(elems) };  }
+  function peg$f64() {    return { kind: 'elongation' };  }
+  function peg$f65(e) {    return { kind: 'element', entry: e };  }
+  function peg$f66(base, parts) {
     let ast = base;
     let weight = null;
     for (const part of parts) {
@@ -482,23 +504,28 @@ function peg$parse(input, options) {
     }
     return [ast, weight];
   }
-  function peg$f61(first, rest) {
+  function peg$f67(first, rest) {
     const seed = ctx.nextSeed();
     return { RandomChoice: [[first, ...rest], seed] };
   }
-  function peg$f62() {    return { Rest: spanOf(location()) };  }
-  function peg$f63(n) {
+  function peg$f68() {    return { Rest: spanOf(location()) };  }
+  function peg$f69(n) {
     if (n < 0) error("Expected non-negative integer");
     return { Pure: located(n, location()) };
   }
-  function peg$f64() {    return { Rest: spanOf(location()) };  }
-  function peg$f65(n) {
+  function peg$f70() {    return { Rest: spanOf(location()) };  }
+  function peg$f71(n) {
     if (n < 0) error("Expected non-negative integer");
     return { Pure: located(n, location()) };
   }
-  function peg$f66(s) {    return s.fast;  }
-  function peg$f67(s) {    return s.slow;  }
-  function peg$f68(first, tail) {
+  function peg$f72(s) {    return s.fast;  }
+  function peg$f73(s) {    return s.slow;  }
+  function peg$f74(head, tail, steps) {
+    const toChild = (s) =>
+      s.asCat.length === 1 && s.asCat[0][1] === null ? s.asCat[0][0] : { Sequence: s.asCat };
+    return { Polymeter: { children: [head, ...tail].map(toChild), steps_per_cycle: steps } };
+  }
+  function peg$f75(first, tail) {
     if (tail.length === 0) {
       return { fast: { FastCat: first.asCat }, slow: { SlowCat: first.asCat } };
     }
@@ -508,10 +535,10 @@ function peg$parse(input, options) {
       slow: { Stack: all.map(s => ({ SlowCat: s.asCat })) },
     };
   }
-  function peg$f69(elems) {    return { asCat: applyElongation(elems) };  }
-  function peg$f70() {    return { kind: 'elongation' };  }
-  function peg$f71(e) {    return { kind: 'element', entry: e };  }
-  function peg$f72(base, parts) {
+  function peg$f76(elems) {    return { asCat: applyElongation(elems) };  }
+  function peg$f77() {    return { kind: 'elongation' };  }
+  function peg$f78(e) {    return { kind: 'element', entry: e };  }
+  function peg$f79(base, parts) {
     let ast = base;
     let weight = null;
     for (const part of parts) {
@@ -523,18 +550,23 @@ function peg$parse(input, options) {
     }
     return [ast, weight];
   }
-  function peg$f73(first, rest) {
+  function peg$f80(first, rest) {
     const seed = ctx.nextSeed();
     return { RandomChoice: [[first, ...rest], seed] };
   }
-  function peg$f74() {    return { Rest: spanOf(location()) };  }
-  function peg$f75(n) {    return { Pure: located(n, location()) };  }
-  function peg$f76() {    return { Rest: spanOf(location()) };  }
-  function peg$f77(n) {    return { Pure: located(n, location()) };  }
-  function peg$f78(s) {    return s.fast;  }
-  function peg$f79(s) {    return s.slow;  }
-  function peg$f80(s) {    return parseFloat(s);  }
-  function peg$f81(s) {    return parseInt(s, 10);  }
+  function peg$f81() {    return { Rest: spanOf(location()) };  }
+  function peg$f82(n) {    return { Pure: located(n, location()) };  }
+  function peg$f83() {    return { Rest: spanOf(location()) };  }
+  function peg$f84(n) {    return { Pure: located(n, location()) };  }
+  function peg$f85(s) {    return s.fast;  }
+  function peg$f86(s) {    return s.slow;  }
+  function peg$f87(head, tail, steps) {
+    const toChild = (s) =>
+      s.asCat.length === 1 && s.asCat[0][1] === null ? s.asCat[0][0] : { Sequence: s.asCat };
+    return { Polymeter: { children: [head, ...tail].map(toChild), steps_per_cycle: steps } };
+  }
+  function peg$f88(s) {    return parseFloat(s);  }
+  function peg$f89(s) {    return parseInt(s, 10);  }
   let peg$currPos = options.peg$currPos | 0;
   let peg$savedPos = peg$currPos;
   const peg$posDetailsCache = [{ line: 1, column: 1 }];
@@ -1739,16 +1771,121 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e22); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
-      s3 = peg$parseNumber();
-      if (s3 === peg$FAILED) {
-        s3 = null;
+      s2 = peg$parseWeightPatternOperand();
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s0 = peg$f25(s2);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
       }
-      peg$savedPos = s0;
-      s0 = peg$f25(s3);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 64) {
+        s1 = peg$c18;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e22); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        s3 = peg$parseNumber();
+        if (s3 === peg$FAILED) {
+          s3 = null;
+        }
+        peg$savedPos = s0;
+        s0 = peg$f26(s3);
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    return s0;
+  }
+
+  function peg$parseWeightPatternOperand() {
+    let s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 91) {
+      s1 = peg$c7;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e7); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      s3 = peg$parseOperandStackExprF64();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 93) {
+          s5 = peg$c8;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e8); }
+        }
+        if (s5 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s0 = peg$f27(s3);
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 60) {
+        s1 = peg$c9;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e9); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        s3 = peg$parseOperandStackExprF64();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (input.charCodeAt(peg$currPos) === 62) {
+            s5 = peg$c10;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e10); }
+          }
+          if (s5 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f28(s3);
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseOperandPolymeterF64();
+      }
     }
 
     return s0;
@@ -1770,7 +1907,7 @@ function peg$parse(input, options) {
       s3 = peg$parseModOperandF64();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f26(s3);
+        s0 = peg$f29(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1799,7 +1936,7 @@ function peg$parse(input, options) {
       s3 = peg$parseModOperandF64();
       if (s3 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f27(s3);
+        s0 = peg$f30(s3);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -1827,12 +1964,12 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$e25); }
     }
     if (s4 !== peg$FAILED) {
-      s5 = peg$parseInteger();
+      s5 = peg$parseReplicateOperand();
       if (s5 === peg$FAILED) {
         s5 = null;
       }
       peg$savedPos = s2;
-      s2 = peg$f28(s5);
+      s2 = peg$f31(s5);
     } else {
       peg$currPos = s2;
       s2 = peg$FAILED;
@@ -1850,12 +1987,12 @@ function peg$parse(input, options) {
           if (peg$silentFails === 0) { peg$fail(peg$e25); }
         }
         if (s4 !== peg$FAILED) {
-          s5 = peg$parseInteger();
+          s5 = peg$parseReplicateOperand();
           if (s5 === peg$FAILED) {
             s5 = null;
           }
           peg$savedPos = s2;
-          s2 = peg$f28(s5);
+          s2 = peg$f31(s5);
         } else {
           peg$currPos = s2;
           s2 = peg$FAILED;
@@ -1866,9 +2003,94 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f29(s1);
+      s1 = peg$f32(s1);
     }
     s0 = s1;
+
+    return s0;
+  }
+
+  function peg$parseReplicateOperand() {
+    let s0, s1, s2, s3, s4, s5;
+
+    s0 = peg$parseInteger();
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 91) {
+        s1 = peg$c7;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$e7); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        s3 = peg$parseOperandStackExprU32();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (input.charCodeAt(peg$currPos) === 93) {
+            s5 = peg$c8;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e8); }
+          }
+          if (s5 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s0 = peg$f33(s3);
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 60) {
+          s1 = peg$c9;
+          peg$currPos++;
+        } else {
+          s1 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e9); }
+        }
+        if (s1 !== peg$FAILED) {
+          s2 = peg$parse_();
+          s3 = peg$parseOperandStackExprU32();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse_();
+            if (input.charCodeAt(peg$currPos) === 62) {
+              s5 = peg$c10;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$e10); }
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s0 = peg$f34(s3);
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseOperandPolymeterU32();
+        }
+      }
+    }
 
     return s0;
   }
@@ -1890,7 +2112,7 @@ function peg$parse(input, options) {
         s2 = null;
       }
       peg$savedPos = s0;
-      s0 = peg$f30(s2);
+      s0 = peg$f35(s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -1961,7 +2183,7 @@ function peg$parse(input, options) {
             }
             if (s11 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f31(s3, s7, s9);
+              s0 = peg$f36(s3, s7, s9);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -1993,7 +2215,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOperandRandomChoiceF64();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f32(s1);
+      s1 = peg$f37(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2001,7 +2223,7 @@ function peg$parse(input, options) {
       s1 = peg$parseNumber();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f33(s1);
+        s1 = peg$f38(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -2027,7 +2249,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f34(s3);
+              s0 = peg$f39(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -2063,7 +2285,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f35(s3);
+                s0 = peg$f40(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2075,6 +2297,9 @@ function peg$parse(input, options) {
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseOperandPolymeterF64();
           }
         }
       }
@@ -2090,7 +2315,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOperandRandomChoiceU32();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f36(s1);
+      s1 = peg$f41(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2098,7 +2323,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f37(s1);
+        s1 = peg$f42(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -2124,7 +2349,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f38(s3);
+              s0 = peg$f43(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -2160,7 +2385,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f39(s3);
+                s0 = peg$f44(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2172,6 +2397,9 @@ function peg$parse(input, options) {
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseOperandPolymeterU32();
           }
         }
       }
@@ -2187,7 +2415,7 @@ function peg$parse(input, options) {
     s1 = peg$parseOperandRandomChoiceI32();
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f40(s1);
+      s1 = peg$f45(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2195,7 +2423,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f41(s1);
+        s1 = peg$f46(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -2221,7 +2449,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f42(s3);
+              s0 = peg$f47(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -2257,7 +2485,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f43(s3);
+                s0 = peg$f48(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2269,6 +2497,9 @@ function peg$parse(input, options) {
           } else {
             peg$currPos = s0;
             s0 = peg$FAILED;
+          }
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseOperandPolymeterI32();
           }
         }
       }
@@ -2332,7 +2563,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f44(s1, s2);
+      s0 = peg$f49(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2373,7 +2604,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f45(s1);
+      s1 = peg$f50(s1);
     }
     s0 = s1;
 
@@ -2404,7 +2635,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f46();
+        s0 = peg$f51();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2418,7 +2649,7 @@ function peg$parse(input, options) {
       s1 = peg$parseOperandElementF64();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f47(s1);
+        s1 = peg$f52(s1);
       }
       s0 = s1;
     }
@@ -2442,7 +2673,7 @@ function peg$parse(input, options) {
         s3 = peg$parseElementPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f48(s1, s2);
+      s0 = peg$f53(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2511,7 +2742,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f49(s1, s2);
+        s0 = peg$f54(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2593,7 +2824,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f50();
+      s1 = peg$f55();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2601,7 +2832,7 @@ function peg$parse(input, options) {
       s1 = peg$parseNumber();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f51(s1);
+        s1 = peg$f56(s1);
       }
       s0 = s1;
     }
@@ -2678,7 +2909,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f52();
+      s1 = peg$f57();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -2686,7 +2917,7 @@ function peg$parse(input, options) {
       s1 = peg$parseNumber();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f53(s1);
+        s1 = peg$f58(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -2712,7 +2943,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f54(s3);
+              s0 = peg$f59(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -2748,7 +2979,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f55(s3);
+                s0 = peg$f60(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -2761,8 +2992,105 @@ function peg$parse(input, options) {
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseOperandPolymeterF64();
+          }
         }
       }
+    }
+
+    return s0;
+  }
+
+  function peg$parseOperandPolymeterF64() {
+    let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 123) {
+      s1 = peg$c4;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e4); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      s3 = peg$parseOperandSequenceF64();
+      if (s3 !== peg$FAILED) {
+        s4 = [];
+        s5 = peg$currPos;
+        s6 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s7 = peg$c0;
+          peg$currPos++;
+        } else {
+          s7 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e0); }
+        }
+        if (s7 !== peg$FAILED) {
+          s8 = peg$parse_();
+          s9 = peg$parseOperandSequenceF64();
+          if (s9 !== peg$FAILED) {
+            s5 = s9;
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s5;
+          s5 = peg$FAILED;
+        }
+        while (s5 !== peg$FAILED) {
+          s4.push(s5);
+          s5 = peg$currPos;
+          s6 = peg$parse_();
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s7 = peg$c0;
+            peg$currPos++;
+          } else {
+            s7 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e0); }
+          }
+          if (s7 !== peg$FAILED) {
+            s8 = peg$parse_();
+            s9 = peg$parseOperandSequenceF64();
+            if (s9 !== peg$FAILED) {
+              s5 = s9;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        }
+        s5 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 125) {
+          s6 = peg$c5;
+          peg$currPos++;
+        } else {
+          s6 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e5); }
+        }
+        if (s6 !== peg$FAILED) {
+          s7 = peg$parsePolymeterSteps();
+          if (s7 === peg$FAILED) {
+            s7 = null;
+          }
+          peg$savedPos = s0;
+          s0 = peg$f61(s3, s4, s7);
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     return s0;
@@ -2823,7 +3151,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f56(s1, s2);
+      s0 = peg$f62(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -2864,7 +3192,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f57(s1);
+      s1 = peg$f63(s1);
     }
     s0 = s1;
 
@@ -2895,7 +3223,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f58();
+        s0 = peg$f64();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -2909,7 +3237,7 @@ function peg$parse(input, options) {
       s1 = peg$parseOperandElementU32();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f59(s1);
+        s1 = peg$f65(s1);
       }
       s0 = s1;
     }
@@ -2933,7 +3261,7 @@ function peg$parse(input, options) {
         s3 = peg$parseElementPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f60(s1, s2);
+      s0 = peg$f66(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -3002,7 +3330,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f61(s1, s2);
+        s0 = peg$f67(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3066,7 +3394,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f62();
+      s1 = peg$f68();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3074,7 +3402,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f63(s1);
+        s1 = peg$f69(s1);
       }
       s0 = s1;
     }
@@ -3133,7 +3461,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f64();
+      s1 = peg$f70();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3141,7 +3469,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f65(s1);
+        s1 = peg$f71(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3167,7 +3495,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f66(s3);
+              s0 = peg$f72(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -3203,7 +3531,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f67(s3);
+                s0 = peg$f73(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -3216,8 +3544,105 @@ function peg$parse(input, options) {
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseOperandPolymeterU32();
+          }
         }
       }
+    }
+
+    return s0;
+  }
+
+  function peg$parseOperandPolymeterU32() {
+    let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 123) {
+      s1 = peg$c4;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e4); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      s3 = peg$parseOperandSequenceU32();
+      if (s3 !== peg$FAILED) {
+        s4 = [];
+        s5 = peg$currPos;
+        s6 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s7 = peg$c0;
+          peg$currPos++;
+        } else {
+          s7 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e0); }
+        }
+        if (s7 !== peg$FAILED) {
+          s8 = peg$parse_();
+          s9 = peg$parseOperandSequenceU32();
+          if (s9 !== peg$FAILED) {
+            s5 = s9;
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s5;
+          s5 = peg$FAILED;
+        }
+        while (s5 !== peg$FAILED) {
+          s4.push(s5);
+          s5 = peg$currPos;
+          s6 = peg$parse_();
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s7 = peg$c0;
+            peg$currPos++;
+          } else {
+            s7 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e0); }
+          }
+          if (s7 !== peg$FAILED) {
+            s8 = peg$parse_();
+            s9 = peg$parseOperandSequenceU32();
+            if (s9 !== peg$FAILED) {
+              s5 = s9;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        }
+        s5 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 125) {
+          s6 = peg$c5;
+          peg$currPos++;
+        } else {
+          s6 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e5); }
+        }
+        if (s6 !== peg$FAILED) {
+          s7 = peg$parsePolymeterSteps();
+          if (s7 === peg$FAILED) {
+            s7 = null;
+          }
+          peg$savedPos = s0;
+          s0 = peg$f74(s3, s4, s7);
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     return s0;
@@ -3278,7 +3703,7 @@ function peg$parse(input, options) {
         }
       }
       peg$savedPos = s0;
-      s0 = peg$f68(s1, s2);
+      s0 = peg$f75(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -3319,7 +3744,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f69(s1);
+      s1 = peg$f76(s1);
     }
     s0 = s1;
 
@@ -3350,7 +3775,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f70();
+        s0 = peg$f77();
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3364,7 +3789,7 @@ function peg$parse(input, options) {
       s1 = peg$parseOperandElementI32();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f71(s1);
+        s1 = peg$f78(s1);
       }
       s0 = s1;
     }
@@ -3388,7 +3813,7 @@ function peg$parse(input, options) {
         s3 = peg$parseElementPart();
       }
       peg$savedPos = s0;
-      s0 = peg$f72(s1, s2);
+      s0 = peg$f79(s1, s2);
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
@@ -3457,7 +3882,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s0 = peg$f73(s1, s2);
+        s0 = peg$f80(s1, s2);
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -3521,7 +3946,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f74();
+      s1 = peg$f81();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3529,7 +3954,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f75(s1);
+        s1 = peg$f82(s1);
       }
       s0 = s1;
     }
@@ -3588,7 +4013,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f76();
+      s1 = peg$f83();
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -3596,7 +4021,7 @@ function peg$parse(input, options) {
       s1 = peg$parseInteger();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$f77(s1);
+        s1 = peg$f84(s1);
       }
       s0 = s1;
       if (s0 === peg$FAILED) {
@@ -3622,7 +4047,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s0 = peg$f78(s3);
+              s0 = peg$f85(s3);
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;
@@ -3658,7 +4083,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s0 = peg$f79(s3);
+                s0 = peg$f86(s3);
               } else {
                 peg$currPos = s0;
                 s0 = peg$FAILED;
@@ -3671,8 +4096,105 @@ function peg$parse(input, options) {
             peg$currPos = s0;
             s0 = peg$FAILED;
           }
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseOperandPolymeterI32();
+          }
         }
       }
+    }
+
+    return s0;
+  }
+
+  function peg$parseOperandPolymeterI32() {
+    let s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 123) {
+      s1 = peg$c4;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$e4); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      s3 = peg$parseOperandSequenceI32();
+      if (s3 !== peg$FAILED) {
+        s4 = [];
+        s5 = peg$currPos;
+        s6 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s7 = peg$c0;
+          peg$currPos++;
+        } else {
+          s7 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e0); }
+        }
+        if (s7 !== peg$FAILED) {
+          s8 = peg$parse_();
+          s9 = peg$parseOperandSequenceI32();
+          if (s9 !== peg$FAILED) {
+            s5 = s9;
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s5;
+          s5 = peg$FAILED;
+        }
+        while (s5 !== peg$FAILED) {
+          s4.push(s5);
+          s5 = peg$currPos;
+          s6 = peg$parse_();
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s7 = peg$c0;
+            peg$currPos++;
+          } else {
+            s7 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$e0); }
+          }
+          if (s7 !== peg$FAILED) {
+            s8 = peg$parse_();
+            s9 = peg$parseOperandSequenceI32();
+            if (s9 !== peg$FAILED) {
+              s5 = s9;
+            } else {
+              peg$currPos = s5;
+              s5 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s5;
+            s5 = peg$FAILED;
+          }
+        }
+        s5 = peg$parse_();
+        if (input.charCodeAt(peg$currPos) === 125) {
+          s6 = peg$c5;
+          peg$currPos++;
+        } else {
+          s6 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$e5); }
+        }
+        if (s6 !== peg$FAILED) {
+          s7 = peg$parsePolymeterSteps();
+          if (s7 === peg$FAILED) {
+            s7 = null;
+          }
+          peg$savedPos = s0;
+          s0 = peg$f87(s3, s4, s7);
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     return s0;
@@ -3828,7 +4350,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f80(s1);
+      s1 = peg$f88(s1);
     }
     s0 = s1;
     peg$silentFails--;
@@ -3893,7 +4415,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$f81(s1);
+      s1 = peg$f89(s1);
     }
     s0 = s1;
     peg$silentFails--;

--- a/src/main/dsl/miniNotation/grammar.peggy
+++ b/src/main/dsl/miniNotation/grammar.peggy
@@ -22,6 +22,13 @@
  *   - Replicate (`!`) accumulates: `x!!` / `x!2!3` sum into a single
  *     Replicate count (1 + Σ(value - 1)), and bare `@` weight defaults to 2 —
  *     both matching Tidal/krill (and `@` is then consistent with `_`).
+ *   - `@` and `!` operands may be patterns: an adjacent `[...]` / `<...>` /
+ *     `{...}` after the sigil parses through the typed operand grammar
+ *     (weights as MiniASTF64, counts as MiniASTU32). A patterned `!` cannot
+ *     be chained with other `!`s, and `_` cannot elongate a pattern-weighted
+ *     element.
+ *   - Modifier operands accept `{...}` polymeter subtrees (with `%n`)
+ *     alongside `[...]` / `<...>` / numbers / `|` choice.
  *   - Separator model matches Tidal/krill: top-level `,` and `|` are mutually
  *     exclusive (commit to one, never mix), feet (`.`) live inside each
  *     operand, and `<...>` / `{...}` are comma-only voices (no `|`).
@@ -61,6 +68,11 @@
           throw new Error("leading `_` has no element to elongate");
         }
         const last = out[out.length - 1];
+        // Elongation adds 1 to a numeric weight; a patterned weight has no
+        // meaningful +1.
+        if (typeof last[1] === 'object' && last[1] !== null) {
+          throw new Error("`_` cannot elongate an element whose weight is a pattern");
+        }
         last[1] = (last[1] ?? 1) + 1;
         continue;
       }
@@ -308,15 +320,25 @@ Modifier
 // Weight is captured at ElementWithWeight level as positional metadata
 // on the sequence entry — never mixed into a modifier chain.
 // Sigils whose operand is mandatory (`*`, `/`) — and `@` — permit whitespace
-// before the operand, mirroring pest's implicit WHITESPACE (`/ 4`, `* 2`,
-// `@ 3` all parse in the Rust grammar). The optional-operand sigils `!` and
-// `?` bind their number only when it is adjacent: `1! 2` / `1? 2` keep the
-// 2 as its own sequence element — matching Tidal/krill and the Rust descent
-// parser. Euclidean already spells its inner whitespace explicitly.
+// before a bare-number operand, mirroring pest's implicit WHITESPACE (`/ 4`,
+// `* 2`, `@ 3` all parse in the Rust grammar). The optional-operand sigils
+// `!` and `?` bind their number only when it is adjacent: `1! 2` / `1? 2`
+// keep the 2 as its own sequence element — matching Tidal/krill and the Rust
+// descent parser. Euclidean already spells its inner whitespace explicitly.
 // Bare `@` (no number) is weight 2 — matching Tidal's `pElongate = 1 + sum`
 // and krill, and consistent with `_` elongation.
+// A bracketed pattern operand (`[...]`, `<...>`, `{...}`) binds only when
+// adjacent to the sigil: `a@ [1 2]` keeps `[1 2]` as its own sequence
+// element. Bare `|` choice is not a weight operand (it stays a sequence-level
+// choice separator); use brackets: `a@[1|2]`.
 Weight
-  = "@" _ n:Number? { return n === null ? 2 : n; }
+  = "@" op:WeightPatternOperand { return op; }
+  / "@" _ n:Number? { return n === null ? 2 : n; }
+
+WeightPatternOperand
+  = "[" _ s:OperandStackExprF64 _ "]" { return s.fast; }
+  / "<" _ s:OperandStackExprF64 _ ">" { return s.slow; }
+  / OperandPolymeterF64
 
 FastMod
   = "*" _ op:ModOperandF64 {
@@ -331,12 +353,29 @@ SlowMod
 // Replicate accumulates: consecutive `!`/`!n` sum into a single Replicate, so
 // `x!` = 2 copies, `x!3` = 3, `x!!` = 3, `x!2!3` = 4 — matching Tidal's
 // `pRepeat = 1 + sum es` and krill. Total copies = 1 + Σ(value - 1).
+// An adjacent bracketed operand is a patterned count sampled per cycle; it
+// must be the sole `!` in the chain (accumulation is numeric).
 Replicate
-  = parts:(_ "!" n:Integer? { return n === null ? 2 : n; })+ {
-      const total = parts.reduce((acc, v) => acc + (v - 1), 1);
+  = parts:(_ "!" op:ReplicateOperand? { return op ?? null; })+ {
+      const patterned = parts.find(p => p !== null && typeof p === 'object');
+      if (patterned !== undefined) {
+        if (parts.length > 1) {
+          error("`!` with a patterned count cannot be chained with other `!`s");
+        }
+        return (ast, _c) => ({ Replicate: [ast, patterned] });
+      }
+      const total = parts.reduce((acc, v) => acc + ((v ?? 2) - 1), 1);
       if (total < 0) error("Replicate count must be a non-negative integer");
       return (ast, _c) => ({ Replicate: [ast, total] });
     }
+
+// `!` binds its operand only when adjacent (`1! 2` keeps the 2 separate).
+// Numeric parts may be negative; the accumulated total is checked instead.
+ReplicateOperand
+  = Integer
+  / "[" _ s:OperandStackExprU32 _ "]" { return s.fast; }
+  / "<" _ s:OperandStackExprU32 _ ">" { return s.slow; }
+  / OperandPolymeterU32
 
 Degrade
   = "?" p:Number? {
@@ -365,6 +404,7 @@ ModOperandF64
     }
   / "[" _ s:OperandStackExprF64 _ "]" { return s.fast; }
   / "<" _ s:OperandStackExprF64 _ ">" { return s.slow; }
+  / OperandPolymeterF64
 
 ModOperandU32
   = r:OperandRandomChoiceU32 { return r; }
@@ -374,6 +414,7 @@ ModOperandU32
     }
   / "[" _ s:OperandStackExprU32 _ "]" { return s.fast; }
   / "<" _ s:OperandStackExprU32 _ ">" { return s.slow; }
+  / OperandPolymeterU32
 
 ModOperandI32
   = r:OperandRandomChoiceI32 { return r; }
@@ -382,6 +423,7 @@ ModOperandI32
     }
   / "[" _ s:OperandStackExprI32 _ "]" { return s.fast; }
   / "<" _ s:OperandStackExprI32 _ ">" { return s.slow; }
+  / OperandPolymeterI32
 
 // Operand subsequence parsing — much simpler than full StackExpr since
 // modifier operands only carry numeric values. Each operand type has its
@@ -441,6 +483,17 @@ OperandBaseF64
   / n:Number { return { Pure: located(n, location()) }; }
   / "[" _ s:OperandStackExprF64 _ "]" { return s.fast; }
   / "<" _ s:OperandStackExprF64 _ ">" { return s.slow; }
+  / OperandPolymeterF64
+
+// Polymeter inside an operand subtree: `{...}` with optional adjacent `%n`,
+// comma-separated voices of operand sequences (no feet). A single-entry,
+// unweighted voice collapses to its bare element, like SequenceExpr.
+OperandPolymeterF64
+  = "{" _ head:OperandSequenceF64 tail:(_ "," _ @OperandSequenceF64)* _ "}" steps:PolymeterSteps? {
+      const toChild = (s) =>
+        s.asCat.length === 1 && s.asCat[0][1] === null ? s.asCat[0][0] : { Sequence: s.asCat };
+      return { Polymeter: { children: [head, ...tail].map(toChild), steps_per_cycle: steps } };
+    }
 
 // ------ u32 operand subtree ------
 
@@ -498,6 +551,15 @@ OperandBaseU32
     }
   / "[" _ s:OperandStackExprU32 _ "]" { return s.fast; }
   / "<" _ s:OperandStackExprU32 _ ">" { return s.slow; }
+  / OperandPolymeterU32
+
+// See OperandPolymeterF64.
+OperandPolymeterU32
+  = "{" _ head:OperandSequenceU32 tail:(_ "," _ @OperandSequenceU32)* _ "}" steps:PolymeterSteps? {
+      const toChild = (s) =>
+        s.asCat.length === 1 && s.asCat[0][1] === null ? s.asCat[0][0] : { Sequence: s.asCat };
+      return { Polymeter: { children: [head, ...tail].map(toChild), steps_per_cycle: steps } };
+    }
 
 // ------ i32 operand subtree ------
 
@@ -549,6 +611,15 @@ OperandBaseI32
   / n:Integer { return { Pure: located(n, location()) }; }
   / "[" _ s:OperandStackExprI32 _ "]" { return s.fast; }
   / "<" _ s:OperandStackExprI32 _ ">" { return s.slow; }
+  / OperandPolymeterI32
+
+// See OperandPolymeterF64.
+OperandPolymeterI32
+  = "{" _ head:OperandSequenceI32 tail:(_ "," _ @OperandSequenceI32)* _ "}" steps:PolymeterSteps? {
+      const toChild = (s) =>
+        s.asCat.length === 1 && s.asCat[0][1] === null ? s.asCat[0][0] : { Sequence: s.asCat };
+      return { Polymeter: { children: [head, ...tail].map(toChild), steps_per_cycle: steps } };
+    }
 
 // ---------------------------------------------------------------------------
 // Numbers & whitespace

--- a/src/main/dsl/typescriptLibGen.ts
+++ b/src/main/dsl/typescriptLibGen.ts
@@ -449,13 +449,19 @@ type ParsedPattern = {
  *
  * | Modifier | Syntax | Meaning |
  * |----------|--------|---------|
- * | Weight | \`@n\` | Relative duration within a sequence (default 1) |
+ * | Weight | \`@n\`, \`@[…]\`, \`@<…>\`, \`@{…}\` | Relative duration within a sequence (default 1; whole cycles inside \`<>\`). A bracketed operand is a pattern sampled per cycle — \`'c4@<1 2> e4'\` alternates the width |
  * | Elongate | \`_\` | Bare \`_\` extends the preceding step's weight by 1; \`'c4 _ _'\` is the same as \`'c4@3'\` |
  * | Speed up | \`*n\` | Repeat \`n\` times within the slot |
  * | Slow down | \`/n\` | Stretch over \`n\` cycles |
- * | Replicate | \`!n\` | Duplicate the element \`n\` times (default 2) |
+ * | Replicate | \`!n\`, \`![…]\`, \`!<…>\`, \`!{…}\` | Duplicate the element \`n\` times (default 2); a bracketed count is sampled per cycle — \`'c4!<2 3> e4'\` |
  * | Degrade | \`?\` or \`?n\` | Randomly drop the element (\`?\` ≈ 50 %) |
  * | Euclidean | \`(k,n)\` or \`(k,n,offset)\` | Distribute \`k\` pulses over \`n\` steps |
+ *
+ * Operands of \`*\`, \`/\`, \`(k,n)\`, \`@\`, and \`!\` may be subpatterns —
+ * \`[1 2]\`, \`<1 2>\`, \`{1 2 3}%4\`, \`[1|2]\` — sampled as the pattern
+ * plays. \`@\`/\`!\` operands must attach with no space, a patterned \`!\`
+ * cannot chain with other \`!\`s, and inside \`<>\` the operand advances
+ * once per pass and must repeat (\`|\` choice is rejected there).
  *
  * @param source - mini-notation source string
  */
@@ -505,13 +511,19 @@ declare namespace $p {
  *
  * | Modifier | Syntax | Meaning |
  * |----------|--------|---------|
- * | Weight | \`@n\` | Relative duration within a sequence (default 1) |
+ * | Weight | \`@n\`, \`@[…]\`, \`@<…>\`, \`@{…}\` | Relative duration within a sequence (default 1; whole cycles inside \`<>\`). A bracketed operand is a pattern sampled per cycle — \`'c4@<1 2> e4'\` alternates the width |
  * | Elongate | \`_\` | Bare \`_\` extends the preceding step's weight by 1; \`'0 _ _'\` is the same as \`'0@3'\` |
  * | Speed up | \`*n\` | Repeat \`n\` times within the slot |
  * | Slow down | \`/n\` | Stretch over \`n\` cycles |
- * | Replicate | \`!n\` | Duplicate the element \`n\` times (default 2) |
+ * | Replicate | \`!n\`, \`![…]\`, \`!<…>\`, \`!{…}\` | Duplicate the element \`n\` times (default 2); a bracketed count is sampled per cycle — \`'c4!<2 3> e4'\` |
  * | Degrade | \`?\` or \`?n\` | Randomly drop the element (\`?\` ≈ 50 %) |
  * | Euclidean | \`(k,n)\` or \`(k,n,offset)\` | Distribute \`k\` pulses over \`n\` steps |
+ *
+ * Operands of \`*\`, \`/\`, \`(k,n)\`, \`@\`, and \`!\` may be subpatterns —
+ * \`[1 2]\`, \`<1 2>\`, \`{1 2 3}%4\`, \`[1|2]\` — sampled as the pattern
+ * plays. \`@\`/\`!\` operands must attach with no space, a patterned \`!\`
+ * cannot chain with other \`!\`s, and inside \`<>\` the operand advances
+ * once per pass and must repeat (\`|\` choice is rejected there).
  *
  * ### Scale strings
  *


### PR DESCRIPTION
Lets mini-notation `@` weights and `!` counts take a pattern operand — `[1 2]`, `<1 2>`, `{1 2}%n`, or a bracketed random choice — instead of only a bare number, and extends the same bracketed-operand grammar to `*`, `/`, and euclidean args.

## Changes

- **Grammar** (`grammar.peggy` / generated parser): `@` accepts an adjacent `[...]`/`<...>`/`{...}` operand through the typed f64 operand grammar; `!` accepts an adjacent bracketed u32 operand (must be the sole `!` in its chain). `_` elongation on a pattern-weighted element is now a parse error. The shared operand grammar gains `{...}%n` polymeter subtrees for all three operand kinds.
- **AST/types**: `Weight` (`f64 | MiniASTF64`) and `ReplicateCount` (`u32 | MiniASTU32`) replace the old static-only fields on `Sequence`/`FastCat`/`SlowCat` entries across both the Rust and TS ASTs. Static payloads still serialize byte-identically.
- **Evaluation**: sequences with patterned `@`/`!` lower to `dyn_timecat`, a query-time combinator that samples each operand at cycle start and re-derives the timecat slot layout per cycle (arena-only allocation, no steady-state heap growth). Dynamic slowcats statically unroll one joint operand period into `timecat(...)._slow(total)`, with `stride_cycles` advancing each entry its own cycles per pass (e.g. `<a@<1 2> b>` plays `a, b, a, a, b`; `@<2>` degenerates exactly to `@2`). Polymeter voices with per-cycle step counts reuse `.fast()` with a sampled `spc/steps` factor pattern.
- **Limits**: the validator rejects aperiodic (`|`) or over-cap operands inside `<...>` and bounds unrolled slots / patterned counts by their largest leaf.
- **Tests**: new parity fixture rows cover bracketed weight/count operands (including an operand-level `!` and bracketed random choice) and `{}%n` polymeter operands on `*`, `/`, and euclid steps; existing rows are byte-stable.
- **Docs**: `typescriptLibGen.ts` doc examples updated for pattern operands on `@`/`!`/`{}`.
